### PR TITLE
Run consistency tests on Orion under new role account

### DIFF
--- a/reg_tests/chgres_cube/driver.orion.sh
+++ b/reg_tests/chgres_cube/driver.orion.sh
@@ -46,7 +46,7 @@ QUEUE="${QUEUE:-batch}"
 
 export HOMEufs=$PWD/../..
 
-export HOMEreg=/work/noaa/da/ggayno/save/ufs_utils.git/reg_tests/chgres_cube
+export HOMEreg=/work/noaa/nems/role-nems/ufs_utils/reg_tests/chgres_cube
 
 LOG_FILE=consistency.log
 SUM_FILE=summary.log

--- a/reg_tests/global_cycle/driver.orion.sh
+++ b/reg_tests/global_cycle/driver.orion.sh
@@ -36,7 +36,7 @@ QUEUE="${QUEUE:-batch}"
 
 export DATA_DIR="${WORK_DIR}/reg-tests/global-cycle"
 
-export HOMEreg=/work/noaa/da/ggayno/save/ufs_utils.git/reg_tests/global_cycle
+export HOMEreg=/work/noaa/nems/role-nems/ufs_utils/reg_tests/global_cycle
 
 export OMP_NUM_THREADS_CY=2
 

--- a/reg_tests/grid_gen/driver.orion.sh
+++ b/reg_tests/grid_gen/driver.orion.sh
@@ -46,7 +46,7 @@ export APRUN_SFC=srun
 export OMP_STACKSIZE=2048m
 export OMP_NUM_THREADS=24
 export machine=ORION
-export HOMEreg=/work/noaa/da/ggayno/save/ufs_utils.git/reg_tests/grid_gen/baseline_data
+export HOMEreg=/work/noaa/nems/role-nems/ufs_utils/reg_tests/grid_gen/baseline_data
 
 rm -fr $WORK_DIR
 

--- a/reg_tests/ice_blend/driver.orion.sh
+++ b/reg_tests/ice_blend/driver.orion.sh
@@ -49,7 +49,7 @@ export COPYGB=/apps/contrib/NCEPLIBS/lib/NCEPLIBS-grib_util/v1.1.1/exec/copygb
 export COPYGB2=/apps/contrib/NCEPLIBS/orion/utils/grib_util.v1.2.0/exec/copygb2
 export CNVGRIB=/apps/contrib/NCEPLIBS/orion/utils/grib_util.v1.2.0/exec/cnvgrib
 
-export HOMEreg=/work/noaa/da/ggayno/save/ufs_utils.git/reg_tests/ice_blend
+export HOMEreg=/work/noaa/nems/role-nems/ufs_utils/reg_tests/ice_blend
 export HOMEgfs=$PWD/../..
 
 rm -fr $DATA

--- a/reg_tests/snow2mdl/driver.orion.sh
+++ b/reg_tests/snow2mdl/driver.orion.sh
@@ -45,7 +45,7 @@ export DATA="${DATA}/reg-tests/snow2mdl"
 
 rm -fr $DATA
 
-export HOMEreg=/work/noaa/da/ggayno/save/ufs_utils.git/reg_tests/snow2mdl
+export HOMEreg=/work/noaa/nems/role-nems/ufs_utils/reg_tests/snow2mdl
 export HOMEgfs=$PWD/../..
 export WGRIB=/apps/contrib/NCEPLIBS/orion/utils/grib_util.v1.2.0/exec/wgrib
 export WGRIB2=/apps/contrib/NCEPLIBS/orion/utils/grib_util.v1.2.0/exec/wgrib2


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
On Orion, the consistency test baseline and input data were placed in a directory owned by 'role-nems'. The Orion consistency test scripts were updated to point to this new directory.

## TESTS CONDUCTED: 
The ./rt.sh script was started from the 'role-nems' crontab. All tests ran and passed. The summary email was sent to my noaa account.

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A

## ISSUE: 
Part of #600