### PR TITLE
Report test coverage using gcovr

### DIFF
--- a/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-1.3.0.yml
+++ b/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-1.3.0.yml
@@ -125,9 +125,4 @@ jobs:
         cmake .. -DCMAKE_PREFIX_PATH='~;~/jasper;~/nceplibs' -DENABLE_DOCS=On
         make -j2
         make test
-
-
-    
         
-   
-

--- a/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-1.3.0.yml
+++ b/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-1.3.0.yml
@@ -102,8 +102,8 @@ jobs:
         key: nceplibs-${{ runner.os }}-1.3.0
 
     - name: build-nceplibs
+      if: steps.cache-nceplibs.outputs.cache-hit != 'true'
       run: |
-        if: steps.cache-nceplibs.outputs.cache-hit != 'true'
         set -x
         export ESMFMKFILE=~/esmf/lib/esmf.mk
         wget https://github.com/NOAA-EMC/NCEPLIBS/archive/v1.3.0.tar.gz &> /dev/null

--- a/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-1.3.0.yml
+++ b/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-1.3.0.yml
@@ -103,6 +103,7 @@ jobs:
 
     - name: build-nceplibs
       run: |
+        if: steps.cache-nceplibs.outputs.cache-hit != 'true'
         set -x
         export ESMFMKFILE=~/esmf/lib/esmf.mk
         wget https://github.com/NOAA-EMC/NCEPLIBS/archive/v1.3.0.tar.gz &> /dev/null

--- a/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
+++ b/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
@@ -131,7 +131,7 @@ jobs:
         gcovr -r .. --html -o test-coverage.html
 
     - uses: actions/upload-artifact@v2
+      if: ${{ matrix.os == 'ubuntu-20.04' }}
       with:
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
         name: test-coverage
         path: ufs_utils/build/test-coverage.html

--- a/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
+++ b/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
@@ -134,4 +134,4 @@ jobs:
       with:
         if: ${{ matrix.os == 'ubuntu-20.04' }}
         name: test-coverage
-        path: ufs_utils/build/test-coverag.html
+        path: ufs_utils/build/test-coverage.html

--- a/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
+++ b/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
@@ -128,9 +128,10 @@ jobs:
         make -j2
         make test
         export PATH="/home/runner/.local/bin:$PATH"
-        gcovr -r .. --html -o test-coverage-${{ matrix.os }}.html
+        gcovr -r .. --html -o test-coverage.html
 
     - uses: actions/upload-artifact@v2
       with:
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
         name: test-coverage
-        path: ufs_utils/build/test-coverage-${{ matrix.os }}.html
+        path: ufs_utils/build/test-coverag.html

--- a/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
+++ b/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
@@ -128,7 +128,7 @@ jobs:
         make -j2
         make test
         export PATH="/home/runner/.local/bin:$PATH"
-        gcovr -r .. --html -o test-coverage.html
+        gcovr -r .. --html -o test-coverage-${{ matrix.os }}.html
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
+++ b/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
@@ -90,7 +90,6 @@ jobs:
         make -j2
         make install
 
-        
     - name: checkout-nceplibs
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
+++ b/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
@@ -133,4 +133,4 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: test-coverage
-        path: ufs_utils/build/test-coverage.html
+        path: ufs_utils/build/test-coverage-${{ matrix.os }}.html

--- a/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
+++ b/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
@@ -96,13 +96,18 @@ jobs:
       with:
         repository: NOAA-EMC/NCEPLIBS
         path: nceplibs
+
+    - name: get-git-hash:
+      run: |
+        cd nceplibs
+        git rev-parse HEAD > hash.txt
         
     - name: cache-nceplibs-develop
       id: cache-nceplibs-develop
       uses: actions/cache@v2
       with:
         path: ~/nceplibs
-        key: nceplibs-develop-${{ runner.os }}-${{ hashFiles('nceplibs/VERSION') }}
+        key: nceplibs-develop-${{ runner.os }}-${{ hashFiles('nceplibs/hash.txt') }}
 
     - name: build-nceplibs
       if: steps.cache-nceplibs-develop.outputs.cache-hit != 'true'

--- a/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
+++ b/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
@@ -34,6 +34,8 @@ jobs:
             sudo ln -sf /usr/local/bin/gfortran-10 /usr/local/bin/gfortran
           fi
         fi
+        export PATH="~/.local/bin:$PATH"
+        python3 -m pip install gcovr
 
     - name: cache-esmf
       id: cache-esmf
@@ -88,19 +90,28 @@ jobs:
         make -j2
         make install
 
+        
     - name: checkout-nceplibs
       uses: actions/checkout@v2
       with:
         repository: NOAA-EMC/NCEPLIBS
         path: nceplibs
+        
+    - name: cache-nceplibs-develop
+      id: cache-nceplibs-develop
+      uses: actions/cache@v2
+      with:
+        path: ~/nceplibs
+        key: nceplibs-develop-${{ runner.os }}-${{ hashFiles('nceplibs/VERSION') }}
 
     - name: build-nceplibs
+      if: steps.cache-nceplibs-develop.outputs.cache-hit != 'true'
       run: |
         set -x
         export ESMFMKFILE=~/esmf/lib/esmf.mk
         cd nceplibs
         mkdir build && cd build
-        cmake .. -DCMAKE_PREFIX_PATH='~;~/jasper' -DCMAKE_INSTALL_PREFIX='~' -DFLAT=ON
+        cmake .. -DCMAKE_PREFIX_PATH='~;~/jasper' -DCMAKE_INSTALL_PREFIX='~/nceplibs' -DFLAT=ON
         make -j2
        
     - name: checkout-ufs-utils
@@ -113,12 +124,13 @@ jobs:
         export ESMFMKFILE=~/esmf/lib/esmf.mk
         cd ufs_utils
         mkdir build && cd build
-        cmake .. -DCMAKE_PREFIX_PATH='~;~/jasper' -DENABLE_DOCS=On
+        cmake .. -DCMAKE_PREFIX_PATH='~/jasper;~/nceplibs' -DENABLE_DOCS=On -DCMAKE_Fortran_FLAGS="-g -fprofile-arcs -ftest-coverage -O0"
         make -j2
         make test
+        export PATH="/home/runner/.local/bin:$PATH"
+        gcovr -r .. --html -o test-coverage.html
 
-
-    
-        
-   
-
+    - uses: actions/upload-artifact@v2
+      with:
+        name: test-coverage
+        path: ufs_utils/build/test-coverage.html

--- a/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
+++ b/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-develop.yml
@@ -97,7 +97,7 @@ jobs:
         repository: NOAA-EMC/NCEPLIBS
         path: nceplibs
 
-    - name: get-git-hash:
+    - name: get-git-hash
       run: |
         cd nceplibs
         git rev-parse HEAD > hash.txt


### PR DESCRIPTION
The workflow uploads test-coverage.html and stores it as an artifact which can be manually  downloaded on the Actions page.

Also cache NCEPLIBS on this workflow by hashing the `VERSION` file contained in the repo.

See here for the current test coverage file: https://github.com/kgerheiser/UFS_UTILS/actions/runs/615240346