### PR TITLE
Port the build and gdas_init scripts to S4

### DIFF
--- a/cmake/LibMPI.cmake
+++ b/cmake/LibMPI.cmake
@@ -154,7 +154,11 @@ function (platform_name RETURN_VARIABLE)
     
 
     set (${RETURN_VARIABLE} "stampede" PARENT_SCOPE)
-          
+
+  elseif (SITENAME MATCHES "^s4-submit.ssec.wisc.edu")
+
+    set (${RETURN_VARIABLE} "s4" PARENT_SCOPE)
+
   else ()
 
     set (${RETURN_VARIABLE} "unknown" PARENT_SCOPE)

--- a/fix/link_fixdirs.sh
+++ b/fix/link_fixdirs.sh
@@ -9,20 +9,20 @@ machine=${2}
 if [ $# -lt 2 ]; then
     set +x
     echo '***ERROR*** must specify two arguements: (1) RUN_ENVIR, (2) machine'
-    echo ' Syntax: link_fv3gfs.sh ( nco | emc ) ( cray | dell | hera  | jet | orion )'
+    echo ' Syntax: link_fv3gfs.sh ( nco | emc ) ( cray | dell | hera  | jet | orion | s4 )'
     exit 1
 fi
 
 if [ $RUN_ENVIR != emc -a $RUN_ENVIR != nco ]; then
     set +x
     echo '***ERROR*** unsupported run environment'
-    echo 'Syntax: link_fv3gfs.sh ( nco | emc ) ( cray | dell | hera | jet | orion )'
+    echo 'Syntax: link_fv3gfs.sh ( nco | emc ) ( cray | dell | hera | jet | orion | s4 )'
     exit 1
 fi
-if [ $machine != cray -a $machine != hera -a $machine != dell -a $machine != jet -a $machine != orion ]; then
+if [ $machine != cray -a $machine != hera -a $machine != dell -a $machine != jet -a $machine != orion -a $machine != s4 ]; then
     set +x
     echo '***ERROR*** unsupported machine'
-    echo 'Syntax: link_fv3gfs.sh ( nco | emc ) ( cray | dell | hera | jet | orion )'
+    echo 'Syntax: link_fv3gfs.sh ( nco | emc ) ( cray | dell | hera | jet | orion | s4 )'
     exit 1
 fi
 
@@ -45,6 +45,8 @@ elif [ $machine = "jet" ]; then
     FIX_DIR="/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix"
 elif [ $machine = "orion" ]; then
     FIX_DIR="/work/noaa/global/glopara/fix"
+elif [ $machine = "s4" ]; then
+    FIX_DIR="/data/prod/glopara/fix"
 fi
 
 for dir in fix_am fix_fv3 fix_orog fix_fv3_gmted2010 fix_sfc_climo; do

--- a/modulefiles/build.s4.intel
+++ b/modulefiles/build.s4.intel
@@ -1,0 +1,28 @@
+#%Module#####################################################
+## Build and run module for S4
+#############################################################
+
+module load license_intel/S4
+module use /data/prod/hpc-stack/modulefiles/stack
+module load hpc/1.1.0
+module load hpc-intel/18.0.4
+module load hpc-impi/18.0.4
+
+module load bacio/2.4.1
+module load g2/3.4.1
+module load ip/3.3.3
+module load nemsio/2.5.2
+module load sp/2.3.3
+module load w3nco/2.4.1
+module load sfcio/1.4.1
+module load sigio/2.3.2
+module load wgrib2/2.0.8
+
+module load jasper/2.0.22
+module load zlib/1.2.11
+module load png/1.6.35
+
+module load hdf5/1.10.6
+module load netcdf/4.7.4
+module load nccmp/1.8.7.0
+module load esmf/8_1_0_beta_snapshot_27

--- a/sorc/machine-setup.sh
+++ b/sorc/machine-setup.sh
@@ -131,6 +131,14 @@ elif [[ "$(hostname)" =~ "odin" ]]; then
 elif [[ -d /work/00315 && -d /scratch/00315 ]] ; then
     target=stampede
     module purge
+elif [[ -d /data/prod ]] ; then
+    # We are on SSEC S4
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        echo load the module command 1>&2
+        source /usr/share/lmod/lmod/init/$__ms_shell
+    fi
+    target=s4
+    module purge
 else
     echo WARNING: UNKNOWN PLATFORM 1>&2
 fi

--- a/util/gdas_init/driver.s4.sh
+++ b/util/gdas_init/driver.s4.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+#---------------------------------------------------------------------
+# Driver script for running on S4.
+#
+# Edit the 'config' file before running.
+#---------------------------------------------------------------------
+
+set -x
+
+compiler=${compiler:-"intel"}
+source ../../sorc/machine-setup.sh > /dev/null 2>&1
+module use ../../modulefiles
+module load build.$target.$compiler
+module list
+
+# Needed for NDATE utility
+module load license_intel/S4
+module use /data/prod/hpc-stack/modulefiles/stack
+module load hpc/1.1.0
+module load hpc-intel/18.0.4
+module load hpc-impi/18.0.4
+module load prod_util/1.2.2
+
+PROJECT_CODE=star
+QUEUE=s4
+
+source config
+
+if [ $EXTRACT_DATA == yes ]; then
+
+  echo "HPSS is not accessible from S4!  If you wish to run just the chgres portion, set EXTRACT_DATA=NO in the config file and try again."
+  exit
+
+else  # do not extract data.
+
+  DEPEND=' '
+
+fi  # extract data?
+
+if [ $RUN_CHGRES == yes ]; then
+
+  export APRUN=srun
+  NODES=3
+  WALLT="0:15:00"
+  export OMP_NUM_THREADS=1
+  if [ $CRES_HIRES == 'C768' ] ; then
+    NODES=5
+  elif [ $CRES_HIRES == 'C1152' ] ; then
+    NODES=8
+    WALLT="0:20:00"
+  fi
+  case $gfs_ver in
+    v12 | v13)
+      export OMP_NUM_THREADS=4
+      export OMP_STACKSIZE=1024M
+      sbatch --parsable --ntasks-per-node=6 --nodes=${NODES} --cpus-per-task=$OMP_NUM_THREADS \
+        -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${CDUMP} \
+        -o log.${CDUMP} -e log.${CDUMP} ${DEPEND} run_pre-v14.chgres.sh ${CDUMP}
+      ;;
+    v14)
+      sbatch --parsable --ntasks-per-node=6 --nodes=${NODES} -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${CDUMP} \
+      -o log.${CDUMP} -e log.${CDUMP} ${DEPEND} run_v14.chgres.sh ${CDUMP}
+      ;;
+    v15)
+      if [ "$CDUMP" = "gdas" ]; then
+        sbatch --parsable --ntasks-per-node=6 --nodes=${NODES} -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${CDUMP} \
+        -o log.${CDUMP} -e log.${CDUMP} ${DEPEND} run_v15.chgres.sh ${CDUMP}
+      else
+        sbatch --parsable --ntasks-per-node=6 --nodes=${NODES} -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${CDUMP} \
+        -o log.${CDUMP} -e log.${CDUMP} ${DEPEND} run_v15.chgres.gfs.sh
+      fi
+      ;;
+    v16retro)
+      if [ "$CDUMP" = "gdas" ] ; then
+        sbatch --parsable --ntasks-per-node=6 --nodes=${NODES} -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${CDUMP} \
+        -o log.${CDUMP} -e log.${CDUMP} ${DEPEND} run_v16retro.chgres.sh hires
+      else
+        sbatch --parsable --ntasks-per-node=6 --nodes=${NODES} -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${CDUMP} \
+        -o log.${CDUMP} -e log.${CDUMP} ${DEPEND} run_v16.chgres.sh ${CDUMP}
+      fi
+      ;;
+    v16)
+      sbatch --parsable --ntasks-per-node=6 --nodes=${NODES} -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${CDUMP} \
+      -o log.${CDUMP} -e log.${CDUMP} ${DEPEND} run_v16.chgres.sh ${CDUMP}
+      ;;
+  esac
+
+  if [ "$CDUMP" = "gdas" ]; then
+
+    WALLT="0:15:00"
+
+    if [ "$gfs_ver" = "v16retro" ]; then
+
+      sbatch --parsable --ntasks-per-node=12 --nodes=1 -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_enkf \
+      -o log.enkf -e log.enkf ${DEPEND} run_v16retro.chgres.sh enkf
+
+    else
+
+      MEMBER=1
+      while [ $MEMBER -le 80 ]; do
+        if [ $MEMBER -lt 10 ]; then
+          MEMBER_CH="00${MEMBER}"
+        else
+          MEMBER_CH="0${MEMBER}"
+        fi
+        case $gfs_ver in
+          v12 | v13)
+              export OMP_NUM_THREADS=2
+              export OMP_STACKSIZE=1024M
+              sbatch --parsable --ntasks-per-node=12 --nodes=1 --cpus-per-task=$OMP_NUM_THREADS \
+               -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${MEMBER_CH} \
+               -o log.${MEMBER_CH} -e log.${MEMBER_CH} ${DEPEND} run_pre-v14.chgres.sh ${MEMBER_CH}
+            ;;
+          v14)
+              sbatch --parsable --ntasks-per-node=12 --nodes=1 -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${MEMBER_CH} \
+              -o log.${MEMBER_CH} -e log.${MEMBER_CH} ${DEPEND} run_v14.chgres.sh ${MEMBER_CH}
+            ;;
+          v15)
+              sbatch --parsable --ntasks-per-node=12 --nodes=1 -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${MEMBER_CH} \
+              -o log.${MEMBER_CH} -e log.${MEMBER_CH} ${DEPEND} run_v15.chgres.sh ${MEMBER_CH}
+            ;;
+          v16)
+              sbatch --parsable --ntasks-per-node=12 --nodes=1 -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${MEMBER_CH} \
+              -o log.${MEMBER_CH} -e log.${MEMBER_CH} ${DEPEND} run_v16.chgres.sh ${MEMBER_CH}
+            ;;
+        esac
+        MEMBER=$(( $MEMBER + 1 ))
+      done
+
+    fi # v16 retro?
+
+  fi  # which CDUMP?
+
+fi  # run chgres?


### PR DESCRIPTION
Support for S4 has been added to the build scripts to support the global workflow.  Additionally, a partial driver for gdas_init (chgres only) has been written for S4.  The port is supported by an official build of hpc-stack supported by me on the system.  I have run several test cycles, the logs of which are available on Orion (/work/noaa/nesdis-rdo2/dhuber/s4_logs/test_dev).  I've also run a test case of gdas_init for 2019111818 @192/96, comparing the resulting outputs from S4 and Hera, which were bitwise identical.  Please let me know if you need any further tests completed.

Fixes #543