### PR TITLE
chgres_cube vertical velocity fix

### DIFF
--- a/reg_tests/chgres_cube/driver.cray.sh
+++ b/reg_tests/chgres_cube/driver.cray.sh
@@ -34,7 +34,7 @@ module list
 
 export OUTDIR=/gpfs/hps3/stmp/$LOGNAME/chgres_reg_tests
 QUEUE="debug"
-PROJECT_CODE="FV3GFS-T2O"
+PROJECT_CODE="GFS-DEV"
 
 #-----------------------------------------------------------------------------
 # Should not have to change anything below here.  HOMEufs is the root

--- a/reg_tests/chgres_cube/driver.dell.sh
+++ b/reg_tests/chgres_cube/driver.dell.sh
@@ -33,7 +33,7 @@ module list
 
 export OUTDIR=/gpfs/dell1/stmp/$LOGNAME/chgres_reg_tests
 QUEUE="debug"
-PROJECT_CODE="FV3GFS-T2O"
+PROJECT_CODE="GFS-DEV"
 
 #-----------------------------------------------------------------------------
 # Should not have to change anything below here.  HOMEufs is the root

--- a/sorc/chgres_cube.fd/input_data.F90
+++ b/sorc/chgres_cube.fd/input_data.F90
@@ -1609,11 +1609,14 @@
  enddo
 
  if (localpet < num_tiles_input_grid) then
-   error=nf90_inq_varid(ncid, 'W', id_var)
-   call netcdf_err(error, 'reading field id' )
-   error=nf90_get_var(ncid, id_var, data_one_tile_3d)
-   call netcdf_err(error, 'reading field' )
-   data_one_tile_3d(:,:,1:lev_input) = data_one_tile_3d(:,:,lev_input:1:-1)
+!  error=nf90_inq_varid(ncid, 'W', id_var)
+!  call netcdf_err(error, 'reading field id' )
+!  error=nf90_get_var(ncid, id_var, data_one_tile_3d)
+!  call netcdf_err(error, 'reading field' )
+!  data_one_tile_3d(:,:,1:lev_input) = data_one_tile_3d(:,:,lev_input:1:-1)
+
+! Using 'w' from restart files has caused problems.  Set to zero.
+   data_one_tile_3d = 0.0_8
  endif
 
  do tile = 1, num_tiles_input_grid
@@ -1943,12 +1946,13 @@
  endif
 
  if (localpet < num_tiles_input_grid) then
-   print*,"- READ VERTICAL VELOCITY."
-   error=nf90_inq_varid(ncid, 'dzdt', id_var)
-   call netcdf_err(error, 'reading field id' )
-   error=nf90_get_var(ncid, id_var, data_one_tile_3d)
-   call netcdf_err(error, 'reading field' )
-   data_one_tile_3d(:,:,1:lev_input) = data_one_tile_3d(:,:,lev_input:1:-1)
+!  print*,"- READ VERTICAL VELOCITY."
+!  error=nf90_inq_varid(ncid, 'dzdt', id_var)
+!  call netcdf_err(error, 'reading field id' )
+!  error=nf90_get_var(ncid, id_var, data_one_tile_3d)
+!  call netcdf_err(error, 'reading field' )
+!  data_one_tile_3d(:,:,1:lev_input) = data_one_tile_3d(:,:,lev_input:1:-1)
+   data_one_tile_3d = 0.0_8
  endif
 
  do tile = 1, num_tiles_input_grid

--- a/sorc/chgres_cube.fd/input_data.F90
+++ b/sorc/chgres_cube.fd/input_data.F90
@@ -1952,6 +1952,9 @@
 !  error=nf90_get_var(ncid, id_var, data_one_tile_3d)
 !  call netcdf_err(error, 'reading field' )
 !  data_one_tile_3d(:,:,1:lev_input) = data_one_tile_3d(:,:,lev_input:1:-1)
+
+! Using w from the tiled history files has caused problems.  
+! Set to zero.
    data_one_tile_3d = 0.0_8
  endif
 


### PR DESCRIPTION
Zero out vertical velocity when using tiled history and tiled warm restart data as input to chgres_cube.  For details, see issue #31 