### PR TITLE
Run consistency tests on Hera under new role account

### DIFF
--- a/reg_tests/chgres_cube/driver.hera.sh
+++ b/reg_tests/chgres_cube/driver.hera.sh
@@ -46,7 +46,7 @@ QUEUE="${QUEUE:-batch}"
 
 export HOMEufs=$PWD/../..
 
-export HOMEreg=/scratch1/NCEPDEV/da/George.Gayno/noscrub/reg_tests/chgres_cube
+export HOMEreg=/scratch1/NCEPDEV/nems/role.ufsutils/reg_tests/chgres_cube
 
 LOG_FILE=consistency.log
 SUM_FILE=summary.log

--- a/reg_tests/chgres_cube/driver.hera.sh
+++ b/reg_tests/chgres_cube/driver.hera.sh
@@ -46,7 +46,7 @@ QUEUE="${QUEUE:-batch}"
 
 export HOMEufs=$PWD/../..
 
-export HOMEreg=/scratch1/NCEPDEV/nems/role.ufsutils/reg_tests/chgres_cube
+export HOMEreg=/scratch1/NCEPDEV/nems/role.ufsutils/ufs_utils/reg_tests/chgres_cube
 
 LOG_FILE=consistency.log
 SUM_FILE=summary.log

--- a/reg_tests/global_cycle/driver.hera.sh
+++ b/reg_tests/global_cycle/driver.hera.sh
@@ -38,7 +38,7 @@ QUEUE="${QUEUE:-batch}"
 
 DATA_DIR="${WORK_DIR}/reg-tests/global-cycle"
 
-export HOMEreg=/scratch1/NCEPDEV/nems/role.ufsutils/reg_tests/global_cycle
+export HOMEreg=/scratch1/NCEPDEV/nems/role.ufsutils/ufs_utils/reg_tests/global_cycle
 
 export OMP_NUM_THREADS_CY=2
 

--- a/reg_tests/global_cycle/driver.hera.sh
+++ b/reg_tests/global_cycle/driver.hera.sh
@@ -38,7 +38,7 @@ QUEUE="${QUEUE:-batch}"
 
 DATA_DIR="${WORK_DIR}/reg-tests/global-cycle"
 
-export HOMEreg=/scratch1/NCEPDEV/da/George.Gayno/noscrub/reg_tests/global_cycle
+export HOMEreg=/scratch1/NCEPDEV/nems/role.ufsutils/reg_tests/global_cycle
 
 export OMP_NUM_THREADS_CY=2
 

--- a/reg_tests/grid_gen/driver.hera.sh
+++ b/reg_tests/grid_gen/driver.hera.sh
@@ -46,7 +46,7 @@ export APRUN=time
 export APRUN_SFC=srun
 export OMP_STACKSIZE=2048m
 export machine=HERA
-export HOMEreg=/scratch1/NCEPDEV/nems/role.ufsutils/reg_tests/grid_gen/baseline_data
+export HOMEreg=/scratch1/NCEPDEV/nems/role.ufsutils/ufs_utils/reg_tests/grid_gen/baseline_data
 
 ulimit -a
 #ulimit -s unlimited

--- a/reg_tests/grid_gen/driver.hera.sh
+++ b/reg_tests/grid_gen/driver.hera.sh
@@ -46,7 +46,7 @@ export APRUN=time
 export APRUN_SFC=srun
 export OMP_STACKSIZE=2048m
 export machine=HERA
-export HOMEreg=/scratch1/NCEPDEV/da/George.Gayno/noscrub/reg_tests/grid_gen/baseline_data
+export HOMEreg=/scratch1/NCEPDEV/nems/role.ufsutils/reg_tests/grid_gen/baseline_data
 
 ulimit -a
 #ulimit -s unlimited

--- a/reg_tests/ice_blend/driver.hera.sh
+++ b/reg_tests/ice_blend/driver.hera.sh
@@ -49,7 +49,7 @@ export COPYGB=/scratch2/NCEPDEV/nwprod/NCEPLIBS/utils/grib_util.v1.1.1/exec/copy
 export COPYGB2=/scratch2/NCEPDEV/nwprod/NCEPLIBS/utils/grib_util.v1.1.1/exec/copygb2
 export CNVGRIB=/scratch2/NCEPDEV/nwprod/NCEPLIBS/utils/grib_util.v1.1.1/exec/cnvgrib
 
-export HOMEreg=/scratch1/NCEPDEV/da/George.Gayno/noscrub/reg_tests/ice_blend
+export HOMEreg=/scratch1/NCEPDEV/nems/role.ufsutils/reg_tests/ice_blend
 export HOMEgfs=$PWD/../..
 
 rm -fr $DATA

--- a/reg_tests/ice_blend/driver.hera.sh
+++ b/reg_tests/ice_blend/driver.hera.sh
@@ -49,7 +49,7 @@ export COPYGB=/scratch2/NCEPDEV/nwprod/NCEPLIBS/utils/grib_util.v1.1.1/exec/copy
 export COPYGB2=/scratch2/NCEPDEV/nwprod/NCEPLIBS/utils/grib_util.v1.1.1/exec/copygb2
 export CNVGRIB=/scratch2/NCEPDEV/nwprod/NCEPLIBS/utils/grib_util.v1.1.1/exec/cnvgrib
 
-export HOMEreg=/scratch1/NCEPDEV/nems/role.ufsutils/reg_tests/ice_blend
+export HOMEreg=/scratch1/NCEPDEV/nems/role.ufsutils/ufs_utils/reg_tests/ice_blend
 export HOMEgfs=$PWD/../..
 
 rm -fr $DATA

--- a/reg_tests/rt.sh
+++ b/reg_tests/rt.sh
@@ -16,7 +16,7 @@ cd ${WORK_DIR}
 rm -f reg_test_results.txt
 rm -rf UFS_UTILS
 
-git clone --recursive https://github.com/NOAA-EMC/UFS_UTILS.git
+git clone --recursive https://github.com/ufs-community/UFS_UTILS.git
 cd UFS_UTILS
 
 source sorc/machine-setup.sh

--- a/reg_tests/snow2mdl/driver.hera.sh
+++ b/reg_tests/snow2mdl/driver.hera.sh
@@ -45,7 +45,7 @@ export DATA="${DATA}/reg-tests/snow2mdl"
 
 rm -fr $DATA
 
-export HOMEreg=/scratch1/NCEPDEV/nems/role.uftutils/reg_tests/snow2mdl
+export HOMEreg=/scratch1/NCEPDEV/nems/role.ufsutils/ufs_utils/reg_tests/snow2mdl
 export HOMEgfs=$PWD/../..
 export WGRIB=/scratch2/NCEPDEV/nwprod/NCEPLIBS/utils/grib_util.v1.1.1/exec/wgrib
 export WGRIB2=/scratch2/NCEPDEV/nwprod/NCEPLIBS/utils/grib_util.v1.1.1/exec/wgrib2

--- a/reg_tests/snow2mdl/driver.hera.sh
+++ b/reg_tests/snow2mdl/driver.hera.sh
@@ -45,7 +45,7 @@ export DATA="${DATA}/reg-tests/snow2mdl"
 
 rm -fr $DATA
 
-export HOMEreg=/scratch1/NCEPDEV/da/George.Gayno/noscrub/reg_tests/snow2mdl
+export HOMEreg=/scratch1/NCEPDEV/nems/role.uftutils/reg_tests/snow2mdl
 export HOMEgfs=$PWD/../..
 export WGRIB=/scratch2/NCEPDEV/nwprod/NCEPLIBS/utils/grib_util.v1.1.1/exec/wgrib
 export WGRIB2=/scratch2/NCEPDEV/nwprod/NCEPLIBS/utils/grib_util.v1.1.1/exec/wgrib2


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
On Hera, the consistency test baseline and input data were placed in a directory owned by 'role.ufsutils'. The Hera consistency test scripts were updated to point to this new directory.

## TESTS CONDUCTED: 
The ./rt.sh script was started from the 'role.ufsutils' crontab. All tests ran and passed. The summary email was sent to my noaa account.

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A

## ISSUE: 
Part of #600.

