### PR TITLE
release/ops gfsv16

### DIFF
--- a/modulefiles/chgres_cube.wcoss_cray
+++ b/modulefiles/chgres_cube.wcoss_cray
@@ -21,8 +21,8 @@ module load esmf/8.0.0
 module rm gcc
 module add gcc/4.9.2
 
-export WGRIB2API_INC=/gpfs/hps3/emc/meso/save/Dusan.Jovic/wgrib2/include
-export WGRIB2_LIB=/gpfs/hps3/emc/meso/save/Dusan.Jovic/wgrib2/lib/libwgrib2.a
+#export WGRIB2API_INC=/gpfs/hps3/emc/meso/save/Dusan.Jovic/wgrib2/include
+#export WGRIB2_LIB=/gpfs/hps3/emc/meso/save/Dusan.Jovic/wgrib2/lib/libwgrib2.a
 
 export FCOMP=ftn
 export FFLAGS="-O3 -fp-model precise -g -r8 -i4 -qopenmp -convert big_endian -assume byterecl"

--- a/modulefiles/chgres_cube.wcoss_dell_p3
+++ b/modulefiles/chgres_cube.wcoss_dell_p3
@@ -15,8 +15,8 @@ module load sigio/2.1.0
 module use /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles
 module load esmf/8.0.0
 
-export WGRIB2API_INC=/u/Wesley.Ebisuzaki/home/grib2.v2.0.8.intel/lib
-export WGRIB2_LIB=/u/Wesley.Ebisuzaki/home/grib2.v2.0.8.intel/lib/libwgrib2.a
+#export WGRIB2API_INC=/u/Wesley.Ebisuzaki/home/grib2.v2.0.8.intel/lib
+#export WGRIB2_LIB=/u/Wesley.Ebisuzaki/home/grib2.v2.0.8.intel/lib/libwgrib2.a
 
 export FCOMP=mpif90
 export FFLAGS="-O3 -fp-model precise -g -traceback -r8 -i4 -qopenmp -convert big_endian -assume byterecl"

--- a/scripts/exemcsfc_global_sfc_prep.sh
+++ b/scripts/exemcsfc_global_sfc_prep.sh
@@ -2,7 +2,7 @@
 
 ####  UNIX Script Documentation Block ###################################
 #                      .                                             .
-# Script name:  exemcsfc_global_sfc_prep.sh.ecf
+# Script name:  exemcsfc_global_sfc_prep.sh
 # RFC Contact:  George Gayno
 # Abstract:  This script calls two utility scripts to prepare a global 
 #    blended ice analysis and global snow analyses for use by GFS/GDAS.
@@ -16,6 +16,8 @@
 #    12/2014  Gayno   Set file defaults to grib 2 versions
 #                     when available.
 #    08/2015  Gayno   Update to current NCO standards
+#    08/2020  Gayno   Rename without the '.ecf' extention per
+#                     latest NCO standards.
 #
 # Usage:
 #  Parameters:    < no arguments >

--- a/sorc/ufs_build.cfg
+++ b/sorc/ufs_build.cfg
@@ -3,7 +3,7 @@
 
  Building NEMS_util (nems_util) ........................ yes
  Building chgres (chgres) .............................. yes
- Building chgres_cube (chgres_cube) .................... yes
+ Building chgres_cube (chgres_cube) .................... no
  Building nst_tf_chg (nst_tf_chg) ...................... yes
  Building orog (orog) .................................. yes
  Building cycle (cycle) ................................ yes


### PR DESCRIPTION
Rename "exemcsfc_global_sfc_prep.sh.ecf" to "exemcsfc_global_sfc_prep.sh"  to comply with the latest NCO standards.
Remove compilation of chgres_cube as that program is not used by GFS v16.  This eliminates the need to implement the wgrib2 library for v16.

See issue #26 