### PR TITLE
Update CMakeModules pointer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "cmake"]
 	path = cmake
 	url = https://github.com/NOAA-EMC/CMakeModules
-	branch = release/public-v1
+	branch = develop


### PR DESCRIPTION
Point to develop of the CMakeModules authoritative repo.
Previously, I was inadvertently pointing to my fork.

See #122 for more details.