### PR TITLE
Change NCEPLIBS directory in the Jet module file

### DIFF
--- a/modulefiles/build.jet
+++ b/modulefiles/build.jet
@@ -12,8 +12,8 @@ setenv CC icc
 setenv FC ifort
 setenv CXX icpc
 
-setenv ESMFMKFILE /lfs4/HFIP/hfv3gfs/software/NCEPLIBS-ufs-v2.0.0beta01/intel-18.0.5.274/impi-2018.4.274/lib64/esmf.mk
-setenv Jasper_ROOT /lfs4/HFIP/hfv3gfs/software/NCEPLIBS-ufs-v2.0.0beta01/intel-18.0.5.274/impi-2018.4.274
+setenv ESMFMKFILE /lfs4/HFIP/hfv3gfs/software/NCEPLIBS-ufs-v2.0.0/intel-18.0.5.274/impi-2018.4.274/lib64/esmf.mk
+setenv Jasper_ROOT /lfs4/HFIP/hfv3gfs/software/NCEPLIBS-ufs-v2.0.0/intel-18.0.5.274/impi-2018.4.274
 
 module use /lfs4/HFIP/hfv3gfs/software/NCEPLIBS-ufs-v2.0.0/intel-18.0.5.274/impi-2018.4.274/modules
 module load w3nco/2.4.1

--- a/modulefiles/build.jet
+++ b/modulefiles/build.jet
@@ -15,7 +15,7 @@ setenv CXX icpc
 setenv ESMFMKFILE /lfs4/HFIP/hfv3gfs/software/NCEPLIBS-ufs-v2.0.0beta01/intel-18.0.5.274/impi-2018.4.274/lib64/esmf.mk
 setenv Jasper_ROOT /lfs4/HFIP/hfv3gfs/software/NCEPLIBS-ufs-v2.0.0beta01/intel-18.0.5.274/impi-2018.4.274
 
-module use /lfs4/HFIP/hfv3gfs/software/NCEPLIBS-ufs-v2.0.0beta01/intel-18.0.5.274/impi-2018.4.274/modules
+module use /lfs4/HFIP/hfv3gfs/software/NCEPLIBS-ufs-v2.0.0/intel-18.0.5.274/impi-2018.4.274/modules
 module load w3nco/2.4.1
 module load w3emc/2.7.3
 module load sp/2.3.3


### PR DESCRIPTION
The NCEPLIBS build directory on Jet changed recently and requires an update to the module file.

Resolves Issue #204.