### PR TITLE
release/public-v1: attempt to fix grib2 read errors with large task counts (draft PR)

### DIFF
--- a/sorc/chgres_cube.fd/model_grid.F90
+++ b/sorc/chgres_cube.fd/model_grid.F90
@@ -609,11 +609,14 @@
 
  implicit none
 
+ include "mpif.h"
+
  integer, intent(in)              :: localpet, npets
 
  character(len=250)               :: the_file
 
  integer                          :: i, j, rc, clb(2), cub(2)
+ integer                          :: ierr
 
  real(esmf_kind_r8), allocatable  :: latitude(:,:)
  real(esmf_kind_r8), allocatable  :: longitude(:,:)
@@ -631,10 +634,14 @@
  num_tiles_input_grid = 1
 
  the_file = trim(data_dir_input_grid) // "/" // grib2_file_input_grid
- print*,'- OPEN AND INVENTORY GRIB2 FILE: ',trim(the_file)
- rc=grb2_mk_inv(the_file,inv_file)
- if (rc /=0) call error_handler("OPENING GRIB2 FILE",rc)
+ if(localpet==0) then
+    print*,'- OPEN AND INVENTORY GRIB2 FILE: ',trim(the_file)
+    rc=grb2_mk_inv(the_file,inv_file)
+    if (rc /=0) call error_handler("OPENING GRIB2 FILE",rc)
+ endif
 
+ ! Wait for localpet 0 to create inventory
+ call mpi_barrier(mpi_comm_world, ierr)
  rc = grb2_inq(the_file,inv_file,':PRES:',':surface:',nx=i_input, ny=j_input, &
     lat=lat4, lon=lon4)
  if (rc /= 1) call error_handler("READING GRIB2 FILE", rc)

--- a/sorc/chgres_cube.fd/utils.f90
+++ b/sorc/chgres_cube.fd/utils.f90
@@ -2,13 +2,17 @@
 
  implicit none
 
+ include 'mpif.h'
+
  character(len=*), intent(in)    :: string
  
  integer,          intent(in)    :: rc
 
+ integer :: ierr
+
  print*,"- FATAL ERROR: ", string
  print*,"- IOSTAT IS: ", rc
- call mpi_abort
+ call mpi_abort(mpi_comm_world, 999, ierr)
 
  end subroutine error_handler
 
@@ -20,6 +24,7 @@
  integer, intent(in) :: err
  character(len=*), intent(in) :: string
  character(len=256) :: errmsg
+ integer :: iret
 
  include "mpif.h"
 
@@ -28,7 +33,7 @@
  print*,''
  print*,'FATAL ERROR: ', trim(string), ': ', trim(errmsg)
  print*,'STOP.'
- call mpi_abort(mpi_comm_world, 999)
+ call mpi_abort(mpi_comm_world, 999, iret)
 
  return
  end subroutine netcdf_err

--- a/sorc/sfc_climo_gen.fd/interp.F90
+++ b/sorc/sfc_climo_gen.fd/interp.F90
@@ -292,7 +292,7 @@
 
  integer, parameter                :: landice=15
 
- integer                           :: i, j
+ integer                           :: i, j, ierr
 
  real                              :: landice_value
 
@@ -348,7 +348,7 @@
      enddo
    case default
      print*,'- FATAL ERROR IN ROUTINE ADJUST_FOR_LANDICE.  UNIDENTIFIED FIELD : ', field_ch
-     call mpi_abort(mpi_comm_world, 57)
+     call mpi_abort(mpi_comm_world, 57, ierr)
  end select
 
  end subroutine adjust_for_landice

--- a/sorc/sfc_climo_gen.fd/model_grid.F90
+++ b/sorc/sfc_climo_gen.fd/model_grid.F90
@@ -83,12 +83,14 @@
 
  implicit none
 
+ include 'mpif.h'
+
  integer, intent(in)              :: localpet, npets
 
  character(len=500)               :: the_file
 
  integer                          :: error, id_dim, id_tiles, ncid
- integer                          :: id_grid_tiles
+ integer                          :: id_grid_tiles, ierr
  integer                          :: extra, rc, tile
  integer, allocatable             :: decomptile(:,:)
 
@@ -124,7 +126,7 @@
  if (mod(npets,num_tiles) /= 0) then
    print*,'- FATAL ERROR: MUST RUN THIS PROGRAM WITH A TASK COUNT THAT'
    print*,'- IS A MULTIPLE OF THE NUMBER OF TILES.'
-   call mpi_abort
+   call mpi_abort(mpi_comm_world, 44, ierr)
  endif
 
 !-----------------------------------------------------------------------


### PR DESCRIPTION
This PR is an attempt to fox the grib2 read errors encountered with large task counts randomly on several machines. The issue is described in length in https://github.com/ufs-community/ufs-mrweather-app/issues/190, together with a suggestion from @GeorgeGayno-NOAA in https://github.com/ufs-community/ufs-mrweather-app/issues/190#issuecomment-696946981 (implemented here).

Changes in this PR:
- sorc/chgres_cube.fd/model_grid.F90: read grib2 inventory only with task 0, let all other processes wait for it to complete
- correct syntax for `MPI_ABORT` calls in various files (from @DusanJovic-NOAA)

Testing:
- Installed a new/test version of NCEPLIBS ufs-v1.1.0 that contains this bugfix on orion and ran the full MRW App regression tests, all of them passed.
- Due to the random nature of the error, repeated runs of the regression test suite will be conducted on orion over night, and if successful also on Cheyenne tomorrow.

@ligiabernardet @panll FYI