### PR TITLE
Create copy of grib_util under Jet role account.

### DIFF
--- a/reg_tests/ice_blend/driver.jet.sh
+++ b/reg_tests/ice_blend/driver.jet.sh
@@ -42,8 +42,8 @@ export DATA="${DATA}/reg-tests/ice-blend"
 
 export WGRIB=/apps/wgrib/1.8.1.0b/bin/wgrib
 export WGRIB2=/apps/wgrib2/0.1.9.6a/bin/wgrib2
-export COPYGB=/lfs4/HFIP/emcda/George.Gayno/ufs_utils.git/jet_port/grib_util/copygb
-export COPYGB2=/lfs4/HFIP/emcda/George.Gayno/ufs_utils.git/jet_port/grib_util/copygb2
+export COPYGB=/lfs4/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/grib_util/NCEPLIBS-grib_util/exec/bin/copygb
+export COPYGB2=/lfs4/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/grib_util/NCEPLIBS-grib_util/exec/bin/copygb2
 export CNVGRIB=/apps/cnvgrib/1.4.0/bin/cnvgrib
 
 export HOMEreg=/lfs4/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/reg_tests/ice_blend


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Compile a copy of grib_util under the Jet role account (the hpc-stack version
of grib_utils does not work). Previously, a local copy under my directory
was being used.  Update the ice_blend regression test script accordingly.

## TESTS CONDUCTED: 
The ice_blend regression test was run on Jet and passed.

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A

## ISSUE: 
#600
