### PR TITLE
wgrib2 text search fix to account for isobaric files 

### DIFF
--- a/sorc/chgres_cube.fd/input_data.F90
+++ b/sorc/chgres_cube.fd/input_data.F90
@@ -2519,7 +2519,7 @@
  if (.not.lret) call error_handler("OPENING GRIB2 ATM FILE.", iret)
 
  print*,"- READ VERTICAL COORDINATE."
- iret = grb2_inq(the_file,inv_file,":var0_2","_0_0:"," hybrid ")
+ iret = grb2_inq(the_file,inv_file,":var0_2","_0_0:",":10 hybrid level:")
   
  if (iret <= 0) then
    lvl_str = "mb:" 


### PR DESCRIPTION
Some isobaric files have data on some hybrid levels. This addresses waves on boundaries when using operational RAP data for LBCs.

Addresses Issue #222 