### PR TITLE
release/public-v1: update instructions to compile UFS_UTILS standalone

### DIFF
--- a/docs/source/chgres_cube.rst
+++ b/docs/source/chgres_cube.rst
@@ -128,9 +128,10 @@ If the NCEPLIBS have been installed and the user wants to compile chgres_cube ag
       * set cmake compiler - export FC=ifort (if ifort is the compiler chosen)
       * cd to where you checked out the UFS_Utils
       * mkdir build and cd build
-      * cmake .. -DCMAKE_INSTALL_PREFIX=/path/where/you/want/the/code/installed
+      * cmake .. -DCMAKE_INSTALL_PREFIX=/path/where/you/want/the/code/installed -DCMAKE_PREFIX_PATH=/path/to/nceplibs/installed
       * make -j x (where x is a number that can be chosen to speed up the make, usually 8)
       * make install
+      * if you do get errors that cmake cannot find "FindNETCDF" or "FindESMF", run: git submodule update --init --recursive
 
 ************************************************
 Program inputs and outputs


### PR DESCRIPTION
This is a minimal update of the documentation on how to compile UFS_UTILS standalone. We will need to update the ufs-v1.1.0 tags of UFS_UTILS and NCEPLIBS umbrella after this PR is merged.