### PR TITLE
separate chgres_cube doxygen build from rest of UFS_UTILS, fix remaining chgres_cube doxygen warnings, turn on WARN_AS_ERROR for chgres_cube

### DIFF
--- a/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-1.3.0.yml
+++ b/.github/workflows/esmf-8.0.1_jasper-2.0.22_nceplibs-1.3.0.yml
@@ -120,6 +120,8 @@ jobs:
 
     - name: build-ufs-utils
       run: |
+        set -x
+        pwd
         export ESMFMKFILE=~/esmf/lib/esmf.mk
         cd ufs_utils
         mkdir build && cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,15 @@ if(EMC_EXEC_DIR)
   set(exec_dir exec)
 endif()
 
+# If doxygen documentation we enabled, build it. This must come before
+# adding the source code directories; the main documentation build
+# must happen before any of the utility document builds.
+if(ENABLE_DOCS)
+  find_package(Doxygen REQUIRED)
+  set(abs_top_srcdir "${CMAKE_SOURCE_DIR}")
+  add_subdirectory(docs)  
+endif()
+
 add_subdirectory(sorc)
 
 # Run unit tests.
@@ -79,8 +88,3 @@ if(BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 
-# If doxygen documentation we enabled, build it.
-if(ENABLE_DOCS)
-  find_package(Doxygen REQUIRED)
-  add_subdirectory(docs)  
-endif()

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -4,7 +4,6 @@
 # Ed Hartnett 10/5/20
 
 # Create doxyfile.
-set(abs_top_srcdir "${CMAKE_SOURCE_DIR}")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
 
 # Build documentation with target all.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -10,8 +10,8 @@ https://github.com/NOAA-EMC/UFS_UTILS.
 
 ## The Utilities
 
-- chgres_cube - Creates cold start initial conditions for FV3 model
-  runs.
+- <a href="chgres_cube/index.html">chgres_cube</a> - Creates cold
+  start initial conditions for FV3 model runs.
 
 - emcsfc_ice_blend - Blends National Ice Center sea ice cover and EMC
   sea ice concentration data to create a global sea ice analysis used

--- a/sorc/chgres_cube.fd/CMakeLists.txt
+++ b/sorc/chgres_cube.fd/CMakeLists.txt
@@ -43,3 +43,9 @@ if(OpenMP_Fortran_FOUND)
 endif()
 
 install(TARGETS ${exe_name} RUNTIME DESTINATION ${exec_dir})
+
+# If doxygen documentation we enabled, build it.
+if(ENABLE_DOCS)
+  add_subdirectory(docs)  
+endif()
+

--- a/sorc/chgres_cube.fd/atmosphere.F90
+++ b/sorc/chgres_cube.fd/atmosphere.F90
@@ -781,7 +781,9 @@
 !!     PS           REAL (IX) SURFACE PRESSURE (PA)                      
 !!   OUTPUT ARGUMENT LIST:                                               
 !!     PM           REAL (IX,KM) MID-LAYER PRESSURE (PA)                 
-!!     DP           REAL (IX,KM) LAYER DELTA PRESSURE (PA)               
+!!     DP           REAL (IX,KM) LAYER DELTA PRESSURE (PA)
+!!
+!! @param localpet ESMF local persistent execution thread  
 !!
 !! @author HANN_MING HENRY JUANG, JUANG, Fanglin Yang, S. Moorthi
  subroutine newpr1(localpet)

--- a/sorc/chgres_cube.fd/docs/CMakeLists.txt
+++ b/sorc/chgres_cube.fd/docs/CMakeLists.txt
@@ -1,14 +1,14 @@
-# This is the CMake file for building the docs directory of NCEPLIBS
-# UFS_UTILS project.
+# This is the CMake file for building the docs directory of UFS_UTILS
+# utility chgres_cube.
 #
-# Ed Hartnett 10/5/20
+# Ed Hartnett 3/8/21
 
 # Create doxyfile.
 set(abs_top_srcdir "${CMAKE_SOURCE_DIR}")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
 
 # Build documentation with target all.
-add_custom_target(doc ALL
+add_custom_target(chgres_cube_doc ALL
   ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Generating API Documentation with Doxygen" VERBATIM)

--- a/sorc/chgres_cube.fd/docs/CMakeLists.txt
+++ b/sorc/chgres_cube.fd/docs/CMakeLists.txt
@@ -4,7 +4,6 @@
 # Ed Hartnett 3/8/21
 
 # Create doxyfile.
-set(abs_top_srcdir "${CMAKE_SOURCE_DIR}")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
 
 # Build documentation with target all.

--- a/sorc/chgres_cube.fd/docs/Doxyfile.in
+++ b/sorc/chgres_cube.fd/docs/Doxyfile.in
@@ -780,7 +780,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = @abs_top_srcdir@/sorc/fre-nctools.fd  @abs_top_srcdir@/sorc/nst_tf_chg.fd
+EXCLUDE                = ../../fre-nctools.fd 
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -881,7 +881,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = @abs_top_srcdir@/docs/sp_user_guide.md 
+USE_MDFILE_AS_MAINPAGE = 
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/sorc/chgres_cube.fd/docs/Doxyfile.in
+++ b/sorc/chgres_cube.fd/docs/Doxyfile.in
@@ -733,7 +733,7 @@ WARN_LOGFILE           =
 
 # WARN_AS_ERROR causes warnings to be treated as errors.
 
-WARN_AS_ERROR = NO
+WARN_AS_ERROR = YES
 
 #---------------------------------------------------------------------------
 # Configuration options related to the input files

--- a/sorc/chgres_cube.fd/docs/Doxyfile.in
+++ b/sorc/chgres_cube.fd/docs/Doxyfile.in
@@ -30,7 +30,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = UFS_UTILS
+PROJECT_NAME           = chgres_cube
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
@@ -56,7 +56,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       =
+OUTPUT_DIRECTORY       = ../../../docs/html/chgres_cube
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -745,7 +745,7 @@ WARN_AS_ERROR = NO
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT = @abs_top_srcdir@/docs/user_guide.md @abs_top_srcdir@/sorc 
+INPUT = @abs_top_srcdir@/sorc/chgres_cube.fd/docs/user_guide.md @abs_top_srcdir@/sorc/chgres_cube.fd
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -780,7 +780,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = @abs_top_srcdir@/sorc/fre-nctools.fd  @abs_top_srcdir@/sorc/chgres_cube.fd
+EXCLUDE                = @abs_top_srcdir@/sorc/fre-nctools.fd  @abs_top_srcdir@/sorc/nst_tf_chg.fd
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -1029,7 +1029,7 @@ GENERATE_HTML          = YES
 # The default directory is: html.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_OUTPUT            = html
+HTML_OUTPUT            = .
 
 # The HTML_FILE_EXTENSION tag can be used to specify the file extension for each
 # generated HTML page (for example: .htm, .php, .asp).

--- a/sorc/chgres_cube.fd/docs/user_guide.md
+++ b/sorc/chgres_cube.fd/docs/user_guide.md
@@ -1,0 +1,12 @@
+@mainpage
+
+# chgres_cube
+
+Creates cold start initial conditions for FV3 model runs. This is part
+of the [NCEPLIBS UFS_UTILS](https://github.com/NOAA-EMC/UFS_UTILS) project.
+
+This is part of the <a href="../index.html">UFS_UTILS documentation</a>.
+
+The chgres_cube code can be found here:
+https://github.com/NOAA-EMC/UFS_UTILS/tree/develop/sorc/chgres_cube.fd.
+

--- a/sorc/chgres_cube.fd/input_data.F90
+++ b/sorc/chgres_cube.fd/input_data.F90
@@ -101,7 +101,7 @@
  integer, public      :: lsoil_input=4  !< number of soil layers, no longer hardwired to allow
                                         !! for 7 layers of soil for the RUC LSM
  
- character(len=50), private, allocatable :: slevs(:)                           
+ character(len=50), private, allocatable :: slevs(:) !< ???
 
 ! Fields associated with the nst model.
 

--- a/sorc/chgres_cube.fd/input_data.F90
+++ b/sorc/chgres_cube.fd/input_data.F90
@@ -101,7 +101,7 @@
  integer, public      :: lsoil_input=4  !< number of soil layers, no longer hardwired to allow
                                         !! for 7 layers of soil for the RUC LSM
  
- character(len=50), private, allocatable :: slevs(:) !< ???
+ character(len=50), private, allocatable :: slevs(:) !< The atmospheric levels in the GRIB2 input file.
 
 ! Fields associated with the nst model.
 


### PR DESCRIPTION
Part of #191 
Part of #357 

In this PR I separate out the doxygen build of chgres_cube from the rest of UFS_UTILS. Now the modules and data type sections of the documentation for chgres_cube look as we want them to.

The top level documentation now just contains a link to the chgres_cube documentation.

This will happen with all the other utilities as well, and then all the module and data type lists will look good.

One advantage of this approach is we can turn on WARN_AS_ERROR in the Doxyfile.in of each utility as we get the documentation completed. In the case of chgres_cube there were still two warnings, which I fix here, and I turn on WARN_AS_ERROR for chgres_cube.

@GeorgeGayno-NOAA I had to use one ??? for a missing field in input_data.F90. What should I put there?