### PR TITLE
Rearrange allocation of hgt_1d in mtnlm7_oclsm.f to fix errors on MacOS

### DIFF
--- a/sorc/orog_mask_tools.fd/orog.fd/mtnlm7_oclsm.f
+++ b/sorc/orog_mask_tools.fd/orog.fd/mtnlm7_oclsm.f
@@ -1902,9 +1902,9 @@ C  (*j*)  for hard wired zero offset (lambda s =0) for terr05
          ENDDO
       ENDDO
 !$omp end parallel do
-      WRITE(6,*) "! MAKEMT ORO SLM VAR VAR4 DONE"
+      WRITE(6,*) "! MAKEMT2 ORO SLM VAR VAR4 DONE"
 C
-
+      deallocate(hgt_1d)
       RETURN
       END
 

--- a/sorc/orog_mask_tools.fd/orog.fd/mtnlm7_oclsm.f
+++ b/sorc/orog_mask_tools.fd/orog.fd/mtnlm7_oclsm.f
@@ -1781,7 +1781,7 @@ C
       implicit none
       real, parameter :: D2R = 3.14159265358979/180.
       integer, parameter :: MAXSUM=20000000
-      real  hgt_1d(MAXSUM)     
+      real, dimension(:), allocatable ::  hgt_1d
       integer IM, JM, IMN, JMN
       real GLAT(JMN), GLON(IMN)
       INTEGER ZAVG(IMN,JMN),ZSLM(IMN,JMN)
@@ -1806,6 +1806,7 @@ C
 ! ---  mskocn=1 Use ocean model sea land mask, OK and present,
 ! ---  mskocn=0 dont use Ocean model sea land mask, not OK, not present
       print *,' _____ SUBROUTINE MAKEMT2 '
+      allocate(hgt_1d(MAXSUM))
 C---- GLOBAL XLAT AND XLON ( DEGREE )
 C
       JM1 = JM - 1


### PR DESCRIPTION
There are some declarations of allocatable variables that result in `illegal instruction` errors on MacOS, despite being valid Fortran77 code. One such instance is found in `sorc/orog_mask_tools.fd/orog.fd/mtnlm7_oclsm.f`, where the real `hgt_1d` is declared in the subroutine MAKEMT2. While the existing code is valid, it can be rearranged in a way that does not trigger this error but gives equivalent results.

This code has been tested on MacOS (GNU 9.3.0), Cheyenne (GNU 10.1.0) and Hera (Intel 18.0.5) by running the end-to-end UFS SRW App workflow release branch tests. Also checked on Cheyenne to ensure the output files from `orog` for the GST test case were bit-for-bit identical. Let me know if there are any other tests required for this PR to be accepted.

This PR will resolve Issue #243. Thanks to @climbfuji for providing the breadcrumbs needed to find and fix this problem.