### PR TITLE
Remove landsfcutil library dependency from snow2mdl program

### DIFF
--- a/sorc/emcsfc_snow2mdl.fd/CMakeLists.txt
+++ b/sorc/emcsfc_snow2mdl.fd/CMakeLists.txt
@@ -19,7 +19,6 @@ target_link_libraries(
   g2::g2_d
   ip::ip_d
   sp::sp_d
-  landsfcutil::landsfcutil_d
   bacio::bacio_4
   w3nco::w3nco_d)
 if(OpenMP_Fortran_FOUND)


### PR DESCRIPTION
The snow2mdl program uses two small routines from the landsfcutil library.  Incorporate these routines into snow2mdl, thereby removing its dependency on the library.

For details, see issue #169