### PR TITLE
Update serial chgres and cycle to use parallel netcdf 4.7.4

### DIFF
--- a/modulefiles/fv3gfs/global_chgres.hera
+++ b/modulefiles/fv3gfs/global_chgres.hera
@@ -6,9 +6,6 @@
 module load intel/18.0.5.274
 module load impi/2018.0.4
 
-module load netcdf/4.7.0
-module load hdf5/1.10.5
-
 # Loding nceplibs modules
 module use -a $MOD_PATH
 module load sigio/2.1.0
@@ -22,8 +19,6 @@ module load ip/3.0.1
 module load sfcio/1.1.0
 module load gfsio/1.1.0
 module load landsfcutil/2.1.0
-
-export NETCDF_INCLUDE="-I${NETCDF}/include"
-export NETCDF_LDFLAGS_F="-L${NETCDF}/lib -lnetcdf -lnetcdff -L${HDF5}/lib -lhdf5 -lhdf5_fortran"
+module load netcdf_parallel/4.7.4
 
 set FCMP ifort

--- a/modulefiles/fv3gfs/global_chgres.wcoss_dell_p3
+++ b/modulefiles/fv3gfs/global_chgres.wcoss_dell_p3
@@ -4,8 +4,6 @@
 module load ips/18.0.1.163
 module load impi/18.0.1
 
-module load NetCDF/4.5.0
-
 module load w3nco/2.0.6
 module load w3emc/2.3.0
 module load sp/2.0.2
@@ -18,6 +16,8 @@ module load landsfcutil/2.1.0
 module load bacio/2.0.2
 module load  sigio/2.1.0 
 
+module use /usrx/local/nceplibs/dev/NCEPLIBS/modulefiles
+module load netcdf_parallel/4.7.4
 
 #
 export FCMP=ifort

--- a/modulefiles/fv3gfs/global_cycle.hera
+++ b/modulefiles/fv3gfs/global_cycle.hera
@@ -6,16 +6,12 @@
 module load intel/18.0.5.274
 module load impi/2018.0.4
 
-module load netcdf/4.7.0
-module load hdf5/1.10.5
-export NETCDF_INCLUDE="-I${NETCDF}/include"
-export NETCDF_LDFLAGS_F="-L${NETCDF}/lib -lnetcdf -lnetcdff -L${HDF5}/lib -lhdf5 -lhdf5_fortran"
-
 # Loding nceplibs modules
 module use -a $MOD_PATH
 module load w3nco/2.0.6
 module load sp/2.0.2
 module load bacio/2.0.2
 module load ip/3.0.1
+module load netcdf_parallel/4.7.4
 
 export FCMP=mpiifort

--- a/modulefiles/fv3gfs/global_cycle.wcoss_dell_p3
+++ b/modulefiles/fv3gfs/global_cycle.wcoss_dell_p3
@@ -5,11 +5,13 @@
 module load ips/18.0.1.163
 module load impi/18.0.1
 
-module load NetCDF/4.5.0
 module load w3nco/2.0.6
 module load sp/2.0.2
 module load ip/3.0.1
 module load bacio/2.0.2
+
+module use /usrx/local/nceplibs/dev/NCEPLIBS/modulefiles
+module load netcdf_parallel/4.7.4
 
 export FCMP=mpif90
 

--- a/modulefiles/module_base.hera
+++ b/modulefiles/module_base.hera
@@ -6,6 +6,7 @@
 module load intel/18.0.5.274
 module load impi/2018.0.4
 module load hpss/hpss
-module load netcdf/4.7.0
 module load nco/4.7.0
-module load hdf5/1.10.5
+module use /scratch2/NCEPDEV/nwprod/NCEPLIBS/modulefiles
+module load netcdf_parallel/4.7.4
+module load hdf5_parallel/1.10.6

--- a/modulefiles/module_base.wcoss_dell_p3
+++ b/modulefiles/module_base.wcoss_dell_p3
@@ -19,15 +19,15 @@ module unload grib_util/1.0.6
 module load grib_util/1.1.0
 
 module load NCO/4.7.0   
-module load HDF5-serial/1.10.1
-module load NetCDF/4.5.0
 module load CFP/2.0.1
 setenv USE_CFP YES
+
+module use -a /usrx/local/nceplibs/dev/NCEPLIBS/modulefiles
+module load hdf5_parallel/1.10.6
+module load netcdf_parallel/4.7.4
 
 # modules used by vrfy
 module load pm5
 
 module use -a /gpfs/dell1/nco/ops/nwprod/modulefiles/
 module load gempak/7.3.1
-
-

--- a/sorc/global_chgres.fd/chgres.f90
+++ b/sorc/global_chgres.fd/chgres.f90
@@ -927,7 +927,7 @@
         ENDIF
 
         ALLOCATE(VCOORDI(LEVSI+1,GFSHEADI%NVCOORD))
-        VCOORDI(:,:) = GFSHEADVI%VCOORD(:,:,1)
+        VCOORDI(:,:) = GFSHEADVI%VCOORD(:,1:GFSHEADI%NVCOORD,1)
 
 ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 !  READ INPUT NEMSIO DATA ARRAY


### PR DESCRIPTION
Fanglin requested a switch to these libraries to support GFS v16 (Hera/Dell):
hdf5_parallel/1.10.6 and netcdf_parallel/4.7.4

Only the old serial chgres and global_cycle programs are used by the global workflow.
Hence, no other programs were updated.   

Also, fix an out-of-bounds array in serial chgres discovered by Dusan.