### PR TITLE
Update ops-hrefv3.1 tag for WCOSS2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "cmake"]
-	path = cmake
-	url = https://github.com/NOAA-EMC/CMakeModules
-	branch = develop

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,20 @@
+# This is the main CMake file for NCEPLIBS-ip.
+#
+# George Gayno
 cmake_minimum_required(VERSION 3.15)
 
+# Get the version from the VERSION file.
 file(STRINGS "VERSION" pVersion)
 
 project(
   ufs_util
   VERSION ${pVersion}
   LANGUAGES C Fortran)
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+# User options.
+option(OPENMP "use OpenMP threading" ON)
+option(ENABLE_DOCS "Enable generation of doxygen-based documentation." OFF)
 
 if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
   message(STATUS "Setting build type to 'Release' as none was specified.")
@@ -15,103 +23,60 @@ if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
       CACHE STRING "Choose the type of build." FORCE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
                                                "MinSizeRel" "RelWithDebInfo")
+  message(STATUS "Set BUILD_TESTING to YES and build unit testing package under tests")
+  set(BUILD_TESTING "YES")
 endif()
 
-if(NOT CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|GNU|Clang|AppleClang)$")
-  message(WARNING "Compiler not officially supported: ${CMAKE_Fortran_COMPILER_ID}")
-endif()
-
-if(NOT CMAKE_C_COMPILER_ID MATCHES "^(Intel|GNU)$")
-  message(WARNING "Compiler not officially supported: ${CMAKE_C_COMPILER_ID}")
-endif()
-
+# Set compiler flags.
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
-  set(CMAKE_Fortran_FLAGS "-g -traceback")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -traceback")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -fp-model precise")
   set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check -check noarg_temp_created -check nopointer -fp-stack-check -fstack-protector-all -fpe0 -debug -ftrapuv")
-elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
-  set(CMAKE_Fortran_FLAGS "-g -fbacktrace")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -fbacktrace")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
-  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -ggdb -fno-unsafe-math-optimizations -frounding-math -fsignaling-nans -ffpe-trap=invalid,zero,overflow -fbounds-check")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-O1 -ggdb -fno-unsafe-math-optimizations -frounding-math -fsignaling-nans -ffpe-trap=invalid,zero,overflow -fbounds-check -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls")
 endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES "^(Intel)$")
-  set(CMAKE_C_FLAGS "-g -traceback")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -traceback")
   set(CMAKE_C_FLAGS_RELEASE "-O2")
   set(CMAKE_C_FLAGS_DEBUG "-O0")
-elseif(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
-  set(CMAKE_C_FLAGS " ")
-  set(CMAKE_C_FLAGS_RELEASE " ")
-  set(CMAKE_C_FLAGS_DEBUG " ")
 endif()
 
-find_package(PNG REQUIRED)
-find_package(ZLIB REQUIRED)
-find_package(Jasper REQUIRED)
-find_package(NetCDF REQUIRED C Fortran)
-find_package(MPI REQUIRED )
-find_package(ESMF MODULE REQUIRED)
-find_package(wgrib2 REQUIRED)
+# Find packages.
+find_package(NetCDF 4.3.3 REQUIRED C Fortran)
+find_package(MPI REQUIRED C Fortran)
+find_package(ESMF 8.0.0 REQUIRED)
 
-option(OPENMP "use OpenMP threading" ON)
 if(OPENMP)
   find_package(OpenMP REQUIRED COMPONENTS Fortran)
 endif()
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG true)
-
-if(NOT TARGET gfsio_4)
-  find_package(gfsio REQUIRED)
-endif()
-
-if(NOT TARGET sfcio_4)
-  find_package(sfcio REQUIRED)
-endif()
-
-if(NOT TARGET w3nco_d)
-  find_package(w3nco REQUIRED)
-endif()
-
-if(NOT TARGET landsfcutil_d)
-  find_package(landsfcutil REQUIRED)
-endif()
-
-if(NOT TARGET bacio_4)
-  find_package(bacio REQUIRED)
-endif()
-
-if(NOT TARGET nemsio)
-  find_package(nemsio REQUIRED)
-endif()
-
-if(NOT TARGET nemsiogfs)
-  find_package(nemsiogfs REQUIRED)
-endif()
-
-if(NOT TARGET sigio_4)
-  find_package(sigio REQUIRED)
-endif()
-
-if(NOT TARGET sp_d)
-  find_package(sp REQUIRED)
-endif()
-
-if(NOT TARGET ip_d)
-  find_package(ip REQUIRED)
-endif()
-
-if(NOT TARGET w3emc_d)
-  find_package(w3emc REQUIRED)
-endif()
-
-if(NOT TARGET g2_d)
-  find_package(g2 REQUIRED)
-endif()
+find_package(sfcio 1.4.0 REQUIRED)
+find_package(w3nco 2.4.0 REQUIRED)
+find_package(bacio 2.4.0 REQUIRED)
+find_package(nemsio 2.5.0 REQUIRED)
+find_package(sigio 2.3.0 REQUIRED)
+find_package(sp 2.3.3 REQUIRED)
+find_package(ip 3.3.3 REQUIRED)
+find_package(g2 3.4.0 REQUIRED)
+find_package(wgrib2 2.0.8 REQUIRED)
+find_package(sigio 2.3.0 REQUIRED)
 
 # EMC requires executables in ./exec
 set(exec_dir bin)
 if(EMC_EXEC_DIR)
   set(exec_dir exec)
+endif()
+
+# If doxygen documentation we enabled, build it. This must come before
+# adding the source code directories; the main documentation build
+# must happen before any of the utility document builds.
+if(ENABLE_DOCS)
+  find_package(Doxygen REQUIRED)
+  set(abs_top_srcdir "${CMAKE_SOURCE_DIR}")
+  add_subdirectory(docs)  
 endif()
 
 add_subdirectory(sorc)

--- a/build_all.sh
+++ b/build_all.sh
@@ -1,30 +1,37 @@
 #! /usr/bin/env bash
+#
+# This build script is only used on NOAA WCOSS systems. All other
+# users should set module files as needed, and build directly with
+# CMake.
+#
+# George Gayno
+
 set -eux
 
 target=${target:-"NULL"}
+compiler=${compiler:-"intel"}
+export MOD_PATH
 
-if [[ $target == "linux.gnu" || $target == "linux.intel" ]]; then
+if [[ "$target" == "linux.*" || "$target" == "macosx.*" ]]; then
  unset -f module
+ set +x
+ source ./modulefiles/build.$target > /dev/null 
+ set -x
 else
- source ./sorc/machine-setup.sh > /dev/null 2>&1
+ set +x
+ source ./sorc/machine-setup.sh
+ module use ./modulefiles
+ module load build.$target.$compiler > /dev/null
+ module list
+ set -x
 fi
 
-export MOD_PATH
-source ./modulefiles/build.$target             > /dev/null 2>&1
-
-#
-# --- Build all programs.
-#
+CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=../ -DEMC_EXEC_DIR=ON"
 
 rm -fr ./build
-mkdir ./build
-cd ./build
+mkdir ./build && cd ./build
 
-if [[ $target == "wcoss_cray" ]]; then
-  cmake .. -DCMAKE_INSTALL_PREFIX=../ -DEMC_EXEC_DIR=ON
-else
-  cmake .. -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_C_COMPILER=icc -DCMAKE_INSTALL_PREFIX=../ -DEMC_EXEC_DIR=ON
-fi
+cmake .. ${CMAKE_FLAGS}
 
 make -j 8 VERBOSE=1
 make install

--- a/cmake/FindESMF.cmake
+++ b/cmake/FindESMF.cmake
@@ -1,0 +1,130 @@
+# - Try to find ESMF
+#
+# Requires setting ESMFMKFILE to the filepath of esmf.mk. If this is NOT set,
+# then ESMF_FOUND will always be FALSE. If ESMFMKFILE exists, then ESMF_FOUND=TRUE
+# and all ESMF makefile variables will be set in the global scope. Optionally,
+# set ESMF_MKGLOBALS to a string list to filter makefile variables. For example,
+# to globally scope only ESMF_LIBSDIR and ESMF_APPSDIR variables, use this CMake
+# command in CMakeLists.txt:
+#
+#   set(ESMF_MKGLOBALS "LIBSDIR" "APPSDIR")
+
+
+# Add the ESMFMKFILE path to the cache if defined as system env variable
+if (DEFINED ENV{ESMFMKFILE} AND NOT DEFINED ESMFMKFILE)
+  set(ESMFMKFILE $ENV{ESMFMKFILE} CACHE FILEPATH "Path to ESMF mk file")
+endif ()
+
+# Found the mk file and ESMF exists on the system
+if (EXISTS ${ESMFMKFILE})
+  set(ESMF_FOUND TRUE CACHE BOOL "ESMF mk file found" FORCE)
+  # Did not find the ESMF mk file
+else()
+  set(ESMF_FOUND FALSE CACHE BOOL "ESMF mk file NOT found" FORCE)
+  # Best to warn users that without the mk file there is no way to find ESMF
+  if (NOT DEFINED ESMFMKFILE)
+    message(FATAL_ERROR "ESMFMKFILE not defined. This is the path to esmf.mk file. \
+Without this filepath, ESMF_FOUND will always be FALSE.")
+  endif ()
+endif()
+
+# Only parse the mk file if it is found
+if (ESMF_FOUND)
+  # Read the mk file
+  file(STRINGS "${ESMFMKFILE}" esmfmkfile_contents)
+  # Parse each line in the mk file
+  foreach(str ${esmfmkfile_contents})
+    # Only consider uncommented lines
+    string(REGEX MATCH "^[^#]" def ${str})
+    # Line is not commented
+    if (def)
+      # Extract the variable name
+      string(REGEX MATCH "^[^=]+" esmf_varname ${str})
+      # Extract the variable's value
+      string(REGEX MATCH "=.+$" esmf_vardef ${str})
+      # Only for variables with a defined value
+      if (esmf_vardef)
+        # Get rid of the assignment string
+        string(SUBSTRING ${esmf_vardef} 1 -1 esmf_vardef)
+        # Remove whitespace
+        string(STRIP ${esmf_vardef} esmf_vardef)
+        # A string or single-valued list
+        if(NOT DEFINED ESMF_MKGLOBALS)
+          # Set in global scope
+          set(${esmf_varname} ${esmf_vardef})
+          # Don't display by default in GUI
+          mark_as_advanced(esmf_varname)
+        else() # Need to filter global promotion
+          foreach(m ${ESMF_MKGLOBALS})
+            string(FIND ${esmf_varname} ${m} match)
+            # Found the string
+            if(NOT ${match} EQUAL -1)
+              # Promote to global scope
+              set(${esmf_varname} ${esmf_vardef})
+              # Don't display by default in the GUI
+              mark_as_advanced (esmf_varname)
+              # No need to search for the current string filter
+              break()
+            endif()
+          endforeach()
+        endif()
+      endif()
+    endif()
+  endforeach()
+
+  # Construct ESMF_VERSION from ESMF_VERSION_STRING_GIT
+  if(ESMF_FOUND)
+    # ESMF_VERSION_MAJOR and ESMF_VERSION_MINOR are defined in ESMFMKFILE
+    set(ESMF_VERSION 0)
+    set(ESMF_VERSION_PATCH ${ESMF_VERSION_REVISION})
+    set(ESMF_BETA_RELEASE FALSE)
+    if(ESMF_VERSION_BETASNAPSHOT MATCHES "^('T')$")
+      set(ESMF_BETA_RELEASE TRUE)
+      string(REGEX REPLACE ".*beta_snapshot_*\([0-9]*\).*" "\\1" ESMF_BETA_SNAPSHOT "${ESMF_VERSION_STRING_GIT}")
+    endif()
+    set(ESMF_VERSION "${ESMF_VERSION_MAJOR}.${ESMF_VERSION_MINOR}.${ESMF_VERSION_PATCH}")
+  endif()
+
+  separate_arguments(ESMF_F90COMPILEPATHS NATIVE_COMMAND ${ESMF_F90COMPILEPATHS})
+  foreach (ITEM ${ESMF_F90COMPILEPATHS})
+     string(REGEX REPLACE "^-I" "" ITEM "${ITEM}")
+     list(APPEND tmp ${ITEM})
+  endforeach()
+  set(ESMF_F90COMPILEPATHS ${tmp})
+
+  add_library(esmf UNKNOWN IMPORTED)
+  # Look for static library, if not found try dynamic library
+  find_library(esmf_lib NAMES libesmf.a PATHS ${ESMF_LIBSDIR})
+  if(esmf_lib MATCHES "esmf_lib-NOTFOUND")
+    message(STATUS "Static ESMF library not found, searching for dynamic library instead")
+    find_library(esmf_lib NAMES esmf_fullylinked PATHS ${ESMF_LIBSDIR})
+    if(esmf_lib MATCHES "esmf_lib-NOTFOUND")
+      message(FATAL_ERROR "Neither the dynamic nor the static ESMF library was found")
+    endif()
+    set(ESMF_INTERFACE_LINK_LIBRARIES "")
+  else()
+    # When linking the static library, also need the ESMF linker flags; strip any leading/trailing whitespaces
+    string(STRIP "${ESMF_F90ESMFLINKRPATHS} ${ESMF_F90ESMFLINKPATHS} ${ESMF_F90LINKPATHS} ${ESMF_F90LINKLIBS} ${ESMF_F90LINKOPTS}" ESMF_INTERFACE_LINK_LIBRARIES)
+  endif()
+
+  message(STATUS "Found ESMF library: ${esmf_lib}")
+  if(ESMF_BETA_RELEASE)
+    message(STATUS "Detected ESMF Beta snapshot ${ESMF_BETA_SNAPSHOT}")
+  endif()
+
+  set_target_properties(esmf PROPERTIES
+    IMPORTED_LOCATION ${esmf_lib}
+    INTERFACE_INCLUDE_DIRECTORIES "${ESMF_F90COMPILEPATHS}"
+    INTERFACE_LINK_LIBRARIES "${ESMF_INTERFACE_LINK_LIBRARIES}")
+
+endif()
+
+## Finalize find_package
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args( ${CMAKE_FIND_PACKAGE_NAME}
+    REQUIRED_VARS ESMF_LIBSDIR
+                  ESMF_INTERFACE_LINK_LIBRARIES
+                  ESMF_F90COMPILEPATHS
+    VERSION_VAR ESMF_VERSION
+    HANDLE_COMPONENTS )

--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -1,0 +1,347 @@
+# (C) Copyright 2011- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+# Try to find NetCDF includes and library.
+# Supports static and shared libaries and allows each component to be found in sepearte prefixes.
+#
+# This module defines
+#
+#   - NetCDF_FOUND                - System has NetCDF
+#   - NetCDF_INCLUDE_DIRS         - the NetCDF include directories
+#   - NetCDF_VERSION              - the version of NetCDF
+#   - NetCDF_CONFIG_EXECUTABLE    - the netcdf-config executable if found
+#   - NetCDF_PARALLEL             - Boolean True if NetCDF4 has parallel IO support via hdf5 and/or pnetcdf
+#   - NetCDF_HAS_PNETCDF          - Boolean True if NetCDF4 has pnetcdf support
+#
+# Deprecated Defines
+#   - NetCDF_LIBRARIES            - [Deprecated] Use NetCDF::NetCDF_<LANG> targets instead.
+#
+#
+# Following components are available:
+#
+#   - C                           - C interface to NetCDF          (netcdf)
+#   - CXX                         - CXX4 interface to NetCDF       (netcdf_c++4)
+#   - Fortran                     - Fortran interface to NetCDF    (netcdff)
+#
+# For each component the following are defined:
+#
+#   - NetCDF_<comp>_FOUND         - whether the component is found
+#   - NetCDF_<comp>_LIBRARIES     - the libraries for the component
+#   - NetCDF_<comp>_LIBRARY_SHARED - Boolean is true if libraries for component are shared
+#   - NetCDF_<comp>_INCLUDE_DIRS  - the include directories for specified component
+#   - NetCDF::NetCDF_<comp>       - target of component to be used with target_link_libraries()
+#
+# The following paths will be searched in order if set in CMake (first priority) or environment (second priority)
+#
+#   - NetCDF_ROOT                 - root of NetCDF installation
+#   - NetCDF_PATH                 - root of NetCDF installation
+#
+# The search process begins with locating NetCDF Include headers.  If these are in a non-standard location,
+# set one of the following CMake or environment variables to point to the location:
+#
+#  - NetCDF_INCLUDE_DIR or NetCDF_${comp}_INCLUDE_DIR
+#  - NetCDF_INCLUDE_DIRS or NetCDF_${comp}_INCLUDE_DIR
+#
+# Notes:
+#
+#   - Use "NetCDF::NetCDF_<LANG>" targets only.  NetCDF_LIBRARIES exists for backwards compatibility and should not be used.
+#     - These targets have all the knowledge of include directories and library search directories, and a single
+#       call to target_link_libraries will provide all these transitive properties to your target.  Normally all that is
+#       needed to build and link against NetCDF is, e.g.:
+#           target_link_libraries(my_c_tgt PUBLIC NetCDF::NetCDF_C)
+#   - "NetCDF" is always the preferred naming for this package, its targets, variables, and environment variables
+#     - For compatibility, some variables are also set/checked using alternate names NetCDF4, NETCDF, or NETCDF4
+#     - Environments relying on these older environment variable names should move to using a "NetCDF_ROOT" environment variable
+#   - Preferred component capitalization follows the CMake LANGUAGES variables: i.e., C, Fortran, CXX
+#     - For compatibility, alternate capitalizations are supported but should not be used.
+#   - If no components are defined, all components will be searched
+#
+
+list( APPEND _possible_components C CXX Fortran )
+
+## Include names for each component
+set( NetCDF_C_INCLUDE_NAME          netcdf.h )
+set( NetCDF_CXX_INCLUDE_NAME        netcdf )
+set( NetCDF_Fortran_INCLUDE_NAME    netcdf.mod )
+
+## Library names for each component
+set( NetCDF_C_LIBRARY_NAME          netcdf )
+set( NetCDF_CXX_LIBRARY_NAME        netcdf_c++4 )
+set( NetCDF_Fortran_LIBRARY_NAME    netcdff )
+
+## Enumerate search components
+foreach( _comp ${_possible_components} )
+  string( TOUPPER "${_comp}" _COMP )
+  set( _arg_${_COMP} ${_comp} )
+  set( _name_${_COMP} ${_comp} )
+endforeach()
+
+set( _search_components C)
+foreach( _comp ${${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS} )
+  string( TOUPPER "${_comp}" _COMP )
+  set( _arg_${_COMP} ${_comp} )
+  list( APPEND _search_components ${_name_${_COMP}} )
+  if( NOT _name_${_COMP} )
+    message(SEND_ERROR "Find${CMAKE_FIND_PACKAGE_NAME}: COMPONENT ${_comp} is not a valid component. Valid components: ${_possible_components}" )
+  endif()
+endforeach()
+list( REMOVE_DUPLICATES _search_components )
+
+## Search hints for finding include directories and libraries
+foreach( _comp IN ITEMS "_" "_C_" "_Fortran_" "_CXX_" )
+  foreach( _name IN ITEMS NetCDF4 NetCDF NETCDF4 NETCDF )
+    foreach( _var IN ITEMS ROOT PATH )
+      list(APPEND _search_hints ${${_name}${_comp}${_var}} $ENV{${_name}${_comp}${_var}} )
+      list(APPEND _include_search_hints
+                ${${_name}${_comp}INCLUDE_DIR} $ENV{${_name}${_comp}INCLUDE_DIR}
+                ${${_name}${_comp}INCLUDE_DIRS} $ENV{${_name}${_comp}INCLUDE_DIRS} )
+    endforeach()
+  endforeach()
+endforeach()
+#Old-school HPC module env variable names
+foreach( _name IN ITEMS NetCDF4 NetCDF NETCDF4 NETCDF )
+  foreach( _comp IN ITEMS "_C" "_Fortran" "_CXX" )
+    list(APPEND _search_hints ${${_name}}         $ENV{${_name}})
+    list(APPEND _search_hints ${${_name}${_comp}} $ENV{${_name}${_comp}})
+  endforeach()
+endforeach()
+
+## Find headers for each component
+set(NetCDF_INCLUDE_DIRS)
+set(_new_search_components)
+foreach( _comp IN LISTS _search_components )
+  if(NOT ${PROJECT_NAME}_NetCDF_${_comp}_FOUND)
+      list(APPEND _new_search_components ${_comp})
+  endif()
+  find_file(NetCDF_${_comp}_INCLUDE_FILE
+    NAMES ${NetCDF_${_comp}_INCLUDE_NAME}
+    DOC "NetCDF ${_comp} include directory"
+    HINTS ${_include_search_hints} ${_search_hints}
+    PATH_SUFFIXES include include/netcdf
+  )
+  mark_as_advanced(NetCDF_${_comp}_INCLUDE_FILE)
+  message(DEBUG "NetCDF_${_comp}_INCLUDE_FILE: ${NetCDF_${_comp}_INCLUDE_FILE}")
+  if( NetCDF_${_comp}_INCLUDE_FILE )
+    get_filename_component(NetCDF_${_comp}_INCLUDE_FILE ${NetCDF_${_comp}_INCLUDE_FILE} ABSOLUTE)
+    get_filename_component(NetCDF_${_comp}_INCLUDE_DIR ${NetCDF_${_comp}_INCLUDE_FILE} DIRECTORY)
+    list(APPEND NetCDF_INCLUDE_DIRS ${NetCDF_${_comp}_INCLUDE_DIR})
+  endif()
+endforeach()
+if(NetCDF_INCLUDE_DIRS)
+    list(REMOVE_DUPLICATES NetCDF_INCLUDE_DIRS)
+endif()
+set(NetCDF_INCLUDE_DIRS "${NetCDF_INCLUDE_DIRS}" CACHE STRING "NetCDF Include directory paths" FORCE)
+
+## Find n*-config executables for search components
+foreach( _comp IN LISTS _search_components )
+  if( _comp MATCHES "^(C)$" )
+    set(_conf "c")
+  elseif( _comp MATCHES "^(Fortran)$" )
+    set(_conf "f")
+  elseif( _comp MATCHES "^(CXX)$" )
+    set(_conf "cxx4")
+  endif()
+  find_program( NetCDF_${_comp}_CONFIG_EXECUTABLE
+      NAMES n${_conf}-config
+    HINTS ${NetCDF_INCLUDE_DIRS} ${_include_search_hints} ${_search_hints}
+    PATH_SUFFIXES bin Bin ../bin ../../bin
+      DOC "NetCDF n${_conf}-config helper" )
+    message(DEBUG "NetCDF_${_comp}_CONFIG_EXECUTABLE: ${NetCDF_${_comp}_CONFIG_EXECUTABLE}")
+endforeach()
+
+set(_C_libs_flag --libs)
+set(_Fortran_libs_flag --flibs)
+set(_CXX_libs_flag --libs)
+set(_C_includes_flag --includedir)
+set(_Fortran_includes_flag --includedir)
+set(_CXX_includes_flag --includedir)
+function(netcdf_config exec flag output_var)
+  set(${output_var} False PARENT_SCOPE)
+  if( exec )
+    execute_process( COMMAND ${exec} ${flag} RESULT_VARIABLE _ret OUTPUT_VARIABLE _val)
+    if( _ret EQUAL 0 )
+      string( STRIP ${_val} _val )
+      set( ${output_var} ${_val} PARENT_SCOPE )
+    endif()
+  endif()
+endfunction()
+
+## Detect additional package properties
+netcdf_config(${NetCDF_C_CONFIG_EXECUTABLE} --has-parallel4 _val)
+if( NOT _val MATCHES "^(yes|no)$" )
+  netcdf_config(${NetCDF_C_CONFIG_EXECUTABLE} --has-parallel _val)
+endif()
+if( _val MATCHES "^(yes)$" )
+  set(NetCDF_PARALLEL TRUE CACHE STRING "NetCDF has parallel IO capability via pnetcdf or hdf5." FORCE)
+else()
+  set(NetCDF_PARALLEL FALSE CACHE STRING "NetCDF has no parallel IO capability." FORCE)
+endif()
+
+if(NetCDF_PARALLEL)
+  find_package(MPI REQUIRED)
+endif()
+
+## Find libraries for each component
+set( NetCDF_LIBRARIES )
+foreach( _comp IN LISTS _search_components )
+  string( TOUPPER "${_comp}" _COMP )
+
+  find_library( NetCDF_${_comp}_LIBRARY
+    NAMES ${NetCDF_${_comp}_LIBRARY_NAME}
+    DOC "NetCDF ${_comp} library"
+    HINTS ${NetCDF_${_comp}_INCLUDE_DIRS} ${_search_hints}
+    PATH_SUFFIXES lib64 lib ../lib64 ../lib ../../lib64 ../../lib )
+  mark_as_advanced( NetCDF_${_comp}_LIBRARY )
+  get_filename_component(NetCDF_${_comp}_LIBRARY ${NetCDF_${_comp}_LIBRARY} ABSOLUTE)
+  set(NetCDF_${_comp}_LIBRARY ${NetCDF_${_comp}_LIBRARY} CACHE STRING "NetCDF ${_comp} library" FORCE)
+  message(DEBUG "NetCDF_${_comp}_LIBRARY: ${NetCDF_${_comp}_LIBRARY}")
+
+  if( NetCDF_${_comp}_LIBRARY )
+    if( NetCDF_${_comp}_LIBRARY MATCHES ".a$" )
+      set( NetCDF_${_comp}_LIBRARY_SHARED FALSE )
+      set( _library_type STATIC)
+    else()
+      list( APPEND NetCDF_LIBRARIES ${NetCDF_${_comp}_LIBRARY} )
+      set( NetCDF_${_comp}_LIBRARY_SHARED TRUE )
+      set( _library_type SHARED)
+    endif()
+  endif()
+
+  #Use nc-config to set per-component LIBRARIES variable if possible
+  netcdf_config( ${NetCDF_${_comp}_CONFIG_EXECUTABLE} ${_${_comp}_libs_flag} _val )
+  if( _val )
+    set( NetCDF_${_comp}_LIBRARIES ${_val} )
+    if(NOT NetCDF_${_comp}_LIBRARY_SHARED AND NOT NetCDF_${_comp}_FOUND) #Static targets should use nc_config to get a proper link line with all necessary static targets.
+      list( APPEND NetCDF_LIBRARIES ${NetCDF_${_comp}_LIBRARIES} )
+    endif()
+  else()
+    set( NetCDF_${_comp}_LIBRARIES ${NetCDF_${_comp}_LIBRARY} )
+    if(NOT NetCDF_${_comp}_LIBRARY_SHARED)
+      message(SEND_ERROR "Unable to properly find NetCDF.  Found static libraries at: ${NetCDF_${_comp}_LIBRARY} but could not run nc-config: ${NetCDF_CONFIG_EXECUTABLE}")
+    endif()
+  endif()
+
+  #Use nc-config to set per-component INCLUDE_DIRS variable if possible
+  netcdf_config( ${NetCDF_${_comp}_CONFIG_EXECUTABLE} ${_${_comp}_includes_flag} _val )
+  if( _val )
+    string( REPLACE " " ";" _val ${_val} )
+    set( NetCDF_${_comp}_INCLUDE_DIRS ${_val} )
+  else()
+    set( NetCDF_${_comp}_INCLUDE_DIRS ${NetCDF_${_comp}_INCLUDE_DIR} )
+  endif()
+
+  if( NetCDF_${_comp}_LIBRARIES AND NetCDF_${_comp}_INCLUDE_DIRS )
+    set( ${CMAKE_FIND_PACKAGE_NAME}_${_arg_${_COMP}}_FOUND TRUE )
+    if (NOT TARGET NetCDF::NetCDF_${_comp})
+      add_library(NetCDF::NetCDF_${_comp} ${_library_type} IMPORTED)
+      set_target_properties(NetCDF::NetCDF_${_comp} PROPERTIES
+        IMPORTED_LOCATION ${NetCDF_${_comp}_LIBRARY}
+        INTERFACE_INCLUDE_DIRECTORIES "${NetCDF_${_comp}_INCLUDE_DIRS}"
+        INTERFACE_LINK_LIBRARIES ${NetCDF_${_comp}_LIBRARIES} )
+      if( NOT _comp MATCHES "^(C)$" )
+        target_link_libraries(NetCDF::NetCDF_${_comp} INTERFACE NetCDF::NetCDF_C)
+      endif()
+      if(MPI_${_comp}_FOUND)
+        target_link_libraries(NetCDF::NetCDF_${_comp} INTERFACE MPI::MPI_${_comp})
+      endif()
+    endif()
+  endif()
+endforeach()
+if(NetCDF_LIBRARIES AND NetCDF_${_comp}_LIBRARY_SHARED)
+    list(REMOVE_DUPLICATES NetCDF_LIBRARIES)
+endif()
+set(NetCDF_LIBRARIES "${NetCDF_LIBRARIES}" CACHE STRING "NetCDF library targets" FORCE)
+
+## Find version via netcdf-config if possible
+if (NetCDF_INCLUDE_DIRS)
+  if( NetCDF_C_CONFIG_EXECUTABLE )
+    netcdf_config( ${NetCDF_C_CONFIG_EXECUTABLE} --version _vers )
+    if( _vers )
+      string(REGEX REPLACE ".* ((([0-9]+)\\.)+([0-9]+)).*" "\\1" NetCDF_VERSION "${_vers}" )
+    endif()
+  else()
+    foreach( _dir IN LISTS NetCDF_INCLUDE_DIRS)
+      if( EXISTS "${_dir}/netcdf_meta.h" )
+        file(STRINGS "${_dir}/netcdf_meta.h" _netcdf_version_lines
+        REGEX "#define[ \t]+NC_VERSION_(MAJOR|MINOR|PATCH|NOTE)")
+        string(REGEX REPLACE ".*NC_VERSION_MAJOR *\([0-9]*\).*" "\\1" _netcdf_version_major "${_netcdf_version_lines}")
+        string(REGEX REPLACE ".*NC_VERSION_MINOR *\([0-9]*\).*" "\\1" _netcdf_version_minor "${_netcdf_version_lines}")
+        string(REGEX REPLACE ".*NC_VERSION_PATCH *\([0-9]*\).*" "\\1" _netcdf_version_patch "${_netcdf_version_lines}")
+        string(REGEX REPLACE ".*NC_VERSION_NOTE *\"\([^\"]*\)\".*" "\\1" _netcdf_version_note "${_netcdf_version_lines}")
+        set(NetCDF_VERSION "${_netcdf_version_major}.${_netcdf_version_minor}.${_netcdf_version_patch}${_netcdf_version_note}")
+        unset(_netcdf_version_major)
+        unset(_netcdf_version_minor)
+        unset(_netcdf_version_patch)
+        unset(_netcdf_version_note)
+        unset(_netcdf_version_lines)
+      endif()
+    endforeach()
+  endif()
+endif ()
+
+## Finalize find_package
+include(FindPackageHandleStandardArgs)
+
+if(NOT NetCDF_FOUND OR _new_search_components)
+    find_package_handle_standard_args( ${CMAKE_FIND_PACKAGE_NAME}
+        REQUIRED_VARS NetCDF_INCLUDE_DIRS NetCDF_LIBRARIES
+        VERSION_VAR NetCDF_VERSION
+        HANDLE_COMPONENTS )
+endif()
+
+foreach( _comp IN LISTS _search_components )
+    if( NetCDF_${_comp}_FOUND )
+        #Record found components to avoid duplication in NetCDF_LIBRARIES for static libraries
+        set(NetCDF_${_comp}_FOUND ${NetCDF_${_comp}_FOUND} CACHE BOOL "NetCDF ${_comp} Found" FORCE)
+        #Set a per-package, per-component found variable to communicate between multiple calls to find_package()
+        set(${PROJECT_NAME}_NetCDF_${_comp}_FOUND True)
+    endif()
+endforeach()
+
+if( ${CMAKE_FIND_PACKAGE_NAME}_FOUND AND NOT ${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY AND _new_search_components)
+  message( STATUS "Find${CMAKE_FIND_PACKAGE_NAME} defines targets:" )
+  message( STATUS "  - NetCDF_VERSION [${NetCDF_VERSION}]")
+  message( STATUS "  - NetCDF_PARALLEL [${NetCDF_PARALLEL}]")
+  foreach( _comp IN LISTS _new_search_components )
+    string( TOUPPER "${_comp}" _COMP )
+    message( STATUS "  - NetCDF_${_comp}_CONFIG_EXECUTABLE [${NetCDF_${_comp}_CONFIG_EXECUTABLE}]")
+    if( ${CMAKE_FIND_PACKAGE_NAME}_${_arg_${_COMP}}_FOUND )
+      get_filename_component(_root ${NetCDF_${_comp}_INCLUDE_DIR}/.. ABSOLUTE)
+      if( NetCDF_${_comp}_LIBRARY_SHARED )
+        message( STATUS "  - NetCDF::NetCDF_${_comp} [SHARED] [Root: ${_root}] Lib: ${NetCDF_${_comp}_LIBRARY} ")
+      else()
+        message( STATUS "  - NetCDF::NetCDF_${_comp} [STATIC] [Root: ${_root}] Lib: ${NetCDF_${_comp}_LIBRARY} ")
+      endif()
+    endif()
+  endforeach()
+endif()
+
+foreach( _prefix NetCDF NetCDF4 NETCDF NETCDF4 ${CMAKE_FIND_PACKAGE_NAME} )
+  set( ${_prefix}_INCLUDE_DIRS ${NetCDF_INCLUDE_DIRS} )
+  set( ${_prefix}_LIBRARIES    ${NetCDF_LIBRARIES})
+  set( ${_prefix}_VERSION      ${NetCDF_VERSION} )
+  set( ${_prefix}_FOUND        ${${CMAKE_FIND_PACKAGE_NAME}_FOUND} )
+  set( ${_prefix}_CONFIG_EXECUTABLE ${NetCDF_CONFIG_EXECUTABLE} )
+  set( ${_prefix}_PARALLEL ${NetCDF_PARALLEL} )
+
+  foreach( _comp ${_search_components} )
+    string( TOUPPER "${_comp}" _COMP )
+    set( _arg_comp ${_arg_${_COMP}} )
+    set( ${_prefix}_${_comp}_FOUND     ${${CMAKE_FIND_PACKAGE_NAME}_${_arg_comp}_FOUND} )
+    set( ${_prefix}_${_COMP}_FOUND     ${${CMAKE_FIND_PACKAGE_NAME}_${_arg_comp}_FOUND} )
+    set( ${_prefix}_${_arg_comp}_FOUND ${${CMAKE_FIND_PACKAGE_NAME}_${_arg_comp}_FOUND} )
+
+    set( ${_prefix}_${_comp}_LIBRARIES     ${NetCDF_${_comp}_LIBRARIES} )
+    set( ${_prefix}_${_COMP}_LIBRARIES     ${NetCDF_${_comp}_LIBRARIES} )
+    set( ${_prefix}_${_arg_comp}_LIBRARIES ${NetCDF_${_comp}_LIBRARIES} )
+
+    set( ${_prefix}_${_comp}_INCLUDE_DIRS     ${NetCDF_${_comp}_INCLUDE_DIRS} )
+    set( ${_prefix}_${_COMP}_INCLUDE_DIRS     ${NetCDF_${_comp}_INCLUDE_DIRS} )
+    set( ${_prefix}_${_arg_comp}_INCLUDE_DIRS ${NetCDF_${_comp}_INCLUDE_DIRS} )
+  endforeach()
+endforeach()

--- a/cmake/Findwgrib2.cmake
+++ b/cmake/Findwgrib2.cmake
@@ -1,0 +1,23 @@
+# This module produces the target wgrib2::wgrib2
+
+find_path(WGRIB2_INCLUDES wgrib2api.mod)
+
+find_library(WGRIB2_LIBRARIES libwgrib2.a)
+
+find_program(WGRIB2_EXE wgrib2)
+execute_process(COMMAND ${WGRIB2_EXE} --version OUTPUT_VARIABLE version_str)
+string(SUBSTRING ${version_str} 3 5 version)
+
+mark_as_advanced(WGRIB2_INCLUDES WGRIB2_LIBRARIES)
+
+add_library(wgrib2::wgrib2 UNKNOWN IMPORTED)
+
+set_target_properties(wgrib2::wgrib2 PROPERTIES
+  IMPORTED_LOCATION "${WGRIB2_LIBRARIES}"
+  INTERFACE_INCLUDE_DIRECTORIES "${WGRIB2_INCLUDES}"
+  INTERFACE_LINK_LIBRARIES "${WGRIB2_LIBRARIES}")
+
+find_package_handle_standard_args(wgrib2
+  REQUIRED_VARS WGRIB2_LIBRARIES WGRIB2_INCLUDES WGRIB2_EXE
+  VERSION_VAR version
+)

--- a/cmake/LibMPI.cmake
+++ b/cmake/LibMPI.cmake
@@ -1,0 +1,221 @@
+# This file contains CMake code related to MPI. (Taken from the
+# ParallelIO project.)
+
+# Jim Edwards
+include (CMakeParseArguments)
+
+# Find Valgrind to perform memory leak check
+if (PIO_VALGRIND_CHECK)
+  find_program (VALGRIND_COMMAND NAMES valgrind)
+  if (VALGRIND_COMMAND)
+    set (VALGRIND_COMMAND_OPTIONS --leak-check=full --show-reachable=yes)
+  else ()
+    message (WARNING "Valgrind not found: memory leak check could not be performed")
+    set (VALGRIND_COMMAND "")
+  endif ()
+endif ()
+
+#
+# - Functions for parallel testing with CTest
+#
+
+#==============================================================================
+# - Get the machine platform-specific
+#
+# Syntax:  platform_name (RETURN_VARIABLE)
+#
+function (platform_name RETURN_VARIABLE)
+
+  # Determine platform name from site name...
+  site_name (SITENAME)
+  
+  # hera
+  if (SITENAME MATCHES "^hfe01" OR
+      SITENAME MATCHES "^hfe02" OR
+      SITENAME MATCHES "^hfe03" OR
+      SITENAME MATCHES "^hfe04" OR
+      SITENAME MATCHES "^hfe05" OR
+      SITENAME MATCHES "^hfe06" OR
+      SITENAME MATCHES "^hfe07" OR
+      SITENAME MATCHES "^hfe08" OR
+      SITENAME MATCHES "^hfe09" OR
+      SITENAME MATCHES "^hfe10" OR
+      SITENAME MATCHES "^hfe11" OR
+      SITENAME MATCHES "^hfe12")
+
+    set (${RETURN_VARIABLE} "hera" PARENT_SCOPE)
+
+  # wcoss_cray (Luna)
+  elseif (SITENAME MATCHES "^llogin1" OR
+      SITENAME MATCHES "^llogin2" OR
+      SITENAME MATCHES "^llogin3")
+
+    set (${RETURN_VARIABLE} "wcoss_cray" PARENT_SCOPE)
+    
+  # wcoss_cray (Surge)
+  elseif (SITENAME MATCHES "^slogin1" OR
+      SITENAME MATCHES "^slogin2" OR
+      SITENAME MATCHES "^slogin3")
+
+    set (${RETURN_VARIABLE} "wcoss_cray" PARENT_SCOPE)
+    
+  # wcoss_dell_p3 (Venus)
+  elseif (SITENAME MATCHES "^v71a1.ncep.noaa.gov" OR
+      SITENAME MATCHES "^v71a2.ncep.noaa.gov" OR
+      SITENAME MATCHES "^v71a3.ncep.noaa.gov" OR
+      SITENAME MATCHES "^v72a1.ncep.noaa.gov" OR
+      SITENAME MATCHES "^v72a2.ncep.noaa.gov" OR
+      SITENAME MATCHES "^v72a3.ncep.noaa.gov")
+
+    set (${RETURN_VARIABLE} "wcoss_dell_p3" PARENT_SCOPE)
+  
+  # wcoss_dell_p3 (Mars)
+  elseif (SITENAME MATCHES "^m71a1.ncep.noaa.gov" OR
+      SITENAME MATCHES "^m71a2.ncep.noaa.gov" OR
+      SITENAME MATCHES "^m71a3.ncep.noaa.gov" OR
+      SITENAME MATCHES "^m72a1.ncep.noaa.gov" OR
+      SITENAME MATCHES "^m72a2.ncep.noaa.gov" OR
+      SITENAME MATCHES "^m72a3.ncep.noaa.gov")
+
+    set (${RETURN_VARIABLE} "wcoss_dell_p3" PARENT_SCOPE)
+
+  # wcoss2
+  elseif (SITENAME MATCHES "^along01" OR
+      SITENAME MATCHES "^alogin02")
+
+    set (${RETURN_VARIABLE} "wcoss2" PARENT_SCOPE)
+
+  # gaea
+  elseif (SITENAME MATCHES "^gaea9" OR
+      SITENAME MATCHES "^gaea10" OR
+      SITENAME MATCHES "^gaea11" OR
+      SITENAME MATCHES "^gaea12" OR
+      SITENAME MATCHES "^gaea13" OR
+      SITENAME MATCHES "^gaea14" OR
+      SITENAME MATCHES "^gaea15" OR
+      SITENAME MATCHES "^gaea16" OR
+      SITENAME MATCHES "^gaea9.ncrc.gov" OR
+      SITENAME MATCHES "^gaea10.ncrc.gov" OR
+      SITENAME MATCHES "^gaea11.ncrc.gov" OR
+      SITENAME MATCHES "^gaea12.ncrc.gov" OR
+      SITENAME MATCHES "^gaea13.ncrc.gov" OR
+      SITENAME MATCHES "^gaea14.ncrc.gov" OR
+      SITENAME MATCHES "^gaea15.ncrc.gov" OR
+      SITENAME MATCHES "^gaea16.ncrc.gov")
+
+    set (${RETURN_VARIABLE} "gaea" PARENT_SCOPE)
+    
+  # jet 
+  elseif (SITENAME MATCHES "^fe1" OR
+      SITENAME MATCHES "^fe2" OR
+      SITENAME MATCHES "^fe3" OR
+      SITENAME MATCHES "^fe4" OR
+      SITENAME MATCHES "^fe5" OR
+      SITENAME MATCHES "^fe6" OR
+      SITENAME MATCHES "^fe7" OR
+      SITENAME MATCHES "^fe8" OR
+      SITENAME MATCHES "^tfe1" OR
+      SITENAME MATCHES "^tfe2")
+
+    set (${RETURN_VARIABLE} "jet" PARENT_SCOPE)
+
+  elseif (SITENAME MATCHES "^Orion-login-1.HPC.MsState.Edu" OR
+      SITENAME MATCHES "^Orion-login-2.HPC.MsState.Edu" OR
+      SITENAME MATCHES "^Orion-login-3.HPC.MsState.Edu" OR
+      SITENAME MATCHES "^Orion-login-4.HPC.MsState.Edu")
+
+    set (${RETURN_VARIABLE} "orion" PARENT_SCOPE)
+
+  elseif (SITENAME MATCHES "^cheyenne1.cheyenne.ucar.edu" OR
+      SITENAME MATCHES "^cheyenne1.cheyenne.ucar.edu" OR
+      SITENAME MATCHES "^cheyenne2.cheyenne.ucar.edu" OR
+      SITENAME MATCHES "^cheyenne3.cheyenne.ucar.edu" OR
+      SITENAME MATCHES "^cheyenne4.cheyenne.ucar.edu" OR
+      SITENAME MATCHES "^cheyenne5.cheyenne.ucar.edu" OR
+      SITENAME MATCHES "^cheyenne6.cheyenne.ucar.edu" OR
+      SITENAME MATCHES "^cheyenne1.ib0.cheyenne.ucar.edu" OR
+      SITENAME MATCHES "^cheyenne2.ib0.cheyenne.ucar.edu" OR
+      SITENAME MATCHES "^cheyenne3.ib0.cheyenne.ucar.edu" OR
+      SITENAME MATCHES "^cheyenne4.ib0.cheyenne.ucar.edu" OR
+      SITENAME MATCHES "^cheyenne5.ib0.cheyenne.ucar.edu" OR
+      SITENAME MATCHES "^cheyenne6.ib0.cheyenne.ucar.edu" OR
+      SITENAME MATCHES "^chadmin1.ib0.cheyenne.ucar.edu" OR
+      SITENAME MATCHES "^chadmin2.ib0.cheyenne.ucar.edu" OR
+      SITENAME MATCHES "^chadmin3.ib0.cheyenne.ucar.edu" OR
+      SITENAME MATCHES "^chadmin4.ib0.cheyenne.ucar.edu" OR
+      SITENAME MATCHES "^chadmin5.ib0.cheyenne.ucar.edu" OR
+      SITENAME MATCHES "^chadmin6.ib0.cheyenne.ucar.edu")
+
+    set (${RETURN_VARIABLE} "cheyenne" PARENT_SCOPE)
+  elseif (SITENAME MATCHES "^login1.stampede2.tacc.utexas.edu" OR
+      SITENAME MATCHES "^login2.stampede2.tacc.utexas.edu" OR
+      SITENAME MATCHES "^login3.stampede2.tacc.utexas.edu" OR
+      SITENAME MATCHES "^login4.stampede2.tacc.utexas.edu")
+    
+
+    set (${RETURN_VARIABLE} "stampede" PARENT_SCOPE)
+
+  elseif (SITENAME MATCHES "^s4-submit.ssec.wisc.edu")
+
+    set (${RETURN_VARIABLE} "s4" PARENT_SCOPE)
+
+  else ()
+
+    set (${RETURN_VARIABLE} "unknown" PARENT_SCOPE)
+
+  endif ()
+endfunction ()
+
+#==============================================================================
+# - Add a new parallel test
+#
+# Syntax:  add_mpi_test (<TESTNAME>
+#                        EXECUTABLE <command>
+#                        ARGUMENTS <arg1> <arg2> ...
+#                        NUMPROCS <num_procs>
+#                        TIMEOUT <timeout>)
+function (add_mpi_test TESTNAME)
+
+  # Parse the input arguments
+  set (options)
+  set (oneValueArgs NUMPROCS TIMEOUT EXECUTABLE)
+  set (multiValueArgs ARGUMENTS)
+  cmake_parse_arguments (${TESTNAME} "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  # Store parsed arguments for convenience
+  set (exec_file ${${TESTNAME}_EXECUTABLE})
+  set (exec_args ${${TESTNAME}_ARGUMENTS})
+  set (num_procs ${${TESTNAME}_NUMPROCS})
+  set (timeout ${${TESTNAME}_TIMEOUT})
+
+  # Get the platform name
+  platform_name (PLATFORM)
+
+  get_property(WITH_MPIEXEC GLOBAL PROPERTY WITH_MPIEXEC)
+  if (WITH_MPIEXEC)
+    set(MPIEXEC "${WITH_MPIEXEC}")
+  endif ()
+
+  # Default ("unknown" platform) execution
+  if (PLATFORM STREQUAL "unknown")
+
+    # Run tests directly from the command line
+    set(EXE_CMD ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${num_procs}
+      ${MPIEXEC_PREFLAGS} ${VALGRIND_COMMAND} ${VALGRIND_COMMAND_OPTIONS} ${exec_file}
+      ${MPIEXEC_POSTFLAGS} ${exec_args})
+
+  else ()
+
+    # Run tests from the platform-specific executable
+    set (EXE_CMD ${CMAKE_SOURCE_DIR}/cmake/mpiexec.${PLATFORM}
+      ${num_procs} ${VALGRIND_COMMAND} ${VALGRIND_COMMAND_OPTIONS} ${exec_file} ${exec_args})
+
+  endif ()
+
+  # Add the test to CTest
+  add_test(NAME ${TESTNAME} COMMAND ${EXE_CMD})
+
+  # Adjust the test timeout
+  set_tests_properties(${TESTNAME} PROPERTIES TIMEOUT ${timeout})
+
+endfunction()

--- a/modulefiles/build.wcoss2_cray.intel
+++ b/modulefiles/build.wcoss2_cray.intel
@@ -1,0 +1,33 @@
+#%Module#####################################################
+## Build and run module for WCOSS2-Cray
+#############################################################
+
+module load envvar/1.0
+module load cmake/3.20.2
+
+module load PrgEnv-intel/8.1.0
+module load craype/2.7.8
+module load intel/19.1.3.304
+module load cray-mpich/8.1.7
+
+module load libjpeg/9c
+module load jasper/2.0.25
+module load zlib/1.2.11
+module load libpng/1.6.37
+
+module load hdf5/1.10.6
+module load netcdf/4.7.4
+module load esmf/8_1_0_beta_snapshot_27
+
+module load bacio/2.4.1
+module load sfcio/1.4.1
+module load w3nco/2.4.1
+module load nemsio/2.5.2
+module load sigio/2.3.2
+module load sp/2.3.3
+module load ip/3.3.3
+module load g2/3.4.1
+module load wgrib2/2.0.8
+
+# for mpiexec command
+module load cray-pals/1.0.12

--- a/modulefiles/build.wcoss2_cray.intel
+++ b/modulefiles/build.wcoss2_cray.intel
@@ -17,7 +17,7 @@ module load libpng/1.6.37
 
 module load hdf5/1.10.6
 module load netcdf/4.7.4
-module load esmf/8_1_0_beta_snapshot_27
+module load esmf/8.1.1
 
 module load bacio/2.4.1
 module load sfcio/1.4.1

--- a/reg_tests/chgres_cube/driver.wcoss2.sh
+++ b/reg_tests/chgres_cube/driver.wcoss2.sh
@@ -45,7 +45,7 @@ QUEUE="${QUEUE:-dev}"
 
 export HOMEufs=$PWD/../..
 
-export HOMEreg=/lfs/h2/emc/eib/noscrub/George.Gayno/ufs_utils.git/reg_tests/chgres_cube
+export HOMEreg=/lfs/h2/emc/global/noscrub/George.Gayno/ufs_utils.git/reg_tests/chgres_cube
 
 LOG_FILE=consistency.log
 SUM_FILE=summary.log
@@ -53,7 +53,8 @@ rm -f $LOG_FILE* $SUM_FILE
 
 export OMP_STACKSIZE=1024M
 
-export NCCMP=${NCCMP:-nccmp}
+export NCCMP=/lfs/h2/emc/global/noscrub/George.Gayno/util/nccmp/nccmp-1.8.5.0/src/nccmp
+#export NCCMP=${NCCMP:-nccmp}
 rm -fr $OUTDIR
 
 this_dir=$PWD

--- a/reg_tests/chgres_cube/driver.wcoss2.sh
+++ b/reg_tests/chgres_cube/driver.wcoss2.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+#-----------------------------------------------------------------------------
+#
+# Run the chgres_cube consistency tests on WCOSS2.
+#
+# Set WORK_DIR to a general working location outside the UFS_UTILS directory.
+# The exact working directory (OUTDIR) will be WORK_DIR/reg_tests/chgres-cube. 
+#
+# Set the PROJECT_CODE and QUEUE as appropriate.
+#
+# Invoke the script with no arguments.  To check the queue, type:
+# "qstat -u USERNAME".
+#
+# The run output will be stored in OUTDIR.  Log output will be placed
+# in LOG_FILE??.  Once the suite has completed, a summary is placed
+# in SUM_FILE.
+#
+# A test fails when its output does not match the baseline files as
+# determined by the "nccmp" utility.  The baseline files are stored in
+# HOMEreg.
+#
+#-----------------------------------------------------------------------------
+
+set -x
+
+compiler=${compiler:-"intel"}
+
+source ../../sorc/machine-setup.sh > /dev/null 2>&1
+module use ../../modulefiles
+module load build.$target.$compiler
+module list
+
+export OUTDIR="${WORK_DIR:-/lfs/h2/emc/stmp/$LOGNAME}"
+export OUTDIR="${OUTDIR}/reg-tests/chgres-cube"
+
+PROJECT_CODE="${PROJECT_CODE:-GFS-DEV}"
+QUEUE="${QUEUE:-dev}"
+
+#-----------------------------------------------------------------------------
+# Should not have to change anything below here.  HOMEufs is the root
+# directory of your UFS_UTILS clone.  HOMEreg contains the input data
+# and baseline data for each test.
+#-----------------------------------------------------------------------------
+
+export HOMEufs=$PWD/../..
+
+export HOMEreg=/lfs/h2/emc/eib/noscrub/George.Gayno/ufs_utils.git/reg_tests/chgres_cube
+
+LOG_FILE=consistency.log
+SUM_FILE=summary.log
+rm -f $LOG_FILE* $SUM_FILE
+
+export OMP_STACKSIZE=1024M
+
+export NCCMP=${NCCMP:-nccmp}
+rm -fr $OUTDIR
+
+this_dir=$PWD
+
+#-----------------------------------------------------------------------------
+# Initialize C96 using FV3 warm restart files.
+#-----------------------------------------------------------------------------
+
+LOG_FILE=consistency.log01
+export APRUN="mpiexec -n 6 -ppn 6 --cpu-bind core"
+TEST1=$(qsub -V -o $LOG_FILE -e $LOG_FILE -q $QUEUE -A $PROJECT_CODE -l walltime=00:05:00 \
+        -N c96.fv3.restart -l select=1:ncpus=6:ompthreads=1:mem=10GB $PWD/c96.fv3.restart.sh)
+
+#-----------------------------------------------------------------------------
+# Initialize C192 using FV3 tiled history files.
+#-----------------------------------------------------------------------------
+
+LOG_FILE=consistency.log02
+export APRUN="mpiexec -n 6 -ppn 6 --cpu-bind core"
+TEST2=$(qsub -V -o $LOG_FILE -e $LOG_FILE -q $QUEUE -A $PROJECT_CODE -l walltime=00:05:00 \
+        -N c192.fv3.history -l select=1:ncpus=6:ompthreads=1:mem=10GB $PWD/c192.fv3.history.sh)
+
+#-----------------------------------------------------------------------------
+# Initialize C96 using FV3 gaussian nemsio files.
+#-----------------------------------------------------------------------------
+
+LOG_FILE=consistency.log03
+export APRUN="mpiexec -n 6 -ppn 6 --cpu-bind core"
+TEST3=$(qsub -V -o $LOG_FILE -e $LOG_FILE -q $QUEUE -A $PROJECT_CODE -l walltime=00:05:00 \
+        -N c96.fv3.nemsio -l select=1:ncpus=6:ompthreads=1:mem=45GB $PWD/c96.fv3.nemsio.sh)
+
+#-----------------------------------------------------------------------------
+# Initialize C96 using spectral GFS sigio/sfcio files.
+#-----------------------------------------------------------------------------
+
+LOG_FILE=consistency.log04
+export OMP_PLACES=cores
+export APRUN="mpiexec -n 6 -ppn 6 --cpu-bind core --depth 4"
+TEST4=$(qsub -V -o $LOG_FILE -e $LOG_FILE -q $QUEUE -A $PROJECT_CODE -l walltime=00:10:00 \
+        -N c96.gfs.sigio -l select=1:ncpus=24:ompthreads=4:mem=45GB $PWD/c96.gfs.sigio.sh)
+
+#-----------------------------------------------------------------------------
+# Initialize C96 using spectral GFS gaussian nemsio files.
+#-----------------------------------------------------------------------------
+
+LOG_FILE=consistency.log05
+export APRUN="mpiexec -n 6 -ppn 6 --cpu-bind core"
+TEST5=$(qsub -V -o $LOG_FILE -e $LOG_FILE -q $QUEUE -A $PROJECT_CODE -l walltime=00:05:00 \
+        -N c96.gfs.nemsio -l select=1:ncpus=6:ompthreads=1:mem=35GB $PWD/c96.gfs.nemsio.sh)
+
+#-----------------------------------------------------------------------------
+# Initialize regional C96 using FV3 gaussian nemsio files.
+#-----------------------------------------------------------------------------
+
+LOG_FILE=consistency.log06
+export APRUN="mpiexec -n 6 -ppn 6 --cpu-bind core"
+TEST6=$(qsub -V -o $LOG_FILE -e $LOG_FILE -q $QUEUE -A $PROJECT_CODE -l walltime=00:05:00 \
+        -N c96.regional -l select=1:ncpus=6:ompthreads=1:mem=35GB $PWD/c96.regional.sh)
+
+#-----------------------------------------------------------------------------
+# Initialize C96 using FV3 gaussian netcdf files.
+#-----------------------------------------------------------------------------
+
+LOG_FILE=consistency.log07
+export APRUN="mpiexec -n 12 -ppn 12 --cpu-bind core"
+TEST7=$(qsub -V -o $LOG_FILE -e $LOG_FILE -q $QUEUE -A $PROJECT_CODE -l walltime=00:05:00 \
+        -N c96.fv3.netcdf -l select=1:ncpus=12:ompthreads=1:mem=80GB $PWD/c96.fv3.netcdf.sh)
+
+#-----------------------------------------------------------------------------
+# Initialize global C192 using GFS GRIB2 files.
+#-----------------------------------------------------------------------------
+
+LOG_FILE=consistency.log08
+export APRUN="mpiexec -n 6 -ppn 6 --cpu-bind core"
+TEST8=$(qsub -V -o $LOG_FILE -e $LOG_FILE -q $QUEUE -A $PROJECT_CODE -l walltime=00:05:00 \
+        -N c192.gfs.grib2 -l select=1:ncpus=6:ompthreads=1:mem=15GB $PWD/c192.gfs.grib2.sh)
+
+#-----------------------------------------------------------------------------
+# Create summary log.
+#-----------------------------------------------------------------------------
+
+LOG_FILE=consistency.log
+qsub -V -o ${LOG_FILE} -e ${LOG_FILE} -q $QUEUE -A $PROJECT_CODE -l walltime=00:01:00 \
+        -N chgres_summary -l select=1:ncpus=1:mem=100MB \
+        -W depend=afterok:$TEST1:$TEST2:$TEST3:$TEST4:$TEST5:$TEST6:$TEST7:$TEST8 << EOF
+#!/bin/bash
+cd ${this_dir}
+grep -a '<<<' ${LOG_FILE}??  > $SUM_FILE
+EOF
+
+exit 0

--- a/sorc/chgres_cube.fd/CMakeLists.txt
+++ b/sorc/chgres_cube.fd/CMakeLists.txt
@@ -1,6 +1,10 @@
-set(fortran_src
+# This is the CMake build file for the chgres_cube utility in the
+# UFS_UTILS package.
+#
+# George Gayno, Mark Potts, Kyle Gerheiser
+
+set(lib_src
     atmosphere.F90
-    chgres.F90
     grib2_util.F90
     input_data.F90
     model_grid.F90
@@ -12,29 +16,52 @@ set(fortran_src
     utils.f90
     write_data.F90)
 
+set(exe_src chgres.F90)
+
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8 -convert big_endian -assume byterecl")
-elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-0 -fdefault-real-8 -fconvert=big-endian")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8 -assume byterecl")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-0 -fdefault-real-8")
+  
+  # Turn on this argument mismatch flag for gfortran10.
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch")
+  endif()
 endif()
 
 set(exe_name chgres_cube)
-add_executable(${exe_name} ${fortran_src})
+
+add_library(chgres_cube_lib STATIC ${lib_src})
+add_executable(${exe_name} ${exe_src})
+
+set(mod_dir "${CMAKE_CURRENT_BINARY_DIR}/mod")
+set_target_properties(chgres_cube_lib PROPERTIES Fortran_MODULE_DIRECTORY ${mod_dir})
+target_include_directories(chgres_cube_lib INTERFACE ${mod_dir})
+
 target_link_libraries(
-  ${exe_name}
-  nemsio
-  sfcio_4
-  sigio_4
-  bacio_4
-  sp_d
-  w3nco_d
+  chgres_cube_lib
+  PUBLIC
+  nemsio::nemsio
+  sfcio::sfcio
+  sigio::sigio
+  bacio::bacio_4
+  sp::sp_d
+  w3nco::w3nco_d
   esmf
-  wgrib2::wgrib2_api
-  wgrib2::wgrib2_lib
+  wgrib2::wgrib2
   MPI::MPI_Fortran
   NetCDF::NetCDF_Fortran)
+
 if(OpenMP_Fortran_FOUND)
-  target_link_libraries(${exe_name} OpenMP::OpenMP_Fortran)
+  target_link_libraries(${exe_name} PUBLIC OpenMP::OpenMP_Fortran)
 endif()
 
+target_link_libraries(${exe_name} PRIVATE chgres_cube_lib)
+
 install(TARGETS ${exe_name} RUNTIME DESTINATION ${exec_dir})
+
+# If doxygen documentation we enabled, build it.
+if(ENABLE_DOCS)
+  add_subdirectory(docs)  
+endif()
+

--- a/sorc/machine-setup.sh
+++ b/sorc/machine-setup.sh
@@ -22,15 +22,18 @@ USERNAME=`echo $LOGNAME | awk '{ print tolower($0)'}`
 if [[ -d /lfs3 ]] ; then
     # We are on NOAA Jet
     if ( ! eval module help > /dev/null 2>&1 ) ; then
-	echo load the module command 1>&2
+        echo load the module command 1>&2
         source /apps/lmod/lmod/init/$__ms_shell
     fi
     target=jet
     module purge
+elif [[ -d /lfs/h1 ]] ; then
+    target=wcoss2_cray
+    module purge
 elif [[ -d /scratch1 ]] ; then
     # We are on NOAA Hera
     if ( ! eval module help > /dev/null 2>&1 ) ; then
-	echo load the module command 1>&2
+        echo load the module command 1>&2
         source /apps/lmod/lmod/init/$__ms_shell
     fi
     target=hera
@@ -38,8 +41,8 @@ elif [[ -d /scratch1 ]] ; then
 elif [[ -d /gpfs/hps && -e /etc/SuSE-release ]] ; then
     # We are on NOAA Luna or Surge
     if ( ! eval module help > /dev/null 2>&1 ) ; then
-	echo load the module command 1>&2
-	source /opt/modules/default/init/$__ms_shell
+        echo load the module command 1>&2
+        source /opt/modules/default/init/$__ms_shell
     fi
     target=wcoss_cray
 
@@ -72,37 +75,73 @@ elif [[ -d /gpfs/hps && -e /etc/SuSE-release ]] ; then
 elif [[ -L /usrx && "$( readlink /usrx 2> /dev/null )" =~ dell ]] ; then
     # We are on NOAA Venus or Mars
     if ( ! eval module help > /dev/null 2>&1 ) ; then
-	echo load the module command 1>&2
-	source /usrx/local/prod/lmod/lmod/init/$__ms_shell
+        echo load the module command 1>&2
+        source /usrx/local/prod/lmod/lmod/init/$__ms_shell
     fi
     target=wcoss_dell_p3
-    module purge 
+    module purge
 elif [[ -d /glade ]] ; then
-    # We are on NCAR Yellowstone
+    # We are on NCAR Cheyenne
     if ( ! eval module help > /dev/null 2>&1 ) ; then
-	echo load the module command 1>&2
-        . /usr/share/Modules/init/$__ms_shell
+        echo load the module command 1>&2
+        . /glade/u/apps/ch/opt/lmod/8.1.7/lmod/8.1.7/init/sh
     fi
-    target=yellowstone
+    target=cheyenne
     module purge
 elif [[ -d /lustre && -d /ncrc ]] ; then
-    # We are on GAEA. 
+    # We are on GAEA.
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         # We cannot simply load the module command.  The GAEA
         # /etc/profile modifies a number of module-related variables
         # before loading the module command.  Without those variables,
         # the module command fails.  Hence we actually have to source
         # /etc/profile here.
-	echo load the module command 1>&2
         source /etc/profile
+        __ms_source_etc_profile=yes
+    else
+        __ms_source_etc_profile=no
+    fi
+    module purge > /dev/null 2>&1
+    module purge
+# clean up after purge
+    unset _LMFILES_
+    unset _LMFILES_000
+    unset _LMFILES_001
+    unset LOADEDMODULES
+    module load modules
+    if [[ -d /opt/cray/ari/modulefiles ]] ; then
+        module use -a /opt/cray/ari/modulefiles
+    fi
+    if [[ -d /opt/cray/pe/ari/modulefiles ]] ; then
+        module use -a /opt/cray/pe/ari/modulefiles
+    fi
+    if [[ -d /opt/cray/pe/craype/default/modulefiles ]] ; then
+        module use -a /opt/cray/pe/craype/default/modulefiles
+    fi
+    if [[ -s /etc/opt/cray/pe/admin-pe/site-config ]] ; then
+        source /etc/opt/cray/pe/admin-pe/site-config
+    fi
+    if [[ "$__ms_source_etc_profile" == yes ]] ; then
+      source /etc/profile
+      unset __ms_source_etc_profile
     fi
     target=gaea
-    module purge
 elif [[ "$(hostname)" =~ "Orion" ]]; then
     target="orion"
     module purge
 elif [[ "$(hostname)" =~ "odin" ]]; then
     target="odin"
+elif [[ -d /work/00315 && -d /scratch/00315 ]] ; then
+    target=stampede
+    module purge
+elif [[ -d /data/prod ]] ; then
+    # We are on SSEC S4
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        echo load the module command 1>&2
+        source /usr/share/lmod/lmod/init/$__ms_shell
+    fi
+    target=s4
+    module purge
 else
     echo WARNING: UNKNOWN PLATFORM 1>&2
 fi


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Port the ops-hrefv3.1 tag to WCOSS2. Then tag a new version.

## TESTS CONDUCTED: 
chgres_cube regression tests passed on WCOSS2. Matt Pyle tested this branch within his HREF workflow.

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #582.
