### PR TITLE
Run consistency tests on Jet under new role account

### DIFF
--- a/reg_tests/chgres_cube/driver.jet.sh
+++ b/reg_tests/chgres_cube/driver.jet.sh
@@ -47,7 +47,7 @@ export HDF5_DISABLE_VERSION_CHECK=2
 
 export HOMEufs=$PWD/../..
 
-export HOMEreg=/lfs4/HFIP/emcda/George.Gayno/reg_tests/chgres_cube
+export HOMEreg=/lfs4/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/reg_tests/chgres_cube
 
 LOG_FILE=consistency.log
 SUM_FILE=summary.log

--- a/reg_tests/global_cycle/driver.jet.sh
+++ b/reg_tests/global_cycle/driver.jet.sh
@@ -36,7 +36,7 @@ QUEUE="${QUEUE:-batch}"
 
 export DATA_DIR="${WORK_DIR}/reg-tests/global-cycle"
 
-export HOMEreg=/lfs4/HFIP/emcda/George.Gayno/reg_tests/global_cycle
+export HOMEreg=/lfs4/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/reg_tests/global_cycle
 
 export OMP_NUM_THREADS_CY=2
 

--- a/reg_tests/grid_gen/driver.jet.sh
+++ b/reg_tests/grid_gen/driver.jet.sh
@@ -44,7 +44,7 @@ export APRUN=time
 export APRUN_SFC=srun
 export OMP_STACKSIZE=2048m
 export machine=JET
-export HOMEreg=/lfs4/HFIP/emcda/George.Gayno/reg_tests/grid_gen/baseline_data
+export HOMEreg=/lfs4/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/reg_tests/grid_gen/baseline_data
 
 ulimit -a
 ulimit -s unlimited

--- a/reg_tests/ice_blend/driver.jet.sh
+++ b/reg_tests/ice_blend/driver.jet.sh
@@ -46,7 +46,7 @@ export COPYGB=/lfs4/HFIP/emcda/George.Gayno/ufs_utils.git/jet_port/grib_util/cop
 export COPYGB2=/lfs4/HFIP/emcda/George.Gayno/ufs_utils.git/jet_port/grib_util/copygb2
 export CNVGRIB=/apps/cnvgrib/1.4.0/bin/cnvgrib
 
-export HOMEreg=/lfs4/HFIP/emcda/George.Gayno/reg_tests/ice_blend
+export HOMEreg=/lfs4/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/reg_tests/ice_blend
 export HOMEgfs=$PWD/../..
 
 rm -fr $DATA

--- a/reg_tests/rt.sh
+++ b/reg_tests/rt.sh
@@ -16,7 +16,7 @@ cd ${WORK_DIR}
 rm -f reg_test_results.txt
 rm -rf UFS_UTILS
 
-git clone --recursive https://github.com/NOAA-EMC/UFS_UTILS.git
+git clone --recursive https://github.com/ufs-community/UFS_UTILS.git
 cd UFS_UTILS
 
 source sorc/machine-setup.sh

--- a/reg_tests/snow2mdl/driver.jet.sh
+++ b/reg_tests/snow2mdl/driver.jet.sh
@@ -40,7 +40,7 @@ export DATA="${DATA}/reg-tests/snow2mdl"
 # Should not have to change anything below.
 #-----------------------------------------------------------------------------
 
-export HOMEreg=/lfs4/HFIP/emcda/George.Gayno/reg_tests/snow2mdl
+export HOMEreg=/lfs4/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/reg_tests/snow2mdl
 export HOMEgfs=$PWD/../..
 export WGRIB=/apps/wgrib/1.8.1.0b/bin/wgrib
 export WGRIB2=/apps/wgrib2/0.1.9.6a/bin/wgrib2


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
On Jet, the consistency test baseline and input data were placed in a directory owned by 'emc.nemspara'. The Jet consistency test scripts were updated to point to this new directory.

## TESTS CONDUCTED: 
The ./rt.sh script was run and all tests ran and passed.

## DEPENDENCIES:
None

## DOCUMENTATION:
N/A

## ISSUE: 
Part of #600
