### PR TITLE
Rearrange allocation of hgt_1d in mtnlm7_oclsm.f to fix errors on macOS

### DIFF
--- a/sorc/orog_mask_tools.fd/orog.fd/mtnlm7_oclsm.f
+++ b/sorc/orog_mask_tools.fd/orog.fd/mtnlm7_oclsm.f
@@ -1772,7 +1772,7 @@ C
       implicit none
       real, parameter :: D2R = 3.14159265358979/180.
       integer, parameter :: MAXSUM=20000000
-      real  hgt_1d(MAXSUM)     
+      real, dimension(:), allocatable ::  hgt_1d
       integer IM, JM, IMN, JMN
       real GLAT(JMN), GLON(IMN)
       INTEGER ZAVG(IMN,JMN),ZSLM(IMN,JMN)
@@ -1797,6 +1797,7 @@ C
 ! ---  mskocn=1 Use ocean model sea land mask, OK and present,
 ! ---  mskocn=0 dont use Ocean model sea land mask, not OK, not present
       print *,' _____ SUBROUTINE MAKEMT2 '
+      allocate(hgt_1d(MAXSUM))
 C---- GLOBAL XLAT AND XLON ( DEGREE )
 C
       JM1 = JM - 1
@@ -1892,9 +1893,9 @@ C  (*j*)  for hard wired zero offset (lambda s =0) for terr05
          ENDDO
       ENDDO
 !$omp end parallel do
-      WRITE(6,*) "! MAKEMT ORO SLM VAR VAR4 DONE"
+      WRITE(6,*) "! MAKEMT2 ORO SLM VAR VAR4 DONE"
 C
-
+      deallocate(hgt_1d)
       RETURN
       END
 


### PR DESCRIPTION
I've been running various UFS_UTILS on my Desktop and I re-discovered #243 in develop.

The problem was fixed in `release/public-v2`, but it still exists in the develop branch.