### PR TITLE
Changes from nwprod to nwpara for wgrib2 v2.0.8 library

### DIFF
--- a/modulefiles/build.wcoss_cray
+++ b/modulefiles/build.wcoss_cray
@@ -36,5 +36,5 @@ export NETCDF=/usrx/local/prod/NetCDF/4.7.4/intel/sandybridge
 module rm gcc
 module load gcc/6.3.0
 
-export wgrib2_ROOT=/gpfs/hps/nco/ops/nwprod/lib/wgrib2/v2.0.8/intel
-###export wgrib2_ROOT=/gpfs/hps/nco/ops/nwpara/lib/wgrib2/v2.0.8/intel
+export wgrib2_ROOT=/gpfs/hps/nco/ops/nwpara/lib/wgrib2/v2.0.8/intel
+#future export wgrib2_ROOT=/gpfs/hps/nco/ops/nwprod/lib/wgrib2/v2.0.8/intel


### PR DESCRIPTION
Is a temporary change, but right now chgres_cube won't build with the existing module file.  I'm planning to deliver to NCO early next week, so would like to give them something that will build out of the box.   