### PR TITLE
Fix bug that prevents Thompson aerosols from being created

### DIFF
--- a/sorc/chgres_cube.fd/program_setup.f90
+++ b/sorc/chgres_cube.fd/program_setup.f90
@@ -407,12 +407,13 @@
 			ACCURATE. "
 	 endif
  endif
- return
  
  if (trim(thomp_mp_climo_file) /= "NULL") then
    use_thomp_mp_climo=.true.
    print*,"- WILL PROCESS CLIMO THOMPSON MP TRACERS FROM FILE: ", trim(thomp_mp_climo_file)
  endif
+
+ return
 
  end subroutine read_setup_namelist
 


### PR DESCRIPTION
The return statement in read_setup_namelist is a few lines too early, and before the if statement that sets use_thomp_mp_climo to true if thomp_mp_climo_file is set in the namelist. This prevents the aerosols from ever being created or written to file, regardless of input data type. Addresses issue https://github.com/NOAA-EMC/UFS_UTILS/issues/178