### PR TITLE
Allow FVCOM tools to Update Ice Surface Roughness Length

### DIFF
--- a/sorc/fvcom_tools.fd/module_nwp.f90
+++ b/sorc/fvcom_tools.fd/module_nwp.f90
@@ -152,7 +152,7 @@ module module_nwp
             this%varnames(4) = 'tisfc'
             this%varnames(5) = 'tsfc'
             this%varnames(6) = 'tsfcl'
-            this%varnames(7) = 'zorl'
+            this%varnames(7) = 'zorli'
 
             allocate(this%latname)
             allocate(this%lonname)
@@ -257,7 +257,7 @@ module module_nwp
       !! @param[inout] zorl Surface roughness length
       !!
       !! @author David Wright, University of Michigan and GLERL
-      subroutine read_nwp(this,filename,itype,wcstart,numlon,numlat,numtimes,time_to_get,mask,sst,ice,sfcT,iceT,sfcTl, zorl)
+      subroutine read_nwp(this,filename,itype,wcstart,numlon,numlat,numtimes,time_to_get,mask,sst,ice,sfcT,iceT,sfcTl,zorl)
 
          class(fcst_nwp) :: this
 

--- a/sorc/fvcom_tools.fd/process_FVCOM.f90
+++ b/sorc/fvcom_tools.fd/process_FVCOM.f90
@@ -66,6 +66,7 @@ program process_FVCOM
    real :: truelat1, truelat2, stdlon, lat1, lon1, r_earth
    real :: knowni, knownj, dx
    real :: one, pi, deg2rad
+   real :: zero
 
    character(len=180) :: fv3file
    character(len=180) :: fvcomfile
@@ -99,6 +100,7 @@ program process_FVCOM
 !
 if(mype==0) then
 
+   zero = 0.0
 !  Get file names from command line arguements
    num_args = command_argument_count()
    allocate(args(num_args))
@@ -229,7 +231,7 @@ if(mype==0) then
               !If ice in FV3-LAM and not FVCOM, remove it from FV3-LAM
               if (fv3mask(i,j) == 2. .and. lbcice(i,j) == 0.) then
                 fv3mask(i,j) = 0.
-                fv3zorl(i,j) = 0.
+                fv3zorl(i,j) = zero / zero !Use Fill_Value
               endif
               fv3sst(i,j) = lbcsst(i,j) + 273.15
               fv3sfcT(i,j) = lbcsst(i,j) + 273.15
@@ -261,7 +263,7 @@ if(mype==0) then
               !If ice in FV3-LAM and not FVCOM, remove it from FV3-LAM
               if (fv3mask(i,j) == 2. .and. lbcice(i,j) == 0.) then
                 fv3mask(i,j) = 0.
-                fv3zorl(i,j) = 0.
+                fv3zorl(i,j) = zero / zero !Use Fill_Value
               endif
               fv3sst(i,j) = lbcsst(i,j) + 273.15
               fv3sfcT(i,j) = lbcsst(i,j) + 273.15

--- a/sorc/fvcom_tools.fd/process_FVCOM.f90
+++ b/sorc/fvcom_tools.fd/process_FVCOM.f90
@@ -277,14 +277,15 @@ if(mype==0) then
    call geo%replace_var("fice",NLON,NLAT,fv3ice)
    call geo%replace_var("slmsk",NLON,NLAT,fv3mask)
    call geo%replace_var("tisfc",NLON,NLAT,fv3iceT)
-   call geo%replace_var("zorl",NLON,NLAT,fv3zorl)
 
    if (wcstart == 'cold') then
 ! Add_New_Var takes names of (Variable,Dim1,Dim2,Dim3,Long_Name,Units)
+      call geo%replace_var("zorl",NLON,NLAT,fv3zorl)
       call geo%add_new_var('glmsk','xaxis_1','yaxis_1','Time','glmsk','none')
       call geo%replace_var('glmsk',NLON,NLAT,lbcmask)
    end if
    if (wcstart == 'warm') then
+      call geo%replace_var("zorli",NLON,NLAT,fv3zorl)
       call geo%replace_var("tsfc",NLON,NLAT,fv3sfcT)
       call geo%replace_var("tsfcl",NLON,NLAT,fv3sfcTl)
       call geo%add_new_var('glmsk','xaxis_1','yaxis_1','glmsk','none')

--- a/sorc/fvcom_tools.fd/process_FVCOM.f90
+++ b/sorc/fvcom_tools.fd/process_FVCOM.f90
@@ -224,7 +224,7 @@ if(mype==0) then
               !If ice in FVCOM, but not in FV3-LAM, change to ice
               if (lbcice(i,j) > 0. .and. fv3mask(i,j) == 0.) then
                 fv3mask(i,j) = 2.
-                fv3zorl(i,j) = 1.
+                fv3zorl(i,j) = 1.1
               endif
               !If ice in FV3-LAM and not FVCOM, remove it from FV3-LAM
               if (fv3mask(i,j) == 2. .and. lbcice(i,j) == 0.) then


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Surface roughness was not being updated by FVCOM tools, specifically over ice points.  This created a segfault issue when running the UFS-SRW, specifically with the MYNN surface layer scheme. This problem only appears when points are changed either from water to ice or from ice to water. Now the code will update the variable zorl for cold starts and zorli for warm starts. 

## TESTS CONDUCTED: 
Test was run on Hera using both warm (restart sfc_data.nc) and cold (chgres_cube sfc_data.nc) files.

## DEPENDENCIES:
None.

## DOCUMENTATION:
No update to documentation needed.

## ISSUE: 
Fixes issue mentioned in #602 


