### PR TITLE
Update GDAS initialization utility for ATMOS subdirectory

### DIFF
--- a/util/gdas_init/driver.hera.sh
+++ b/util/gdas_init/driver.hera.sh
@@ -11,6 +11,10 @@ set -x
 source ../../sorc/machine-setup.sh > /dev/null 2>&1
 source ../../modulefiles/build.$target
 
+# Needed for NDATE utility
+module use -a /scratch2/NCEPDEV/nwprod/NCEPLIBS/modulefiles
+module load prod_util/1.1.0
+
 PROJECT_CODE=fv3-cpu
 QUEUE=batch
 

--- a/util/gdas_init/run_pre-v14.chgres.sh
+++ b/util/gdas_init/run_pre-v14.chgres.sh
@@ -27,14 +27,14 @@ if [ ${MEMBER} == 'hires' ]; then
   CTAR=${CRES_HIRES}
   INPUT_DATA_DIR="${EXTRACT_DIR}/gdas.${yy}${mm}${dd}/${hh}"
   RADSTAT_DATA_DIR="${EXTRACT_DIR}/gdas.${yy}${mm}${dd}/${hh}"
-  OUTDIR=$OUTDIR/gdas.${yy}${mm}${dd}/${hh}
+  OUTDIR=$OUTDIR/gdas.${yy}${mm}${dd}/${hh}/atmos
   ATMFILE="gdas1.t${hh}z.sanl"
   SFCFILE="gdas1.t${hh}z.sfcanl"
 else  
   CTAR=${CRES_ENKF}
   INPUT_DATA_DIR="${EXTRACT_DIR}/enkf.${yy}${mm}${dd}/${hh}/mem${MEMBER}"
   RADSTAT_DATA_DIR="${EXTRACT_DIR}/enkf.${yy}${mm}${dd}/${hh}/mem${MEMBER}"
-  OUTDIR=$OUTDIR/enkfgdas.${yy}${mm}${dd}/${hh}/mem${MEMBER}
+  OUTDIR=$OUTDIR/enkfgdas.${yy}${mm}${dd}/${hh}/atmos/mem${MEMBER}
   ATMFILE="siganl_${yy}${mm}${dd}${hh}_mem${MEMBER}"
   SFCFILE="sfcanl_${yy}${mm}${dd}${hh}_mem${MEMBER}"
 fi

--- a/util/gdas_init/run_v14.chgres.sh
+++ b/util/gdas_init/run_v14.chgres.sh
@@ -26,7 +26,7 @@ if [ ${MEMBER} == 'hires' ]; then
   CTAR=${CRES_HIRES}
   INPUT_DATA_DIR="${EXTRACT_DIR}/gdas.${yy}${mm}${dd}/${hh}"
   RADSTAT_DATA_DIR="${EXTRACT_DIR}/gdas.${yy}${mm}${dd}/${hh}"
-  OUTDIR=$OUTDIR/gdas.${yy}${mm}${dd}/${hh}
+  OUTDIR=$OUTDIR/gdas.${yy}${mm}${dd}/${hh}/atmos
   ATMFILE="gdas.t${hh}z.atmanl.nemsio"
   SFCFILE="gdas.t${hh}z.sfcanl.nemsio"
   NSTFILE="gdas.t${hh}z.nstanl.nemsio"
@@ -34,7 +34,7 @@ else
   CTAR=${CRES_ENKF}
   INPUT_DATA_DIR="${EXTRACT_DIR}/enkf.${yy}${mm}${dd}/${hh}/mem${MEMBER}"
   RADSTAT_DATA_DIR="${EXTRACT_DIR}/enkf.${yy}${mm}${dd}/${hh}/mem${MEMBER}"
-  OUTDIR=$OUTDIR/enkfgdas.${yy}${mm}${dd}/${hh}/mem${MEMBER}
+  OUTDIR=$OUTDIR/enkfgdas.${yy}${mm}${dd}/${hh}/atmos/mem${MEMBER}
   ATMFILE="gdas.t${hh}z.ratmanl.mem${MEMBER}.nemsio"
   SFCFILE="gdas.t${hh}z.sfcanl.mem${MEMBER}.nemsio"
   NSTFILE="gdas.t${hh}z.nstanl.mem${MEMBER}.nemsio"

--- a/util/gdas_init/run_v15.chgres.sh
+++ b/util/gdas_init/run_v15.chgres.sh
@@ -27,13 +27,13 @@ if [ ${MEMBER} == 'hires' ]; then
   CTAR=${CRES_HIRES}
   INPUT_DATA_DIR="${EXTRACT_DIR}/gdas.${yy_d}${mm_d}${dd_d}/${hh_d}/RESTART"
   RADSTAT_DATA_DIR="${EXTRACT_DIR}/gdas.${yy}${mm}${dd}/${hh}"
-  OUTDIR=$OUTDIR/gdas.${yy}${mm}${dd}/${hh}
+  OUTDIR=$OUTDIR/gdas.${yy}${mm}${dd}/${hh}/atmos
 else  
   CINP=C384
   CTAR=${CRES_ENKF}
   INPUT_DATA_DIR="${EXTRACT_DIR}/enkfgdas.${yy_d}${mm_d}${dd_d}/${hh_d}/mem${MEMBER}/RESTART"
   RADSTAT_DATA_DIR="${EXTRACT_DIR}/enkfgdas.${yy}${mm}${dd}/${hh}/mem${MEMBER}"
-  OUTDIR=$OUTDIR/enkfgdas.${yy}${mm}${dd}/${hh}/mem${MEMBER}
+  OUTDIR=$OUTDIR/enkfgdas.${yy}${mm}${dd}/${hh}/atmos/mem${MEMBER}
 fi
 
 rm -fr $WORKDIR


### PR DESCRIPTION
Update the GDAS initialization utility for the new 'atmos' subdirectory employed by the global workflow.  Add load of NDATE utility in the hera driver script, which was inadvertently removed during a previous commit.

See issue #159 for more details.