### PR TITLE
Remove duplicate 'to_upper' from chgres_cube

### DIFF
--- a/sorc/chgres_cube.fd/grib2_util.F90
+++ b/sorc/chgres_cube.fd/grib2_util.F90
@@ -88,30 +88,4 @@ subroutine convert_omega(omega,p,t,q,clb,cub)
 
 end subroutine convert_omega
 
-!> Convert string from lower to uppercase.
-!! @author Clive Page
-!!
-!! Adapted from http://www.star.le.ac.uk/~cgp/fortran.html (25 May 2012)
-!!
-!! @param[in] strIn   string to convert
-!! @return strOut string in uppercase
-function to_upper(strIn) result(strOut)
-
-     implicit none
-
-     character(len=*), intent(in) :: strIn
-     character(len=len(strIn)) :: strOut
-     integer :: i,j
-
-     do i = 1, len(strIn)
-          j = iachar(strIn(i:i))
-          if (j>= iachar("a") .and. j<=iachar("z") ) then
-               strOut(i:i) = achar(iachar(strIn(i:i))-32)
-          else
-               strOut(i:i) = strIn(i:i)
-          end if
-     end do
-
-end function to_upper
-
  end module grib2_util

--- a/sorc/chgres_cube.fd/input_data.F90
+++ b/sorc/chgres_cube.fd/input_data.F90
@@ -4580,7 +4580,6 @@ else
  subroutine read_input_sfc_grib2_file(localpet)
 
    use wgrib2api
-   use grib2_util, only    : to_upper
    use program_setup, only : vgtyp_from_climo, sotyp_from_climo
    use model_grid, only    : input_grid_type
    use search_util
@@ -4593,9 +4592,9 @@ else
    character(len=250)                    :: the_file
    character(len=250)                    :: geo_file
    character(len=20)                     :: vname, vname_file,slev
-
-   character(len=50)                      :: method
-
+   character(len=50)                     :: method
+   character(len=20)                     :: to_upper
+ 
    integer                               :: rc, varnum, iret, i, j,k
    integer                               :: ncid2d, varid, varsize
    integer, parameter                    :: icet_default = 265.0

--- a/sorc/chgres_cube.fd/utils.F90
+++ b/sorc/chgres_cube.fd/utils.F90
@@ -24,7 +24,7 @@
 
  end subroutine error_handler
 
-!> @brief Error handler for netcdf
+!> Error handler for netcdf
 !!
 !! @param[in] err     error status code
 !! @param[in] string  error message
@@ -49,17 +49,18 @@
  return
  end subroutine netcdf_err
  
-!> @brief Convert from lower to uppercase.
+!> Convert string from lower to uppercase.
 !! @author Clive Page
 !!
 !! Adapted from http://www.star.le.ac.uk/~cgp/fortran.html (25 May 2012)
 !!
-!! @param[in,out] strIn   string to convert
- subroutine to_upper(strIn)
+!! @param[in] strIn   string to convert
+!! @return strOut string in uppercase
+function to_upper(strIn) result(strOut)
 
      implicit none
 
-     character(len=*), intent(inout) :: strIn
+     character(len=*), intent(in) :: strIn
      character(len=len(strIn)) :: strOut
      integer :: i,j
 
@@ -71,10 +72,10 @@
                strOut(i:i) = strIn(i:i)
           end if
      end do
-  strIn(:) = strOut(:)
-end subroutine to_upper
 
-!> @brief Convert from upper to lowercase
+end function to_upper
+
+!> Convert from upper to lowercase
 !! @author Clive Page
 !!
 !! Adapted from http://www.star.le.ac.uk/~cgp/fortran.html (25 May 2012)

--- a/tests/chres_cube/ftst_utils.F90
+++ b/tests/chres_cube/ftst_utils.F90
@@ -10,6 +10,7 @@ program ftst_utils
 
  logical                          :: match_result
 
+ character(len=12)                :: to_upper
  character(len=12)                :: test_input_char_1, test_input_char_2, u_st_base, l_st_base
 
  u_st_base="STAGGERLOCCE"
@@ -29,13 +30,11 @@ program ftst_utils
  call to_lower(test_input_char_1) 
  match_result = test_input_char_1 == l_st_base
  if (.not.match_result) then
-   stop
+   stop 1
  endif
 
- call to_upper(test_input_char_2)
- match_result = test_input_char_2 == u_st_base
- if (.not.match_result) then
-   stop
+ if (to_upper(test_input_char_2) /= u_st_base) then
+   stop 2
  endif
 
 !-------------------------------------------------------------------------


### PR DESCRIPTION
One version was a function and the other was a subroutine.  Only the function was being used by chgres_cube. 

The unit test was using the subroutine. So the test was updated to use the function.

Fixes #303