### PR TITLE
updated workflow to enable caching of ESMF

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/esmf
-        key: esmf-${{ runner.os }}-8.0.1
+        key: esmf-${{ runner.os }}-8.0.1-1
 
     - name: build-esmf
       if: steps.cache-esmf.outputs.cache-hit != 'true'
@@ -36,7 +36,7 @@ jobs:
         export ESMF_INSTALL_LIBDIR=lib
         export ESMF_INSTALL_MODDIR=mod
         export ESMF_COMPILER=gfortran
-        export ESMF_INSTALL_PREFIX=~
+        export ESMF_INSTALL_PREFIX=~/esmf
         export ESMF_NETCDF=split
         export ESMF_NETCDF_INCLUDE=/usr/include
         export ESMF_NETCDF_LIBPATH=/usr/x86_64-linux-gnu
@@ -67,7 +67,7 @@ jobs:
 
     - name: build-nceplibs
       run: |
-        export ESMFMKFILE=~/lib/esmf.mk
+        export ESMFMKFILE=~/esmf/lib/esmf.mk
         wget https://github.com/NOAA-EMC/NCEPLIBS/archive/v1.3.0.tar.gz &> /dev/null && ls -l
         cd nceplibs
         mkdir build && cd build

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -68,6 +68,7 @@ jobs:
     - name: build-nceplibs
       run: |
         export ESMFMKFILE=~/lib/esmf.mk
+        wget https://github.com/NOAA-EMC/NCEPLIBS/archive/v1.3.0.tar.gz &> /dev/null && ls -l
         cd nceplibs
         mkdir build && cd build
         cmake .. -DCMAKE_INSTALL_PREFIX=~ -DFLAT=ON

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,18 +16,21 @@ jobs:
         sudo apt-get install libnetcdf-dev libnetcdff-dev netcdf-bin pkg-config
         sudo apt-get install libpng-dev
         sudo apt-get install libjpeg-dev
-
-    - name: checkout-esmf
-      uses: actions/checkout@v2
+        sudo apt-get install wget
+    - name: cache-esmf
+      id: cache-esmf
+      uses: actions/cache@v2
       with:
-       repository: esmf-org/esmf
-       path: esmf
-       ref: ESMF_8_0_1
-        
+        path: ~/esmf
+        key: esmf-${{ runner.os }}-8.0.1
+
     - name: build-esmf
+      if: steps.cache-esmf.outputs.cache-hit != 'true'
       run: |
-        export ESMF_DIR=`pwd`/esmf
-        cd esmf
+        export ESMF_DIR=`pwd`/esmf-ESMF_8_0_1
+        wget https://github.com/esmf-org/esmf/archive/ESMF_8_0_1.tar.gz &> /dev/null && ls -l
+        tar zxf ESMF_8_0_1.tar.gz && ls -l
+        cd esmf-ESMF_8_0_1
         export ESMF_COMM=mpich3
         export ESMF_INSTALL_BINDIR=bin
         export ESMF_INSTALL_LIBDIR=lib
@@ -78,6 +81,7 @@ jobs:
     - name: build-ufs-utils
       run: |
         export ESMFMKFILE=~/lib/esmf.mk
+        export ESMF_DIR=`pwd`/esmf-ESMF_8_0_1
         cd ufs_utils
         mkdir build && cd build
         cmake .. -DCMAKE_PREFIX_PATH=~

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -82,7 +82,6 @@ jobs:
     - name: build-ufs-utils
       run: |
         export ESMFMKFILE=~/lib/esmf.mk
-        export ESMF_DIR=`pwd`/esmf-ESMF_8_0_1
         cd ufs_utils
         mkdir build && cd build
         cmake .. -DCMAKE_PREFIX_PATH=~


### PR DESCRIPTION
Fifth time's the charm!

Part of #260 

It took me many tries to get the right. Turns out that GitHub actions sometimes just freezes when your workflow file is wrong. ;-)

In this PR I change the CI to get ESMF and other codes with wget, instead of checking them out, and then I use GitHub caching, so that these codes are only build the first time. For subsequent tests, GitHub pulls them from the cache.