### PR TITLE
After the move to ufs-community, update all documention.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -2,7 +2,7 @@
 
 - You may delete any sections labeled "optional".
 
-- If you are unclear on what should be written here, see https://github.com/NOAA-EMC/UFS_UTILS/wiki/9.-Creating-a-Pull-Request for some guidance. 
+- If you are unclear on what should be written here, see https://github.com/ufs-community/UFS_UTILS/wiki/9.-Creating-a-Pull-Request for some guidance. 
 
 - The title of this pull request should be a brief summary (ideally less than 100 characters) of the changes included in this PR. Please also include the branch to which this PR is being issued.
 
@@ -19,7 +19,7 @@ State whether the contingency tests were run or are pending, and if they were al
 ## DEPENDENCIES:
 Add any links to pending PRs that are required prior to merging this PR. For example:
 
-NOAA-EMC/UFS_UTILS/pull/<pr_number>
+ufs-community/UFS_UTILS/pull/<pr_number>
 
 ## DOCUMENTATION:
 If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files in the docs/source directory as supporting material.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@ Copyright 2020 National Oceanic and Atmospheric Administration (by assignment fr
  
 The ufs_utils code incorporated in the Unified Forecast System (UFS) was jointly developed by the 
 National Oceanic and Atmospheric Administration and the I. M. Systems Group. The gold standard copy
-of the Code will be maintained by NOAA at https://github.com/NOAA-EMC/UFS_UTILS
+of the Code will be maintained by NOAA at https://github.com/ufs-community/UFS_UTILS
  
 The National Oceanic and Atmospheric Administration is releasing this code under the GNU Lesser 
 General Public License v3.0 (the "License"); you may not use this code except in compliance 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Documentation for chgres_cube and other utilities can be found at
 https://noaa-emcufs-utils.readthedocs.io/en/latest/.
 
 Complete documentation can be found at
-https://noaa-emc.github.io/UFS_UTILS/.
+https://ufs-community.github.io/UFS_UTILS/.
 
 ## Authors
 

--- a/docs/source/chgres_cube.rst
+++ b/docs/source/chgres_cube.rst
@@ -407,12 +407,12 @@ Running the program stand alone
 Making changes to the chgres_cube program
 -----------------------------------------
 
-chgres_cube is part of the UFS_UTILS repository (https://github.com/NOAA-EMC/UFS_UTILS). When wanting to contribute to this repository developers shall follow the Gitflow software development process
+chgres_cube is part of the UFS_UTILS repository (https://github.com/ufs-community/UFS_UTILS). When wanting to contribute to this repository developers shall follow the Gitflow software development process
 
       * Developers shall create their own fork of the UFS_UTILS repository
       * Developers shall create a ‘feature’ branch off ‘develop’ in their fork for all changes.
       * Developers shall open an issue and reference it in all commits.
 
-For more details, see the UFS_UTILS wiki page: https://github.com/NOAA-EMC/UFS_UTILS/wiki
+For more details, see the UFS_UTILS wiki page: https://github.com/ufs-community/UFS_UTILS/wiki
 
 Changes that support current or future NCEP operations will be given priority for inclusion into the authoritative repository.

--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -5,7 +5,7 @@
 Introduction
 ****************************
 
-The Unified Forecast Systems (UFS) Utilities repository contains pre-processing programs for the UFS weather model.  These programs set up the model grid and create coldstart initial conditions. The repository is hosted on `Github <https://github.com/NOAA-EMC/UFS_UTILS>`_.  Information on checking out the code and making changes to it is available on the repository `wiki page <https://github.com/NOAA-EMC/UFS_UTILS/wiki>`_.
+The Unified Forecast Systems (UFS) Utilities repository contains pre-processing programs for the UFS weather model.  These programs set up the model grid and create coldstart initial conditions. The repository is hosted on `Github <https://github.com/ufs-community/UFS_UTILS>`_.  Information on checking out the code and making changes to it is available on the repository `wiki page <https://github.com/ufs-community/UFS_UTILS/wiki>`_.
 
 ***********************************
 Grid Generation

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -6,7 +6,7 @@ Utilities for the NCEP models. This is part of the
 [NCEPLIBS](https://github.com/NOAA-EMC/NCEPLIBS) project.
 
 The UFS_UTILS code can be found here:
-https://github.com/NOAA-EMC/UFS_UTILS.
+https://github.com/ufs-community/UFS_UTILS.
 
 ## The Utilities
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -99,4 +99,4 @@ the unit test framework.
 
 ### QUESTIONS
 
-Please contact the repository managers: https://github.com/NOAA-EMC/UFS_UTILS/wiki
+Please contact the repository managers: https://github.com/ufs-community/UFS_UTILS/wiki


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Updated all documentation for the new location of ufs_utils.

## TESTS CONDUCTED: 
N/A. Only a documentation update. The updated doxygen and readthedocs were created and checked.

## DEPENDENCIES:
None.

## DOCUMENTATION:
 https://georgegayno-noaaufs-utils.readthedocs.io/en/bugfix-move/ufs_utils.html
https://www.emc.ncep.noaa.gov/jcsda/ggayno/doxygen/html/index.html

## ISSUE: 
Fixes #593


