### PR TITLE
Point to new NCEPLIBS location on Jet

### DIFF
--- a/modulefiles/build.jet.intel
+++ b/modulefiles/build.jet.intel
@@ -12,10 +12,10 @@ setenv CC icc
 setenv FC ifort
 setenv CXX icpc
 
-setenv ESMFMKFILE /lfs4/HFIP/hfv3gfs/software/NCEPLIBS-ufs-v2.0.0beta01/intel-18.0.5.274/impi-2018.4.274/lib64/esmf.mk
-setenv Jasper_ROOT /lfs4/HFIP/hfv3gfs/software/NCEPLIBS-ufs-v2.0.0beta01/intel-18.0.5.274/impi-2018.4.274
+setenv ESMFMKFILE /lfs4/HFIP/hfv3gfs/software/NCEPLIBS-ufs-v2.0.0/intel-18.0.5.274/impi-2018.4.274/lib64/esmf.mk
+setenv Jasper_ROOT /lfs4/HFIP/hfv3gfs/software/NCEPLIBS-ufs-v2.0.0/intel-18.0.5.274/impi-2018.4.274
 
-module use /lfs4/HFIP/hfv3gfs/software/NCEPLIBS-ufs-v2.0.0beta01/intel-18.0.5.274/impi-2018.4.274/modules
+module use /lfs4/HFIP/hfv3gfs/software/NCEPLIBS-ufs-v2.0.0/intel-18.0.5.274/impi-2018.4.274/modules
 module load w3nco/2.4.1
 module load w3emc/2.7.3
 module load sp/2.3.3


### PR DESCRIPTION
On Jet, UFS_UTILS was pointing to Dom's directory, which was recently moved/renamed.  As a result, the repo can't be compiled on Jet - an officially supported machine.

For more details see #196.

