### PR TITLE
Update the requested memory in the Orion chgres_cube consistency test script

### DIFF
--- a/reg_tests/chgres_cube/driver.orion.sh
+++ b/reg_tests/chgres_cube/driver.orion.sh
@@ -68,7 +68,7 @@ rm -fr $OUTDIR
 
 LOG_FILE1=${LOG_FILE}01
 export OMP_NUM_THREADS=1  # needs to match cpus-per-task
-TEST1=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 -t 0:15:00 -A $PROJECT_CODE -q $QUEUE -J c96.fv3.restart \
+TEST1=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 --mem=75G -t 0:15:00 -A $PROJECT_CODE -q $QUEUE -J c96.fv3.restart \
       -o $LOG_FILE1 -e $LOG_FILE1 ./c96.fv3.restart.sh)
 
 #-----------------------------------------------------------------------------
@@ -77,7 +77,7 @@ TEST1=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 -t 0:15:00 -A $PROJECT_C
 
 LOG_FILE2=${LOG_FILE}02
 export OMP_NUM_THREADS=1  # needs to match cpus-per-task
-TEST2=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 -t 0:15:00 -A $PROJECT_CODE -q $QUEUE -J c192.fv3.history \
+TEST2=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 --mem=75G -t 0:15:00 -A $PROJECT_CODE -q $QUEUE -J c192.fv3.history \
       --open-mode=append -o $LOG_FILE2 -e $LOG_FILE2 ./c192.fv3.history.sh)
 
 #-----------------------------------------------------------------------------
@@ -86,7 +86,7 @@ TEST2=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 -t 0:15:00 -A $PROJECT_C
 
 LOG_FILE3=${LOG_FILE}03
 export OMP_NUM_THREADS=1  # needs to match cpus-per-task
-TEST3=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 -t 0:15:00 -A $PROJECT_CODE -q $QUEUE -J c96.fv3.nemsio \
+TEST3=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 --mem=75G -t 0:15:00 -A $PROJECT_CODE -q $QUEUE -J c96.fv3.nemsio \
       --open-mode=append -o $LOG_FILE3 -e $LOG_FILE3 ./c96.fv3.nemsio.sh)
 
 #-----------------------------------------------------------------------------
@@ -95,7 +95,7 @@ TEST3=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 -t 0:15:00 -A $PROJECT_C
 
 LOG_FILE4=${LOG_FILE}04
 export OMP_NUM_THREADS=6  # needs to match cpus-per-task
-TEST4=$(sbatch --parsable --ntasks-per-node=3 --cpus-per-task=6 --nodes=2 -t 0:15:00 -A $PROJECT_CODE -q $QUEUE -J c96.gfs.sigio \
+TEST4=$(sbatch --parsable --ntasks-per-node=3 --cpus-per-task=6 --nodes=2 --mem=50G -t 0:15:00 -A $PROJECT_CODE -q $QUEUE -J c96.gfs.sigio \
       --open-mode=append -o $LOG_FILE4 -e $LOG_FILE4 ./c96.gfs.sigio.sh)
 
 #-----------------------------------------------------------------------------
@@ -104,7 +104,7 @@ TEST4=$(sbatch --parsable --ntasks-per-node=3 --cpus-per-task=6 --nodes=2 -t 0:1
 
 LOG_FILE5=${LOG_FILE}05
 export OMP_NUM_THREADS=1  # needs to match cpus-per-task
-TEST5=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 -t 0:15:00 -A $PROJECT_CODE -q $QUEUE -J c96.gfs.nemsio \
+TEST5=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 --mem=75G -t 0:15:00 -A $PROJECT_CODE -q $QUEUE -J c96.gfs.nemsio \
       --open-mode=append -o $LOG_FILE5 -e $LOG_FILE5 ./c96.gfs.nemsio.sh)
 
 #-----------------------------------------------------------------------------
@@ -113,7 +113,7 @@ TEST5=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 -t 0:15:00 -A $PROJECT_C
 
 LOG_FILE6=${LOG_FILE}06
 export OMP_NUM_THREADS=1  # needs to match cpus-per-task
-TEST6=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 -t 0:15:00 -A $PROJECT_CODE -q $QUEUE -J c96.regional \
+TEST6=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 --mem=75G -t 0:15:00 -A $PROJECT_CODE -q $QUEUE -J c96.regional \
       --open-mode=append -o $LOG_FILE6 -e $LOG_FILE6 ./c96.regional.sh)
 
 #-----------------------------------------------------------------------------
@@ -122,7 +122,7 @@ TEST6=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 -t 0:15:00 -A $PROJECT_C
 
 LOG_FILE7=${LOG_FILE}07
 export OMP_NUM_THREADS=1  # needs to match cpus-per-task
-TEST7=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 -t 0:05:00 -A $PROJECT_CODE -q $QUEUE -J c192.gfs.grib2 \
+TEST7=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 --mem=75G -t 0:05:00 -A $PROJECT_CODE -q $QUEUE -J c192.gfs.grib2 \
       --open-mode=append -o $LOG_FILE7 -e $LOG_FILE7 ./c192.gfs.grib2.sh)
 
 #-----------------------------------------------------------------------------
@@ -131,7 +131,7 @@ TEST7=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 -t 0:05:00 -A $PROJECT_C
 
 LOG_FILE8=${LOG_FILE}08
 export OMP_NUM_THREADS=1  # needs to match cpus-per-task
-TEST8=$(sbatch --parsable --ntasks-per-node=6 --nodes=2 -t 0:10:00 -A $PROJECT_CODE -q $QUEUE -J c96.fv3.netcdf \
+TEST8=$(sbatch --parsable --ntasks-per-node=6 --nodes=2 --mem=75G -t 0:10:00 -A $PROJECT_CODE -q $QUEUE -J c96.fv3.netcdf \
       --open-mode=append -o $LOG_FILE8 -e $LOG_FILE8 ./c96.fv3.netcdf.sh)
 
 #-----------------------------------------------------------------------------
@@ -140,7 +140,7 @@ TEST8=$(sbatch --parsable --ntasks-per-node=6 --nodes=2 -t 0:10:00 -A $PROJECT_C
 
 LOG_FILE9=${LOG_FILE}09
 export OMP_NUM_THREADS=1   # should match cpus-per-task
-TEST9=$(sbatch --parsable --ntasks-per-node=12 --nodes=1 -t 0:15:00 -A $PROJECT_CODE -q $QUEUE -J c96.fv3.netcdf2wam \
+TEST9=$(sbatch --parsable --ntasks-per-node=12 --nodes=1 --mem=100G -t 0:15:00 -A $PROJECT_CODE -q $QUEUE -J c96.fv3.netcdf2wam \
       --open-mode=append -o $LOG_FILE9 -e $LOG_FILE9 ./c96.fv3.netcdf2wam.sh)
 
 #-----------------------------------------------------------------------------
@@ -149,7 +149,7 @@ TEST9=$(sbatch --parsable --ntasks-per-node=12 --nodes=1 -t 0:15:00 -A $PROJECT_
 
 LOG_FILE10=${LOG_FILE}10
 export OMP_NUM_THREADS=1   # should match cpus-per-task
-TEST10=$(sbatch --parsable --ntasks-per-node=12 --nodes=1 -t 0:10:00 -A $PROJECT_CODE -q $QUEUE -J 25km.conus.gfs.grib2 \
+TEST10=$(sbatch --parsable --ntasks-per-node=12 --nodes=1 --mem=75G -t 0:10:00 -A $PROJECT_CODE -q $QUEUE -J 25km.conus.gfs.grib2 \
       --open-mode=append -o $LOG_FILE10 -e $LOG_FILE10 ./25km.conus.gfs.grib2.sh)
 
 #-----------------------------------------------------------------------------
@@ -158,7 +158,7 @@ TEST10=$(sbatch --parsable --ntasks-per-node=12 --nodes=1 -t 0:10:00 -A $PROJECT
 
 LOG_FILE11=${LOG_FILE}11
 export OMP_NUM_THREADS=1   # should match cpus-per-task
-TEST11=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 -t 0:10:00 -A $PROJECT_CODE -q $QUEUE -J 3km.conus.hrrr.gfssdf.grib2 \
+TEST11=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 --mem=75G -t 0:10:00 -A $PROJECT_CODE -q $QUEUE -J 3km.conus.hrrr.gfssdf.grib2 \
       --open-mode=append -o $LOG_FILE11 -e $LOG_FILE11 ./3km.conus.hrrr.gfssdf.grib2.sh)
 
 #-----------------------------------------------------------------------------
@@ -167,7 +167,7 @@ TEST11=$(sbatch --parsable --ntasks-per-node=6 --nodes=1 -t 0:10:00 -A $PROJECT_
 
 LOG_FILE12=${LOG_FILE}12
 export OMP_NUM_THREADS=1   # should match cpus-per-task
-TEST12=$(sbatch --parsable --ntasks-per-node=6 --nodes=2 -t 0:10:00 -A $PROJECT_CODE -q $QUEUE -J 3km.conus.hrrr.newsfc.grib2 \
+TEST12=$(sbatch --parsable --ntasks-per-node=6 --nodes=2 --mem=75G -t 0:10:00 -A $PROJECT_CODE -q $QUEUE -J 3km.conus.hrrr.newsfc.grib2 \
       --open-mode=append -o $LOG_FILE12 -e $LOG_FILE12 ./3km.conus.hrrr.newsfc.grib2.sh)
 
 #-----------------------------------------------------------------------------
@@ -176,7 +176,7 @@ TEST12=$(sbatch --parsable --ntasks-per-node=6 --nodes=2 -t 0:10:00 -A $PROJECT_
 
 LOG_FILE13=${LOG_FILE}13
 export OMP_NUM_THREADS=1   # should match cpus-per-task
-TEST13=$(sbatch --parsable --ntasks-per-node=12 --nodes=1 -t 0:10:00 -A $PROJECT_CODE -q $QUEUE -J 13km.conus.nam.grib2 \
+TEST13=$(sbatch --parsable --ntasks-per-node=12 --nodes=1 --mem=75G -t 0:10:00 -A $PROJECT_CODE -q $QUEUE -J 13km.conus.nam.grib2 \
       --open-mode=append -o $LOG_FILE13 -e $LOG_FILE13 ./13km.conus.nam.grib2.sh)
 
 #-----------------------------------------------------------------------------
@@ -185,7 +185,7 @@ TEST13=$(sbatch --parsable --ntasks-per-node=12 --nodes=1 -t 0:10:00 -A $PROJECT
 
 LOG_FILE14=${LOG_FILE}14
 export OMP_NUM_THREADS=1   # should match cpus-per-task
-TEST14=$(sbatch --parsable --ntasks-per-node=12 --nodes=1 -t 0:10:00 -A $PROJECT_CODE -q $QUEUE -J 13km.conus.rap.grib2 \
+TEST14=$(sbatch --parsable --ntasks-per-node=12 --nodes=1 --mem=75G -t 0:10:00 -A $PROJECT_CODE -q $QUEUE -J 13km.conus.rap.grib2 \
       --open-mode=append -o $LOG_FILE14 -e $LOG_FILE14 ./13km.conus.rap.grib2.sh)
 
 #-----------------------------------------------------------------------------
@@ -194,7 +194,7 @@ TEST14=$(sbatch --parsable --ntasks-per-node=12 --nodes=1 -t 0:10:00 -A $PROJECT
 
 LOG_FILE15=${LOG_FILE}15
 export OMP_NUM_THREADS=1   # should match cpus-per-task
-TEST15=$(sbatch --parsable --ntasks-per-node=12 --nodes=1 -t 0:10:00 -A $PROJECT_CODE -q $QUEUE -J 13km.na.gfs.ncei.grib2 \
+TEST15=$(sbatch --parsable --ntasks-per-node=12 --nodes=1 --mem=75G -t 0:10:00 -A $PROJECT_CODE -q $QUEUE -J 13km.na.gfs.ncei.grib2 \
       --open-mode=append -o $LOG_FILE15 -e $LOG_FILE15 ./13km.na.gfs.ncei.grib2.sh)
 
 #-----------------------------------------------------------------------------
@@ -203,7 +203,7 @@ TEST15=$(sbatch --parsable --ntasks-per-node=12 --nodes=1 -t 0:10:00 -A $PROJECT
 
 LOG_FILE16=${LOG_FILE}16
 export OMP_NUM_THREADS=1   # should match cpus-per-task
-TEST16=$(sbatch --parsable --ntasks-per-node=12 --nodes=1 -t 0:10:00 -A $PROJECT_CODE -q $QUEUE -J 25km.conus.gfs.pbgrib2 \
+TEST16=$(sbatch --parsable --ntasks-per-node=12 --nodes=1 --mem=75G -t 0:10:00 -A $PROJECT_CODE -q $QUEUE -J 25km.conus.gfs.pbgrib2 \
       --open-mode=append -o $LOG_FILE16 -e $LOG_FILE16 ./25km.conus.gfs.pbgrib2.sh)
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Explicitly request the amount of memory for each chgres_cube test. Previously, the default
allocation by Slurm was being used.

## TESTS CONDUCTED: 
The script was tested on Orion under my own account. It ran successfully six times in a row.
Previously, one of the 16 tests would always fail.

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #609
