### PR TITLE
Update FindESMF.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
 # Find packages.
 find_package(NetCDF REQUIRED C Fortran)
 find_package(MPI REQUIRED C Fortran)
-find_package(ESMF MODULE REQUIRED)
+find_package(ESMF 8.1.0.27 REQUIRED)
 
 if(OPENMP)
   find_package(OpenMP REQUIRED COMPONENTS Fortran)

--- a/cmake/FindESMF.cmake
+++ b/cmake/FindESMF.cmake
@@ -72,6 +72,20 @@ if (ESMF_FOUND)
     endif()
   endforeach()
 
+  # Construct ESMF_VERSION from ESMF_VERSION_STRING_GIT
+  if(ESMF_FOUND)
+    # ESMF_VERSION_MAJOR and ESMF_VERSION_MINOR are defined in ESMFMKFILE
+    set(ESMF_VERSION 0)
+    set(ESMF_VERSION_PATCH ${ESMF_VERSION_REVISION})
+    set(ESMF_VERSION_TWEAK 0)
+    set(ESMF_BETA_RELEASE FALSE)
+    if(ESMF_VERSION_BETASNAPSHOT MATCHES "^('T')$")
+      set(ESMF_BETA_RELEASE TRUE)
+      string(REGEX REPLACE ".*beta_snapshot_*\([0-9]*\).*" "\\1" ESMF_VERSION_TWEAK "${ESMF_VERSION_STRING_GIT}")
+    endif()
+    set(ESMF_VERSION "${ESMF_VERSION_MAJOR}.${ESMF_VERSION_MINOR}.${ESMF_VERSION_PATCH}.${ESMF_VERSION_TWEAK}")
+  endif()
+
   separate_arguments(ESMF_F90COMPILEPATHS NATIVE_COMMAND ${ESMF_F90COMPILEPATHS})
   foreach (ITEM ${ESMF_F90COMPILEPATHS})
      string(REGEX REPLACE "^-I" "" ITEM "${ITEM}")
@@ -103,3 +117,13 @@ if (ESMF_FOUND)
     INTERFACE_LINK_LIBRARIES "${ESMF_INTERFACE_LINK_LIBRARIES}")
 
 endif()
+
+## Finalize find_package
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args( ${CMAKE_FIND_PACKAGE_NAME}
+    REQUIRED_VARS ESMF_LIBSDIR
+                  ESMF_INTERFACE_LINK_LIBRARIES
+                  ESMF_F90COMPILEPATHS
+    VERSION_VAR ESMF_VERSION
+    HANDLE_COMPONENTS )


### PR DESCRIPTION
This PR updates `FindESMF.cmake` based on `esmf.mk` to define the following variables:
- create `ESMF_VERSION` string based on `ESMF_VERSION_STRING_GIT`
- define `MAJOR`, `MINOR`, `PATCH`, `TWEAK` components of `ESMF_VERSION`
- add a variable `ESMF_BETA_RELEASE` to indicate returned version is a Beta release.

Usage:
```
find_package(ESMF <VERSION> <REQUIRED>)
```

If the found version is less than the desired `VERSION`, `find_package` will fail with an error message.

I have tested a stripped down build on my macOS and Orion, but not on the various platforms. 