### PR TITLE
Re-add NETCDF env variable so CMake can find NetCDF on WCOSS Cray

### DIFF
--- a/modulefiles/build.wcoss_cray.intel
+++ b/modulefiles/build.wcoss_cray.intel
@@ -36,5 +36,6 @@ setenv Jasper_ROOT /usrx/local/prod/jasper/1.900.1/intel/haswell
 module use /gpfs/hps3/emc/nems/noscrub/emc.nemspara/soft/modulefiles
 #module load esmf/8.0.0
 setenv ESMFMKFILE /gpfs/hps3/emc/nems/noscrub/emc.nemspara/soft/esmf/8.0.0/lib/esmf.mk
+setenv NETCDF /opt/cray/netcdf/4.3.3.1/INTEL/14.0
 module rm gcc
 module load gcc/6.3.0


### PR DESCRIPTION
Variable was removed by accident

Fixes #475 