### PR TITLE
Update for new NCEPLIB library location on Jet

### DIFF
--- a/driver_scripts/driver_grid.jet.sh
+++ b/driver_scripts/driver_grid.jet.sh
@@ -54,7 +54,7 @@ set -x
 
 . /apps/lmod/lmod/init/sh
 module purge
-module load intel/15.0.3.187
+module load intel/18.0.5.274
 module load impi/2018.4.274
 module load szip
 module load hdf5

--- a/modulefiles/chgres_cube.jet
+++ b/modulefiles/chgres_cube.jet
@@ -2,22 +2,21 @@
 ## chgres build module for Jet
 #############################################################
 
-module use /mnt/lfs3/projects/hfv3gfs/gwv/ljtjet/lib/modulefiles
-
-module load intel/15.0.3.187
+module load intel/18.0.5.274
 module load impi/2018.4.274
 module load szip
 module load hdf5
 module load netcdf/4.2.1.1
 
-module load esmflocal/ESMF_8_0_0_beta_snapshot_21
+module load w3nco/v2.0.6
+module load sp/v2.0.2
+module load bacio/v2.0.2
+module load sigio/v2.1.0
+module load sfcio/v1.0.0
+module load nemsio/v2.2.3
 
-module load w3nco-intel-sandybridge/2.0.6
-module load sp-intel-sandybridge/2.0.2
-module load bacio-intel-sandybridge/2.0.2
-module load sigio-intel-sandybridge/2.0.1
-module load sfcio-intel-sandybridge/1.0.0
-module load nemsio-intel-sandybridge/2.2.2
+module use /mnt/lfs3/projects/hfv3gfs/gwv/ljtjet/lib/modulefiles
+module load esmflocal/ESMF_8_0_0_beta_snapshot_21
 
 export FCOMP=mpiifort
 export FFLAGS="-O3 -fp-model precise -g -traceback -r8 -i4 -qopenmp -convert big_endian -assume byterecl"

--- a/modulefiles/fv3gfs/global_chgres.jet
+++ b/modulefiles/fv3gfs/global_chgres.jet
@@ -3,7 +3,7 @@
 #############################################################
 
 module purge
-module load intel/15.0.3.187
+module load intel/18.0.5.274
 module load szip/2.1
 module load hdf5/1.8.9
 module load netcdf/4.2.1.1
@@ -13,8 +13,8 @@ module load sp/v2.0.2
 module load w3emc/v2.2.0
 module load w3nco/v2.0.6
 module load bacio/v2.0.2
-module load sigio/v2.0.1
-module load nemsio/v2.2.2
+module load sigio/v2.1.0
+module load nemsio/v2.2.3
 module load nemsiogfs/v2.0.1
 module load sfcio/v1.0.0
 module load gfsio/v1.1.0

--- a/modulefiles/fv3gfs/global_cycle.jet
+++ b/modulefiles/fv3gfs/global_cycle.jet
@@ -3,12 +3,12 @@
 #############################################################
 
 # Loading Intel Compiler Suite
-module load intel/15.0.3.187
-module load impi/5.0.3.048
+module load intel/18.0.5.274
+module load impi/2018.4.274
 
 module load w3nco/v2.0.6
 module load sp/v2.0.2
-module load bacio/v2.0.1
+module load bacio/v2.0.2
 module load ip/v3.0.0
 module load szip
 module load hdf5/1.8.9

--- a/modulefiles/fv3gfs/nst_tf_chg.jet
+++ b/modulefiles/fv3gfs/nst_tf_chg.jet
@@ -3,11 +3,11 @@
 #############################################################
 
 # Loading Intel Compiler Suite
-module load intel/15.0.3.187
+module load intel/18.0.5.274
 
 module load w3nco/v2.0.6
 module load bacio/v2.0.2
-module load nemsio/v2.2.2
+module load nemsio/v2.2.3
 module load szip
 module load hdf5/1.8.9
 module load netcdf/4.2.1.1

--- a/modulefiles/fv3gfs/orog.jet
+++ b/modulefiles/fv3gfs/orog.jet
@@ -5,7 +5,7 @@
 #
 module purge
 
-module load intel/15.0.3.187
+module load intel/18.0.5.274
 module load szip/2.1
 module load hdf5/1.8.9
 module load netcdf/4.2.1.1
@@ -13,6 +13,6 @@ module load netcdf/4.2.1.1
 # Loding nceplibs modules
 module load ip/v2.0.0
 module load sp/v2.0.2
-module load w3emc/v2.2.0
+module load w3emc/v2.3.0
 module load w3nco/v2.0.6
 module load bacio/v2.0.2

--- a/modulefiles/module_base.jet
+++ b/modulefiles/module_base.jet
@@ -1,3 +1,4 @@
+#%Module#############################################################
 ##
 ##      nems prerequisites
 ##
@@ -6,19 +7,15 @@ proc ModulesHelp {} {
      puts stderr "The prerequisites for compiling or running FV3 on Jet. "
 }
 
-module load newdefaults intel/15.0.3.187 impi/5.1.3.181 szip hdf5 netcdf4/4.2.1.1
+module load intel/15.0.3.187 impi/2018.4.274 szip hdf5 netcdf4/4.2.1.1
 
-module use /lfs3/projects/hfv3gfs/nwprod/lib/modulefiles
+module use /lfs3/projects/hfv3gfs/nwprod/NCEPLIBS/modulefiles
 module load bacio/v2.0.2
 module load sp/v2.0.2
 module load ip/v2.0.0
 module load w3nco/v2.0.6
-module load w3emc/v2.2.0
-module load nemsio/v2.2.2
-
-#set NCEPLIBS $::env(NCEPLIBS)
-#module use $NCEPLIBS/modulefiles
-#module load esmf/7.1.0r_impi
+module load w3emc/v2.3.0
+module load nemsio/v2.2.3
 
 module use /lfs3/projects/hwrf-vd/soft/modulefiles
 module load prod_util
@@ -29,4 +26,3 @@ module load hpss
 module load mpiserial
 
 module load gempak/7.4.2
-

--- a/modulefiles/module_nemsutil.jet
+++ b/modulefiles/module_nemsutil.jet
@@ -3,12 +3,12 @@
 #############################################################
 
 # Loading Intel Compiler Suite
-module load intel/15.0.3.187
+module load intel/18.0.5.274
 module load impi/5.0.3.048
 
 # Loding nceplibs modules
 module load w3nco/v2.0.6
-module load bacio/v2.0.1
-module load nemsio/v2.2.1
+module load bacio/v2.0.2
+module load nemsio/v2.2.3
 
 export FCMP=ifort

--- a/modulefiles/modulefile.global_emcsfc_ice_blend.jet
+++ b/modulefiles/modulefile.global_emcsfc_ice_blend.jet
@@ -2,15 +2,15 @@
 ## emcsfc_ice_blend build module for Jet
 #############################################################
 
-module load intel/15.0.3.187
+module load intel/18.0.5.274
 export FCOMP=ifort
 export FFLAGS="-O0 -i4"
 
 # load ncep library modules
 
 module load w3nco/v2.0.6
-module load bacio/v2.0.1
+module load bacio/v2.0.2
 module load jasper/v1.900.1
 module load z/v1.2.6
 module load png/v1.2.44
-module load g2/v2.5.0
+module load g2/v3.1.0

--- a/modulefiles/modulefile.global_emcsfc_snow2mdl.jet
+++ b/modulefiles/modulefile.global_emcsfc_snow2mdl.jet
@@ -4,19 +4,19 @@
 
 # load intel compiler
 
-module load intel/15.0.3.187
+module load intel/18.0.5.274
 
 # load ncep library modules
 
 module load ip/v3.0.0
 module load sp/v2.0.2
 module load w3nco/v2.0.6
-module load bacio/v2.0.1
+module load bacio/v2.0.2
 module load jasper/v1.900.1
 module load z/v1.2.6
 module load png/v1.2.44
-module load g2/v2.5.0
+module load g2/v3.1.0
 module load landsfcutil/v2.1.0
 
 export FCOMP=ifort
-export FFLAGS="-O0 -r8 -i4 -FR -I${IP_INCd} -openmp -convert big_endian -assume byterecl"
+export FFLAGS="-O0 -r8 -i4 -FR -I${IP_INCd} -qopenmp -convert big_endian -assume byterecl"

--- a/modulefiles/modulefile.sfc_climo_gen.jet
+++ b/modulefiles/modulefile.sfc_climo_gen.jet
@@ -4,7 +4,7 @@
 
 module use /mnt/lfs3/projects/hfv3gfs/gwv/ljtjet/lib/modulefiles
 
-module load intel/15.0.3.187
+module load intel/18.0.5.274
 module load impi/2018.4.274
 module load szip
 module load hdf5

--- a/reg_tests/chgres_cube/driver.jet.sh
+++ b/reg_tests/chgres_cube/driver.jet.sh
@@ -26,7 +26,7 @@ set -x
 
 source /apps/lmod/lmod/init/sh
 module purge
-module load intel/15.0.3.187
+module load intel/18.0.5.274
 module load impi/2018.4.274
 module load szip
 module load hdf5

--- a/sorc/machine-setup.sh
+++ b/sorc/machine-setup.sh
@@ -27,7 +27,7 @@ if [[ -d /lfs3 ]] ; then
     fi
     target=jet
     module purge
-    module use /mnt/lfs3/projects/hfv3gfs/nwprod/lib/modulefiles
+    module use /lfs3/projects/hfv3gfs/nwprod/NCEPLIBS/modulefiles
 elif [[ -d /scratch1 ]] ; then
     # We are on NOAA Hera
     if ( ! eval module help > /dev/null 2>&1 ) ; then

--- a/ush/fv3gfs_driver_grid.sh
+++ b/ush/fv3gfs_driver_grid.sh
@@ -185,6 +185,10 @@ if [ $gtype = uniform ] || [ $gtype = stretch ] || [ $gtype = nest ];  then
       echo
       set -x
       $script_dir/fv3gfs_make_orog.sh $res $tile $grid_dir $orog_dir $script_dir $topo $TMPDIR
+      err=$?
+      if [ $err != 0 ]; then
+        exit $err
+      fi
       tile=$(( $tile + 1 ))
     done
   fi
@@ -322,6 +326,10 @@ elif [ $gtype = regional ]; then
     echo
     set -x
     $script_dir/fv3gfs_make_orog.sh $res $tile $grid_dir $orog_dir $script_dir $topo $TMPDIR
+    err=$?
+    if [ $err != 0 ]; then
+      exit $err
+    fi
   fi
 
   set +x


### PR DESCRIPTION
NCEPLIBS was recompiled and moved on Jet.  Update repository so it compiles and runs.  See issue #34 for more details.