### PR TITLE
Define NDATE in GDAS initialization scripts

### DIFF
--- a/modulefiles/build.hera
+++ b/modulefiles/build.hera
@@ -8,6 +8,7 @@ module load intel/18.0.5.274
 module load impi/2018.0.4
 
 module use -a /scratch2/NCEPDEV/nwprod/NCEPLIBS/modulefiles
+module load prod_util/1.1.0
 module load w3nco/2.0.6
 module load w3emc/2.3.0
 module load nemsio/2.2.3

--- a/modulefiles/build.wcoss_cray
+++ b/modulefiles/build.wcoss_cray
@@ -2,6 +2,7 @@
 ## Build and run module for WCOSS-Cray
 #############################################################
 
+module load prod_util/1.1.0
 module load hpss/4.1.0.3
 module load xt-lsfhpc/9.1.3
 module load cfp-intel-sandybridge/1.1.0

--- a/modulefiles/build.wcoss_dell_p3
+++ b/modulefiles/build.wcoss_dell_p3
@@ -29,3 +29,6 @@ module use /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles
 module load esmf/8.0.0_ParallelNetCDF
 
 export WGRIB2_ROOT=/gpfs/dell2/emc/modeling/noscrub/George.Gayno/wgrib2
+
+module use /usrx/local/dev/modulefiles
+module load prod_util/1.1.3


### PR DESCRIPTION
The NDATE program was not being defined in the GDAS initialization scripts.
As a result, the scripts would not work when initializing with GFS v15 data.

For details see #115.  