### PR TITLE
Update NetCDF and HDF5 modules on Hera

### DIFF
--- a/modulefiles/build.hera
+++ b/modulefiles/build.hera
@@ -24,6 +24,6 @@ module load landsfcutil/2.4.1
 module load wgrib2/2.0.8
 
 module use /scratch1/NCEPDEV/nems/emc.nemspara/soft/modulefiles
-module load hdf5_parallel/1.10.6
-module load netcdf_parallel/4.7.4
+module load hdf5_parallel/1.10.6.release
+module load netcdf_parallel/4.7.4.release
 module load esmf/8.0.0_ParallelNetCDF


### PR DESCRIPTION
NCEPLIBS was built with a different NetCDF and it wasn't updated in this modulefile. @JeffBeck-NOAA found he couldn't run the wgrib2 executable with this NetCDF loaded.

I ran regression tests on Hera and they all passed.