### PR TITLE
changed build system to accomodate name change of bacio library in bacio-2.5.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ if(OPENMP)
   find_package(OpenMP REQUIRED COMPONENTS Fortran)
 endif()
 
+# Find the NCEPLIBS packages we need.
 find_package(sfcio 1.4.0 REQUIRED)
 find_package(w3nco 2.4.0 REQUIRED)
 find_package(bacio 2.4.0 REQUIRED)
@@ -66,6 +67,16 @@ find_package(ip 3.3.3 REQUIRED)
 find_package(g2 3.4.0 REQUIRED)
 find_package(wgrib2 2.0.8 REQUIRED)
 find_package(sigio 2.3.0 REQUIRED)
+
+# The name of the bacio library changed with the 2.5.0 release. The
+# "_4" was removed from the library and include directory name in the
+# bacio-2.5.0 release. Set a name variable to be used in the rest of
+# the cmake build.
+if(bacio_VERSION GREATER_EQUAL 2.5.0)
+  set(bacio_name bacio)
+else()
+  set(bacio_name bacio_4)
+endif()
 
 # EMC requires executables in ./exec
 set(exec_dir bin)

--- a/sorc/chgres_cube.fd/CMakeLists.txt
+++ b/sorc/chgres_cube.fd/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(
   nemsio::nemsio
   sfcio::sfcio
   sigio::sigio
-  bacio::bacio_4
+  bacio::${bacio_name}
   sp::sp_d
   w3nco::w3nco_d
   esmf

--- a/sorc/emcsfc_ice_blend.fd/CMakeLists.txt
+++ b/sorc/emcsfc_ice_blend.fd/CMakeLists.txt
@@ -10,7 +10,7 @@ set(exe_name emcsfc_ice_blend)
 add_executable(${exe_name} ${fortran_src})
 target_link_libraries(
   ${exe_name}
-  bacio::bacio_4
+  bacio::${bacio_name}
   g2::g2_4
   w3nco::w3nco_4)
 

--- a/sorc/emcsfc_snow2mdl.fd/CMakeLists.txt
+++ b/sorc/emcsfc_snow2mdl.fd/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(snow2mdl_lib
   g2::g2_d
   ip::ip_d
   sp::sp_d
-  bacio::bacio_4
+  bacio::${bacio_name}
   w3nco::w3nco_d)
 
 if(OpenMP_Fortran_FOUND)

--- a/sorc/global_cycle.fd/CMakeLists.txt
+++ b/sorc/global_cycle.fd/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(
   global_cycle_lib
   PUBLIC
   w3nco::w3nco_d
-  bacio::bacio_4
+  bacio::${bacio_name}
   ip::ip_d
   sp::sp_d
   MPI::MPI_Fortran

--- a/sorc/orog_mask_tools.fd/orog.fd/CMakeLists.txt
+++ b/sorc/orog_mask_tools.fd/orog.fd/CMakeLists.txt
@@ -1,3 +1,7 @@
+# This is the CMake file for the orog.fd directory in UFS_UTILS.
+#
+# Mark Potts, Kyle Gerheiser, Rahul Mahajan, Ed Hartnett
+
 set(lib_src netcdf_io.F90)
 set(exe_src mtnlm7_oclsm.f)
 
@@ -22,7 +26,7 @@ target_include_directories(orog_lib INTERFACE ${mod_dir})
 target_link_libraries(
   orog_lib
   PUBLIC
-  bacio::bacio_4
+  bacio::${bacio_name}
   w3nco::w3nco_d
   ip::ip_d
   sp::sp_d


### PR DESCRIPTION
Fixes #589 

In the bacio-2.5.0 release (Oct 20, 2021) the name of the bacio library and include directory change to no longer include the "_4".

In this PR I change the UFS_UTILS build to handle this. The version of bacio is checked in the top-level CMake file, and cmake variable bacio_name is set to either "bacio" or "bacio_4", depending on the bacio version. All other cmake files which use bacio have the name changed to ${bacio_name}.

I will add a github action which tests against the develop branch of bacio to ensure that UFS_UTILS keeps working with both old and new versions of the bacio library.