### PR TITLE
more doxygen work

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 Utilities for the NCEP models. This is part of the
 [NCEPLIBS](https://github.com/NOAA-EMC/NCEPLIBS) project.
 
+Complete documentation can be found at
+https://noaa-emc.github.io/UFS_UTILS/.
+
 ## Authors
 
 NCEP/EMC developers.

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -741,7 +741,23 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT = @abs_top_srcdir@/docs/user_guide.md @abs_top_srcdir@/src
+INPUT = @abs_top_srcdir@/docs/user_guide.md @abs_top_srcdir@/sorc \
+@abs_top_srcdir@/sorc/chgres_cube.fd  \
+@abs_top_srcdir@/sorc/emcsfc_ice_blend.fd  \
+@abs_top_srcdir@/sorc/emcsfc_snow2mdl.fd  \
+@abs_top_srcdir@/sorc/fre-nctools.fd  \
+@abs_top_srcdir@/sorc/fvcom_tools.fd  \
+@abs_top_srcdir@/sorc/global_chgres.fd  \
+@abs_top_srcdir@/sorc/global_cycle.fd  \
+@abs_top_srcdir@/sorc/grid_tools.fd  \
+@abs_top_srcdir@/sorc/mkgfsnemsioctl.fd  \
+@abs_top_srcdir@/sorc/nemsio_chgdate.fd  \
+@abs_top_srcdir@/sorc/nemsio_get.fd  \
+@abs_top_srcdir@/sorc/nemsio_read.fd  \
+@abs_top_srcdir@/sorc/nst_tf_chg.fd  \
+@abs_top_srcdir@/sorc/orog_mask_tools.fd  \
+@abs_top_srcdir@/sorc/sfc_climo_gen.fd  \
+@abs_top_srcdir@/sorc/vcoord_gen.fd
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/sorc/nst_tf_chg.fd/nst_tf_chg.f90
+++ b/sorc/nst_tf_chg.fd/nst_tf_chg.f90
@@ -1,8 +1,9 @@
+!> @file
+!! Replace tref to be a new one by
+!! 1. Read in a new Tref
+!! 2. Smoothing Tref
+!! @author Xu Li @date Mar, 2017
 program nst_tref_chg
-! Abstract:  Replace tref to be a new one by
-!            1. Read in a new Tref
-!            2. Smoothing Tref
-! Created by Xu Li, Mar., 2017
   use nemsio_module, only: nemsio_init,nemsio_open,nemsio_close
   use nemsio_module, only: nemsio_gfile,nemsio_getfilehead
   use nemsio_module, only: nemsio_readrec,nemsio_writerec,nemsio_readrecv,nemsio_writerecv


### PR DESCRIPTION
Part of #191 

I have built the current doxygen docs, and put them up at https://noaa-emc.github.io/UFS_UTILS/. I will update as we develop these docs. Eventually, this on-line version will only be updated when we do a version release, but while the docs are under development, I will keep it updated when there are changes.

In this PR I add the list of source directories to the Doxyfile.in. If directories are added, renamed, or deleted, the Doxyfile.in will also need to be updated so it can find the code.

In our code, we must convert existing comments to doxygen comments. I have done so for one file in this PR.

Once we get this PR merged I will convert the other Fortran files, in batches, trying to avoid any active work areas so there are no conflicts.