### PR TITLE
for GitHub workflow,s, use caching, rename for clarity, add workflow for nceplibs develop branch test

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,6 +54,9 @@ jobs:
 
     - name: build-jasper
       run: |
+        set -x
+	pwd
+	wget https://github.com/jasper-software/jasper/archive/version-2.0.22.tar.gz &> /dev/null && ls -l
         cd jasper
         mkdir build-jasper && cd build-jasper
         cmake .. -DCMAKE_INSTALL_PREFIX=~

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -78,7 +78,7 @@ jobs:
         wget https://github.com/NOAA-EMC/NCEPLIBS/archive/v1.3.0.tar.gz &> /dev/null && ls -l
         cd nceplibs
         mkdir build && cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX=~;~/jasper -DFLAT=ON
+        cmake .. -DCMAKE_INSTALL_PREFIX='~;~/jasper' -DFLAT=ON
         make -j2
        
     - name: checkout-ufs-utils
@@ -91,7 +91,7 @@ jobs:
         export ESMFMKFILE=~/esmf/lib/esmf.mk
         cd ufs_utils
         mkdir build && cd build
-        cmake .. -DCMAKE_PREFIX_PATH=~;~/jasper
+        cmake .. -DCMAKE_PREFIX_PATH='~;~/jasper'
         make -j2
 
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -57,6 +57,7 @@ jobs:
         set -x
         pwd
         wget https://github.com/jasper-software/jasper/archive/version-2.0.22.tar.gz &> /dev/null && ls -l
+        tar zxf version-2.0.22.tar.gz && ls -l
         cd jasper
         mkdir build-jasper && cd build-jasper
         cmake .. -DCMAKE_INSTALL_PREFIX=~

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -58,7 +58,7 @@ jobs:
         pwd
         wget https://github.com/jasper-software/jasper/archive/version-2.0.22.tar.gz &> /dev/null && ls -l
         tar zxf version-2.0.22.tar.gz && ls -l
-        cd jasper
+        cd jasper-version-2.0.22
         mkdir build-jasper && cd build-jasper
         cmake .. -DCMAKE_INSTALL_PREFIX=~
         make -j2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -55,8 +55,8 @@ jobs:
     - name: build-jasper
       run: |
         set -x
-	pwd
-	wget https://github.com/jasper-software/jasper/archive/version-2.0.22.tar.gz &> /dev/null && ls -l
+        pwd
+        wget https://github.com/jasper-software/jasper/archive/version-2.0.22.tar.gz &> /dev/null && ls -l
         cd jasper
         mkdir build-jasper && cd build-jasper
         cmake .. -DCMAKE_INSTALL_PREFIX=~

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -57,6 +57,8 @@ jobs:
         set -x
         pwd
         wget https://github.com/jasper-software/jasper/archive/version-2.0.22.tar.gz &> /dev/null && ls -l
+        tar zxf version-2.0.22.tar.gz
+	ls -l
         cd jasper
         mkdir build-jasper && cd build-jasper
         cmake .. -DCMAKE_INSTALL_PREFIX=~

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -69,7 +69,7 @@ jobs:
       with:
         repository: NOAA-EMC/NCEPLIBS
         path: nceplibs
-        ref: v1.2.0
+        ref: v1.3.0
 
     - name: build-nceplibs
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -91,7 +91,7 @@ jobs:
         export ESMFMKFILE=~/esmf/lib/esmf.mk
         cd ufs_utils
         mkdir build && cd build
-        cmake .. -DCMAKE_PREFIX_PATH=~
+        cmake .. -DCMAKE_PREFIX_PATH=~;~/jasper
         make -j2
 
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -44,15 +44,15 @@ jobs:
         export ESMF_NETCDF_LIBPATH=/usr/x86_64-linux-gnu
         make -j2
         make install
-
-    - name: checkout-jasper
-      uses: actions/checkout@v2
+    - name: cache-jasper
+      id: cache-jasper
+      uses: actions/cache@v2
       with:
-        repository: jasper-software/jasper
-        path: jasper
-        ref: version-2.0.22
+        path: ~/jasper
+        key: jasper-${{ runner.os }}-2.0.22
 
     - name: build-jasper
+      if: steps.cache-jasper.outputs.cache-hit != 'true'
       run: |
         set -x
         pwd
@@ -60,7 +60,7 @@ jobs:
         tar zxf version-2.0.22.tar.gz && ls -l
         cd jasper-version-2.0.22
         mkdir build-jasper && cd build-jasper
-        cmake .. -DCMAKE_INSTALL_PREFIX=~
+        cmake .. -DCMAKE_INSTALL_PREFIX=~/jasper
         make -j2
         make install
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -57,8 +57,6 @@ jobs:
         set -x
         pwd
         wget https://github.com/jasper-software/jasper/archive/version-2.0.22.tar.gz &> /dev/null && ls -l
-        tar zxf version-2.0.22.tar.gz
-	ls -l
         cd jasper
         mkdir build-jasper && cd build-jasper
         cmake .. -DCMAKE_INSTALL_PREFIX=~

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -78,7 +78,7 @@ jobs:
         wget https://github.com/NOAA-EMC/NCEPLIBS/archive/v1.3.0.tar.gz &> /dev/null && ls -l
         cd nceplibs
         mkdir build && cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX=~ -DFLAT=ON
+        cmake .. -DCMAKE_INSTALL_PREFIX=~;~/jasper -DFLAT=ON
         make -j2
        
     - name: checkout-ufs-utils

--- a/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-1.3.0.yml
+++ b/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-1.3.0.yml
@@ -63,21 +63,21 @@ jobs:
         cmake .. -DCMAKE_INSTALL_PREFIX=~/jasper
         make -j2
         make install
-
-    - name: checkout-nceplibs
-      uses: actions/checkout@v2
+    - name: cache-nceplibs
+      id: cache-nceplibs
+      uses: actions/cache@v2
       with:
-        repository: NOAA-EMC/NCEPLIBS
-        path: nceplibs
-        ref: v1.3.0
+        path: ~/nceplibs
+        key: nceplibs-${{ runner.os }}-1.3.0
 
     - name: build-nceplibs
+      if: steps.cache-nceplibs.outputs.cache-hit != 'true'
       run: |
         set -x
         export ESMFMKFILE=~/esmf/lib/esmf.mk
         wget https://github.com/NOAA-EMC/NCEPLIBS/archive/v1.3.0.tar.gz &> /dev/null
         tar zxf v1.3.0.tar.gz && ls -l
-        cd nceplibs
+        cd NCEPLIBS-1.3.0
         mkdir build && cd build
         cmake .. -DCMAKE_PREFIX_PATH='~;~/jasper' -DCMAKE_INSTALL_PREFIX='~/nceplibs' -DFLAT=ON
         make -j2

--- a/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-1.3.0.yml
+++ b/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-1.3.0.yml
@@ -30,8 +30,8 @@ jobs:
         set -x
         pushd ~
         export ESMF_DIR=~/esmf-ESMF_8_0_1
-        wget https://github.com/esmf-org/esmf/archive/ESMF_8_0_1.tar.gz &> /dev/null && ls -l
-        tar zxf ESMF_8_0_1.tar.gz && ls -l
+        wget https://github.com/esmf-org/esmf/archive/ESMF_8_0_1.tar.gz &> /dev/null
+        tar zxf ESMF_8_0_1.tar.gz
         cd esmf-ESMF_8_0_1
         export ESMF_COMM=mpich3
         export ESMF_INSTALL_BINDIR=bin
@@ -56,8 +56,8 @@ jobs:
       run: |
         set -x
         pwd
-        wget https://github.com/jasper-software/jasper/archive/version-2.0.22.tar.gz &> /dev/null && ls -l
-        tar zxf version-2.0.22.tar.gz && ls -l
+        wget https://github.com/jasper-software/jasper/archive/version-2.0.22.tar.gz &> /dev/null
+        tar zxf version-2.0.22.tar.gz
         cd jasper-version-2.0.22
         mkdir build-jasper && cd build-jasper
         cmake .. -DCMAKE_INSTALL_PREFIX=~/jasper

--- a/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-1.3.0.yml
+++ b/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-1.3.0.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: esmf-8.0.1_jasper-2.0.22_nceplibs-1.3.0
 on: [push, pull_request]
 
 jobs:
@@ -69,15 +69,17 @@ jobs:
       with:
         repository: NOAA-EMC/NCEPLIBS
         path: nceplibs
+        ref: v1.3.0
 
     - name: build-nceplibs
       run: |
         set -x
         export ESMFMKFILE=~/esmf/lib/esmf.mk
-        wget https://github.com/NOAA-EMC/NCEPLIBS/archive/v1.3.0.tar.gz &> /dev/null && ls -l
+        wget https://github.com/NOAA-EMC/NCEPLIBS/archive/v1.3.0.tar.gz &> /dev/null
+        tar zxf v1.3.0.tar.gz && ls -l
         cd nceplibs
         mkdir build && cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX='~;~/jasper' -DFLAT=ON
+        cmake .. -DCMAKE_PREFIX_PATH='~;~/jasper' -DCMAKE_INSTALL_PREFIX='~/nceplibs' -DFLAT=ON
         make -j2
        
     - name: checkout-ufs-utils
@@ -90,7 +92,7 @@ jobs:
         export ESMFMKFILE=~/esmf/lib/esmf.mk
         cd ufs_utils
         mkdir build && cd build
-        cmake .. -DCMAKE_PREFIX_PATH='~;~/jasper'
+        cmake .. -DCMAKE_PREFIX_PATH='~;~/jasper;~/nceplibs'
         make -j2
 
 

--- a/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
+++ b/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: esmf-8.0.1_jasper-2.0.22_nceplibs-develop
 on: [push, pull_request]
 
 jobs:
@@ -74,10 +74,9 @@ jobs:
       run: |
         set -x
         export ESMFMKFILE=~/esmf/lib/esmf.mk
-        wget https://github.com/NOAA-EMC/NCEPLIBS/archive/v1.3.0.tar.gz &> /dev/null && ls -l
         cd nceplibs
         mkdir build && cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX='~;~/jasper' -DFLAT=ON
+        cmake .. -DCMAKE_PREFIX_PATH='~;~/jasper' -DCMAKE_INSTALL_PREFIX='~' -DFLAT=ON
         make -j2
        
     - name: checkout-ufs-utils


### PR DESCRIPTION
Fixes #260 
Fixes #259

Now cache jasper build.
Also rename workflows for clarity.
Also added workflow to test against nceplibs-1.3.0.
Changed existing workflow to use nceplibs develop branch.
