### PR TITLE
Catch unimplemented build method, add support for macOS compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
   message("setting intel true")
   set(IntelComp true )
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU*")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU*" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang*")
   set(GNUComp true )
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "pgc*")
   set(PGIComp true )
@@ -45,7 +45,17 @@ find_package(BACIO REQUIRED)
 find_package(NEMSIO REQUIRED)
 find_package(SIGIO REQUIRED)
 find_package(SP REQUIRED)
-find_package(ESMF)
+# If UFS_UTILS is built as part of the NCEPLIBS umbrella build,
+# ESMF_INC and ESMF_LIB are set by the top-level CMakeLists.txt.
+# If UFS_UTILS is built standalone, these variables need to be
+# detected here. This logic has not yet been implemented.
+if (NOT ESMF_INC OR NOT ESMF_LIB)
+    # See the umbrella build's CMakeLists.txt file for how to
+    # obtain ESMF_INC and ESMF_LIB from ESMF's own FindESMF.cmake
+    # module. Also need to add the path to this macro to CMAKE_MODULE_PATH.
+    #find_package(ESMF)
+    message(FATAL_ERROR "Determining ESMF configuration for UFS_UTILS cmake standalone build not yet implemented")
+endif()
 
 add_subdirectory(sorc/chgres_cube.fd)
 #add_subdirectory(sorc/emcsfc_ice_blend.fd)


### PR DESCRIPTION
This PR adds a guard inCMakeLists.txt to prevent building UFS_UTILS using cmake standalone. This has not been implemented yet, because we are now using the findESMF macro directly from ESMF. Using this macro requires a bit of additional logic (see NCEPLIBS umbrella build CMakeLists.txt, branhf ufs_release_v1.0).

This PR also adds support for macOS with clang compilers, which somehow slipped in previous PRs. I am going to merge this PR, because it doesn't remove/change any working logic.

Note: the following CMakeLists.txt files only know about the Intel compiler and return an "unknown compiler" warning for any other compiler. This needs to be fixed (see issue https://github.com/NOAA-EMC/UFS_UTILS/issues/44).