### PR TITLE
Eliminate compiler warning in chgres_cube

### DIFF
--- a/sorc/chgres_cube.fd/input_data.F90
+++ b/sorc/chgres_cube.fd/input_data.F90
@@ -6045,11 +6045,11 @@ if (localpet == 0) then
  real(esmf_kind_r8)                      :: d2r
 
  integer                                 :: varnum_u, varnum_v, vlev, & !ncid, id_var, &
-                                            error, iret, i,istr
+                                            error, iret, istr
 
  character(len=20)                       :: vname
  character(len=50)                       :: method_u, method_v
- character(len=250)                      :: file_coord, cmdline_msg
+ character(len=250)                      :: file_coord
  character(len=10000)                    :: temp_msg
 
  d2r=acos(-1.0_esmf_kind_r8) / 180.0_esmf_kind_r8

--- a/sorc/chgres_cube.fd/model_grid.F90
+++ b/sorc/chgres_cube.fd/model_grid.F90
@@ -810,7 +810,7 @@
  use netcdf
  use wgrib2api
  use program_setup, only       : grib2_file_input_grid, data_dir_input_grid, &
-                                  fix_dir_input_grid, external_model
+                                  fix_dir_input_grid
  implicit none
 
  character(len=500)           :: the_file, temp_file
@@ -826,7 +826,7 @@
  real(esmf_kind_r8)                    :: deltalon, dx
  integer                               :: ncid,id_var, id_dim
  real(esmf_kind_r8), pointer           :: lat_src_ptr(:,:), lon_src_ptr(:,:)
- character(len=10000)            :: cmdline_msg, temp_msg, temp_msg2
+ character(len=10000)            :: temp_msg
  character(len=10)              :: temp_num = 'NA'
 
  num_tiles_input_grid = 1

--- a/sorc/chgres_cube.fd/surface.F90
+++ b/sorc/chgres_cube.fd/surface.F90
@@ -2935,7 +2935,7 @@ print*,"- CALL FieldGet FOR TARGET GRID FACSF."
  do i =clb(1),cub(1)
    do j = clb(2),cub(2)
      if (landmask_ptr(i,j)==1 .and. soilm_target_ptr(i,j,1) < 0.001 .and. nint(veg_type_target_ptr(i,j)) /= veg_type_landice_target) then !.and. &
-         WRITE(*,'(a,2i5,a,2i3)'), " CORRECTING G.P. ",i,j," PARAMS FROM SEA TO LAND &
+         WRITE(*,'(a,2i5,a,2i3)') " CORRECTING G.P. ",i,j," PARAMS FROM SEA TO LAND &
                     VALUES; curr stype,vtype=",  nint(soil_type_target_ptr(i,j)),nint(veg_type_target_ptr(i,j))
          ! Set values to missing so that search function can then replace 
          ! them with nearby point values (see replace_land_sfcparams)

--- a/sorc/chgres_cube.fd/surface.F90
+++ b/sorc/chgres_cube.fd/surface.F90
@@ -155,9 +155,8 @@
                                        read_input_nst_data
 
  use program_setup, only             : calc_soil_params_driver, &
-                                       convert_nst, &
-                                       vgtyp_from_climo, &
-                                       sotyp_from_climo
+                                       convert_nst
+                                  
  use static_data, only               :  get_static_fields, &
                                        cleanup_static_fields
 


### PR DESCRIPTION
Update a write statement that was causing a compile warning in the CI.
Remove some unused variables that can cause a warning
with some compilers.

Fixes #450