### PR TITLE
cleared doxygen warnings from vcoord_gen utility

### DIFF
--- a/sorc/vcoord_gen.fd/docs/Doxyfile.in
+++ b/sorc/vcoord_gen.fd/docs/Doxyfile.in
@@ -733,7 +733,7 @@ WARN_LOGFILE           =
 
 # WARN_AS_ERROR causes warnings to be treated as errors.
 
-WARN_AS_ERROR = NO
+WARN_AS_ERROR = YES
 
 #---------------------------------------------------------------------------
 # Configuration options related to the input files

--- a/sorc/vcoord_gen.fd/driver.f90
+++ b/sorc/vcoord_gen.fd/driver.f90
@@ -1,4 +1,10 @@
 !> @file
+!! @brief Driver for vcoord_gen.
+!! @author Mark Iredell @date 2008-08-01
+
+!> Driver for vcoord_gen.
+!! @return 0 for success, error code otherwise.
+!! @author Mark Iredell @date 2008-08-01
 program driver
   implicit none
   integer levs,lupp,k

--- a/sorc/vcoord_gen.fd/matrix_utils.f90
+++ b/sorc/vcoord_gen.fd/matrix_utils.f90
@@ -1,12 +1,9 @@
 !> @file
-!! Lower and upper triangular decomposition
-!! @author Iredell @date 2008-08-01
-!
+!! Lower and upper triangular decomposition.
+!! @author Mark Iredell @date 2008-08-01
+
 !> This subprogram decomposes a matrix into a product of
 !! lower and upper triangular matrices.
-!!
-!! Program history log:
-!! -  2008-08-01  Mark Iredell
 !!
 !! @param[inout] a - input: a real(np,np) matrix (will be overwritten) output:
 !!                 - output real(np,np) LU-decomposed matrix
@@ -19,7 +16,7 @@
 !!              (original A rows are permuted in order i with indx(i))
 !! @param[out] d real determinant permutation (1 or -1, or 0 if singular)
 !!              (determinant is output diagonal product times d)
-!!
+!! @author Mark Iredell @date 2008-08-01
 subroutine ludcmp(a,n,np,indx,d)
   implicit none
   integer,intent(in):: n,np
@@ -92,19 +89,14 @@ end subroutine
 !! This subprogram back substitutes to solve decomposed
 !! lower and upper triangular matrices as outputted by ludcmp.
 !!
-!! Program history log:
-!! -  2008-08-01  Mark Iredell
-!!
-!!   Input argument list:
-!! @param[in] a        real(np,np) LU-decomposed matrix
-!!                     (from ludcmp)
-!! @param[in] n        integer order of matrix
-!! @param[in] np       integer dimension of matrix
-!! @param[in] indx     integer(n) pivot indices (from ludcmp)
+!! @param[in] a real(np,np) LU-decomposed matrix (from ludcmp)
+!! @param[in] n integer order of matrix
+!! @param[in] np integer dimension of matrix
+!! @param[in] indx integer(n) pivot indices (from ludcmp)
 !! @param[inout] b  - input real(n) rhs vector of linear problem (will be overwritten)
 !!                  - output real(n) solution of linear problem 
 !!                    (original A times output B equals original B)
-!!
+!! @author Mark Iredell @date 2008-08-01
 subroutine lubksb(a,n,np,indx,b)
   implicit none
   integer,intent(in):: n,np

--- a/sorc/vcoord_gen.fd/vcoord_gen.f90
+++ b/sorc/vcoord_gen.fd/vcoord_gen.f90
@@ -1,9 +1,8 @@
 !> @file
-!!
-!! vcoord_gen   Generates hybrid coordinate interface profiles
-!! @author Iredell @date 2008-08-01
-!
-!! This subprogram generates hybrid coordinate interface profiles
+!! @brief Generates hybrid coordinate interface profiles.
+!! @author Mark Iredell @date 2008-08-01
+
+!> This subprogram generates hybrid coordinate interface profiles
 !! from a few given parameters. The hybrid coordinate is intended to start
 !! out at the bottom in pure sigma and end up at the top in pure pressure,
 !! with a smooth transition in between. The pressure thickness is close to
@@ -18,9 +17,6 @@
 !! the constant top pressure (which can be zero) is the top boundary condition.
 !!
 !! The procedure for the calculation is described in the remarks section below.
-!!
-!! Program history log:
-!! -  2008-08-01  Mark Iredell
 !!
 !! @param[in] levs     integer number of levels 
 !! @param[in] lupp     integer number of levels below pupp
@@ -151,7 +147,7 @@
 !! <pre>
 !!     p(psfc)=ak+bk*psfc
 !! </pre>
-!!
+!! @author Mark Iredell @date 2008-08-01
 subroutine vcoord_gen(levs,lupp,pbot,psig,ppre,pupp,ptop,&
                    dpbot,dpsig,dppre,dpupp,dptop,pmin,ak,bk)
   implicit none


### PR DESCRIPTION
Part of #191 
Fixes #403 

Clearing remaining doxygen warnings for vcoord_gen, and turning on WARN_AS_ERROR for doxygen there.