### PR TITLE
Remove find_package(landsfcutil) because it is not used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,10 +46,6 @@ find_package(ESMF MODULE REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(WGRIB2 REQUIRED)
 
-if(NOT TARGET landsfcutil_4)
-  find_package(landsfcutil REQUIRED)
-endif()
-
 if(NOT TARGET sfcio_4)
   find_package(sfcio REQUIRED)
 endif()


### PR DESCRIPTION
The CMake build doesn't use `landsfcutil` for anything, so we shouldn't look for it