### PR TITLE
Add GRIB2 regression test for CHGRES_CUBE

### DIFF
--- a/reg_tests/chgres_cube/c192.fv3.history.sh
+++ b/reg_tests/chgres_cube/c192.fv3.history.sh
@@ -41,7 +41,7 @@ ${HOMEufs}/ush/chgres_cube.sh
 
 iret=$?
 if [ $iret -ne 0 ]; then
-  echo "<<< C96 FV3 GAUSSIAN NEMSIO TEST FAILED. <<<"
+  echo "<<< C192 FV3 HISTORY TEST FAILED. <<<"
   exit $iret
 fi
 

--- a/reg_tests/chgres_cube/c192.gfs.grib2.sh
+++ b/reg_tests/chgres_cube/c192.gfs.grib2.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+#-----------------------------------------------------------------------------
+# Invoke chgres to create C192 coldstart files using GFS GRIB2 data
+# as input.  The coldstart files are then compared to baseline files
+# using the 'nccmp' utility.  This script is run by the machine specific 
+# driver script.
+#-----------------------------------------------------------------------------
+
+set -x
+
+export DATA=$OUTDIR/c192_gfs_grib2
+rm -fr $DATA
+
+export CRES=192
+export FIXfv3=${HOMEreg}/fix/C192
+export COMIN=${HOMEreg}/input_data/gfs.grib2
+
+export GRIB2_FILE_INPUT=gfs.t00z.pgrb2.0p50.f000
+export VCOORD_FILE=${HOMEufs}/fix/fix_am/global_hyblev.l65.txt
+export VARMAP_FILE=${HOMEufs}/parm/varmap_tables/GFSphys_var_map.txt
+export INPUT_TYPE='grib2'
+export CONVERT_NST=".false."
+
+export CDATE=2019110400
+
+export OMP_NUM_THREADS_CY=1
+
+#-----------------------------------------------------------------------------
+# Invoke chgres program.
+#-----------------------------------------------------------------------------
+
+echo "Starting at: " `date`
+
+${HOMEufs}/ush/chgres_cube.sh
+
+iret=$?
+if [ $iret -ne 0 ]; then
+  echo "<<< C192 GFS GRIB2 TEST FAILED. <<<"
+  exit $iret
+fi
+
+echo "Ending at: " `date`
+
+#-----------------------------------------------------------------------------
+# Compare output from chgres to baseline set of data.
+#-----------------------------------------------------------------------------
+
+cd $DATA
+
+test_failed=0
+for files in *.nc
+do
+  if [ -f $files ]; then
+    echo CHECK $files
+    $NCCMP -dmfqS $files $HOMEreg/baseline_data/c192_gfs_grib2/$files
+    iret=$?
+    if [ $iret -ne 0 ]; then
+      test_failed=1
+    fi
+  fi
+done
+
+set +x
+if [ $test_failed -ne 0 ]; then
+  echo "<<< C192 GFS GRIB2 TEST FAILED. >>>"
+else
+  echo "<<< C192 GFS GRIB2 TEST PASSED. >>>"
+fi
+
+exit 0

--- a/reg_tests/chgres_cube/driver.cray.sh
+++ b/reg_tests/chgres_cube/driver.cray.sh
@@ -64,7 +64,6 @@ export KMP_AFFINITY=disabled
 
 export OMP_NUM_THREADS=1
 export APRUN="aprun -j 1 -n 6 -N 6 -d ${OMP_NUM_THREADS} -cc depth"
-export INPUT_DATA=${HOMEreg}/input_data/fv3.restart
 bsub -e $LOG_FILE -o $LOG_FILE -q $QUEUE -P $PROJECT_CODE -J c96.fv3.restart -M 1000 -W 0:15 -extsched 'CRAYLINUX[]' \
         "export NODES=1; $PWD/c96.fv3.restart.sh"
 
@@ -74,7 +73,6 @@ bsub -e $LOG_FILE -o $LOG_FILE -q $QUEUE -P $PROJECT_CODE -J c96.fv3.restart -M 
 
 export OMP_NUM_THREADS=1
 export APRUN="aprun -j 1 -n 6 -N 6 -d ${OMP_NUM_THREADS} -cc depth"
-export INPUT_DATA=${HOMEreg}/input_data/fv3.history
 bsub -e $LOG_FILE -o $LOG_FILE -q $QUEUE -P $PROJECT_CODE -J c192.fv3.history -M 1000 -W 0:15 -extsched 'CRAYLINUX[]' \
         -w 'ended(c96.fv3.restart)' "export NODES=1; $PWD/c192.fv3.history.sh"
 
@@ -84,7 +82,6 @@ bsub -e $LOG_FILE -o $LOG_FILE -q $QUEUE -P $PROJECT_CODE -J c192.fv3.history -M
 
 export OMP_NUM_THREADS=1
 export APRUN="aprun -j 1 -n 6 -N 6 -d ${OMP_NUM_THREADS} -cc depth"
-export INPUT_DATA=${HOMEreg}/input_data/fv3.nemsio
 bsub -e $LOG_FILE -o $LOG_FILE -q $QUEUE -P $PROJECT_CODE -J c96.fv3.nemsio -M 1000 -W 0:15 -extsched 'CRAYLINUX[]' \
         -w 'ended(c192.fv3.history)' "export NODES=1; $PWD/c96.fv3.nemsio.sh"
 
@@ -94,7 +91,6 @@ bsub -e $LOG_FILE -o $LOG_FILE -q $QUEUE -P $PROJECT_CODE -J c96.fv3.nemsio -M 1
 
 export OMP_NUM_THREADS=4
 export APRUN="aprun -j 1 -n 6 -N 6 -d ${OMP_NUM_THREADS} -cc depth"
-export INPUT_DATA=${HOMEreg}/input_data/gfs.sigio
 bsub -e $LOG_FILE -o $LOG_FILE -q $QUEUE -P $PROJECT_CODE -J c96.gfs.sigio -M 1000 -W 0:15 -extsched 'CRAYLINUX[]' \
         -w 'ended(c96.fv3.nemsio)' "export NODES=1; $PWD/c96.gfs.sigio.sh"
 
@@ -104,7 +100,6 @@ bsub -e $LOG_FILE -o $LOG_FILE -q $QUEUE -P $PROJECT_CODE -J c96.gfs.sigio -M 10
 
 export OMP_NUM_THREADS=1
 export APRUN="aprun -j 1 -n 6 -N 6 -d ${OMP_NUM_THREADS} -cc depth"
-export INPUT_DATA=${HOMEreg}/input_data/gfs.nemsio
 bsub -e $LOG_FILE -o $LOG_FILE -q $QUEUE -P $PROJECT_CODE -J c96.gfs.nemsio -M 1000 -W 0:15 -extsched 'CRAYLINUX[]' \
         -w 'ended(c96.gfs.sigio)' "export NODES=1; $PWD/c96.gfs.nemsio.sh"
 
@@ -114,14 +109,22 @@ bsub -e $LOG_FILE -o $LOG_FILE -q $QUEUE -P $PROJECT_CODE -J c96.gfs.nemsio -M 1
 
 export OMP_NUM_THREADS=1
 export APRUN="aprun -j 1 -n 6 -N 6 -d ${OMP_NUM_THREADS} -cc depth"
-export INPUT_DATA=${HOMEreg}/input_data/fv3.nemsio
 bsub -e $LOG_FILE -o $LOG_FILE -q $QUEUE -P $PROJECT_CODE -J c96.regional -M 1000 -W 0:15 -extsched 'CRAYLINUX[]' \
         -w 'ended(c96.gfs.nemsio)' "export NODES=1; $PWD/c96.regional.sh"
+
+#-----------------------------------------------------------------------------
+# Initialize global C192 using GFS GRIB2 data.
+#-----------------------------------------------------------------------------
+
+export OMP_NUM_THREADS=1
+export APRUN="aprun -j 1 -n 6 -N 6 -d ${OMP_NUM_THREADS} -cc depth"
+bsub -e $LOG_FILE -o $LOG_FILE -q $QUEUE -P $PROJECT_CODE -J c192.gfs.grib2 -M 1000 -W 0:05 -extsched 'CRAYLINUX[]' \
+        -w 'ended(c96.regional)' "export NODES=1; $PWD/c192.gfs.grib2.sh"
 
 #-----------------------------------------------------------------------------
 # Create summary log.
 #-----------------------------------------------------------------------------
 
-bsub -o $LOG_FILE -q $QUEUE -P $PROJECT_CODE -J summary -R "rusage[mem=100]" -W 0:01 -w 'ended(c96.regional)' "grep -a '<<<' $LOG_FILE >> $SUM_FILE"
+bsub -o $LOG_FILE -q $QUEUE -P $PROJECT_CODE -J summary -R "rusage[mem=100]" -W 0:01 -w 'ended(c192.gfs.grib2)' "grep -a '<<<' $LOG_FILE >> $SUM_FILE"
 
 exit

--- a/reg_tests/chgres_cube/driver.hera.sh
+++ b/reg_tests/chgres_cube/driver.hera.sh
@@ -100,11 +100,18 @@ TEST6=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 -t 0:15:00 -A $PROJECT_C
       -o $LOG_FILE -e $LOG_FILE -d afterok:$TEST5 ./c96.regional.sh)
 
 #-----------------------------------------------------------------------------
+# Initialize global C192 using GFS GRIB2 files.
+#-----------------------------------------------------------------------------
+
+TEST7=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 -t 0:05:00 -A $PROJECT_CODE -q $QUEUE -J c192.gfs.grib2 \
+      -o $LOG_FILE -e $LOG_FILE -d afterok:$TEST6 ./c192.gfs.grib2.sh)
+
+#-----------------------------------------------------------------------------
 # Create summary log.
 #-----------------------------------------------------------------------------
 
 sbatch --nodes=1 -t 0:01:00 -A $PROJECT_CODE -J chgres_summary -o $LOG_FILE -e $LOG_FILE \
-       --open-mode=append -q $QUEUE -d afterok:$TEST6 << EOF
+       --open-mode=append -q $QUEUE -d afterok:$TEST7 << EOF
 #!/bin/sh
 grep -a '<<<' $LOG_FILE  > $SUM_FILE
 EOF

--- a/reg_tests/chgres_cube/driver.jet.sh
+++ b/reg_tests/chgres_cube/driver.jet.sh
@@ -102,11 +102,18 @@ TEST6=$(sbatch --parsable --partition=xjet --nodes=1 --ntasks-per-node=6 -t 0:10
       -o $LOG_FILE -e $LOG_FILE -d afterok:$TEST5 ./c96.regional.sh)
 
 #-----------------------------------------------------------------------------
+# Initialize C192 using GFS GRIB2 data.
+#-----------------------------------------------------------------------------
+
+TEST7=$(sbatch --parsable --partition=xjet --nodes=1 --ntasks-per-node=6 -t 0:05:00 -A $PROJECT_CODE -q $QUEUE -J c192.gfs.grib2 \
+      -o $LOG_FILE -e $LOG_FILE -d afterok:$TEST6 ./c192.gfs.grib2.sh)
+
+#-----------------------------------------------------------------------------
 # Create summary log.
 #-----------------------------------------------------------------------------
 
 sbatch --partition=xjet --nodes=1  -t 0:01:00 -A $PROJECT_CODE -J chgres_summary -o $LOG_FILE -e $LOG_FILE \
-       --open-mode=append -q $QUEUE -d afterok:$TEST6 << EOF
+       --open-mode=append -q $QUEUE -d afterok:$TEST7 << EOF
 #!/bin/sh
 grep -a '<<<' $LOG_FILE  > $SUM_FILE
 EOF

--- a/sorc/chgres_cube.fd/write_data.F90
+++ b/sorc/chgres_cube.fd/write_data.F90
@@ -1164,7 +1164,7 @@
  HEADER : if (localpet < num_tiles_target_grid) then
 
    tile = localpet + 1
-   WRITE(OUTFILE, '(A, I1, A)'), 'out.atm.tile', tile, '.nc'
+   WRITE(OUTFILE, '(A, I1, A)') 'out.atm.tile', tile, '.nc'
 
 !--- open the file
    error = nf90_create(outfile, IOR(NF90_NETCDF4,NF90_CLASSIC_MODEL), &
@@ -1634,7 +1634,7 @@
 
    LOCAL_PET : if (localpet == 0) then
 
-     WRITE(OUTFILE, '(A, I1, A)'), 'out.sfc.tile', tile, '.nc'
+     WRITE(OUTFILE, '(A, I1, A)') 'out.sfc.tile', tile, '.nc'
 
 !--- open the file
      error = nf90_create(outfile, IOR(NF90_NETCDF4,NF90_CLASSIC_MODEL), &

--- a/ush/chgres_cube.sh
+++ b/ush/chgres_cube.sh
@@ -66,7 +66,7 @@ HALO_BLEND=${HALO_BLEND:-0}
 #              'restart' for tiled fv3 warm restart files.  'gfs_gaussian'
 #              for spectral gfs nemsio files.  'gfs_spectral' for 
 #              for spectral gfs sigio/sfcio files.  'gaussian' for fv3
-#              gaussian nemsio files.
+#              gaussian nemsio files. 'grib2' for gfs grib2 files.
 #
 # MOSAIC_FILE_INPUT_GRID - Path/Name of mosaic file for input grid.  Only
 #                          used for 'history' and 'restart' INPUT_TYPE.
@@ -101,7 +101,7 @@ COMIN=${COMIN:-$PWD}
 
 #----------------------------------------------------------------------------
 # ATM_FILES_INPUT - Input atmospheric data file(s).  Not used for 'restart'
-#                   INPUT_TYPE.
+#                   and 'grib2' INPUT_TYPE.
 #
 # ATM_CORE_FILES - Input atmospheric core files.  Used for 'restart' 
 #                  INPUT_TYPE only.  The first six entries are the tiled
@@ -111,11 +111,16 @@ COMIN=${COMIN:-$PWD}
 # ATM_TRACER_FILES_INPUT - Input atmospheric tracer files for each tile.
 #                          Used for 'restart' INPUT_TYPE only.
 #
-# SFC_FILES_INPUT - Input surface data file(s).
+# SFC_FILES_INPUT - Input surface data file(s).  Not used for 'grib2'
+#                   INPUT_TYPE.
 #
 # NST_FILES_INPUT - Input nst data file.  'gfs_gaussian' INPUT_TYPE only.
 #
+# GRIB2_FILE_INPUT - Input gfs grib2 data file.  Only used for 'grib2'
+#                    INPUT_TYPE.
+#
 # TRACERS_INPUT - List of input atmospheric tracer records to be processed.
+#                 Not used for 'grib2' INPUT_TYPE.
 #----------------------------------------------------------------------------
 
 ATM_FILES_INPUT=${ATM_FILES_INPUT:-NULL}
@@ -123,13 +128,17 @@ ATM_CORE_FILES_INPUT=${ATM_CORE_FILES_INPUT:-NULL}
 ATM_TRACER_FILES_INPUT=${ATM_TRACER_FILES_INPUT:-NULL}
 SFC_FILES_INPUT=${SFC_FILES_INPUT:-NULL}
 NST_FILES_INPUT=${NST_FILES_INPUT:-NULL}
+GRIB2_FILE_INPUT=${GRIB2_FILE_INPUT:-NULL}
 TRACERS_INPUT=${TRACERS_INPUT:-'"spfh","clwmr","o3mr","icmr","rwmr","snmr","grle"'}
 
 #----------------------------------------------------------------------------
-# TRACERS_TARGET - List of target tracer records. Must corresponde with
-#                  with TRACERS_INPUT.
 #
-# VCOORD_FILE - File containing vertical coordinate defintion for target
+# VARMAP_FILE - Variable mapping table.  Only used for 'grib2' INPUT_TYPE.
+#
+# TRACERS_TARGET - List of target tracer records. Must corresponde with
+#                  with TRACERS_INPUT.  Not used for 'grib2' INPUT_TYPE.
+#
+# VCOORD_FILE - File containing vertical coordinate definition for target
 #               grid.
 #
 # MOSAIC FILE_TARGET_GRID - Mosaic file for target grid (include path).
@@ -139,6 +148,8 @@ TRACERS_INPUT=${TRACERS_INPUT:-'"spfh","clwmr","o3mr","icmr","rwmr","snmr","grle
 # OROG_FILES_TARGET_GRID - Orography file(s) for target grid.  Assumed to
 #                          be located in FIXfv3.
 #----------------------------------------------------------------------------
+
+VARMAP_FILE=${VARMAP_FILE:-NULL}
 
 TRACERS_TARGET=${TRACERS_TARGET:-'"sphum","liq_wat","o3mr","ice_wat","rainwat","snowwat","graupel"'}
 
@@ -196,6 +207,8 @@ cat << EOF > ./fort.41
   atm_tracer_files_input_grid="${ATM_TRACER_FILES_INPUT}"
   sfc_files_input_grid="${SFC_FILES_INPUT}"
   nst_files_input_grid="${NST_FILES_INPUT}"
+  grib2_file_input_grid="${GRIB2_FILE_INPUT}"
+  varmap_file="${VARMAP_FILE}"
   cycle_mon=$im
   cycle_day=$id
   cycle_hour=$ih


### PR DESCRIPTION
CHGRES_CUBE was recently updated to ingest GFS GRIB2 data.  Add a regression test for this new capability.  

Fix legacy Fortran extension in routine "write_data.F90" identified by Dusan.