### PR TITLE
Use ESMF 8.2.0 library (feature/esmf_8_2_0)

### DIFF
--- a/.github/workflows/debug-docs-test_coverage.yml
+++ b/.github/workflows/debug-docs-test_coverage.yml
@@ -26,16 +26,16 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/esmf
-        key: esmf-8.1.1-${{ runner.os }}3
+        key: esmf-8.2.0-${{ runner.os }}3
 
     - name: build-esmf
       if: steps.cache-esmf.outputs.cache-hit != 'true'
       run: |
         pushd ~
-        export ESMF_DIR=~/esmf-ESMF_8_1_1
-        wget https://github.com/esmf-org/esmf/archive/ESMF_8_1_1.tar.gz &> /dev/null
-        tar zxf ESMF_8_1_1.tar.gz
-        cd esmf-ESMF_8_1_1
+        export ESMF_DIR=~/esmf-ESMF_8_2_0
+        wget https://github.com/esmf-org/esmf/archive/ESMF_8_2_0.tar.gz &> /dev/null
+        tar zxf ESMF_8_2_0.tar.gz
+        cd esmf-ESMF_8_2_0
         export ESMF_COMM=mpich3
         export ESMF_INSTALL_BINDIR=bin
         export ESMF_INSTALL_LIBDIR=lib

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -85,16 +85,16 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/esmf
-        key: esmf-8.1.1-${{ runner.os }}-intel3
+        key: esmf-8.2.0-${{ runner.os }}-intel3
 
     - name: build-esmf
       if: steps.cache-esmf.outputs.cache-hit != 'true'
       run: |
         pushd ~
-        export ESMF_DIR=~/esmf-ESMF_8_1_1
-        wget https://github.com/esmf-org/esmf/archive/ESMF_8_1_1.tar.gz &> /dev/null
-        tar zxf ESMF_8_1_1.tar.gz
-        cd esmf-ESMF_8_1_1
+        export ESMF_DIR=~/esmf-ESMF_8_2_0
+        wget https://github.com/esmf-org/esmf/archive/ESMF_8_2_0.tar.gz &> /dev/null
+        tar zxf ESMF_8_2_0.tar.gz
+        cd esmf-ESMF_8_2_0
         export ESMF_COMM=intelmpi
         export ESMF_INSTALL_BINDIR=bin
         export ESMF_INSTALL_LIBDIR=lib

--- a/.github/workflows/linux-mac-nceplibs-mpi.yml
+++ b/.github/workflows/linux-mac-nceplibs-mpi.yml
@@ -123,17 +123,17 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/esmf
-        key: esmf--8.1.1-${{ runner.os }}-${{ matrix.mpi_type }}-netcdf-${{ matrix.netcdf_version }}3
+        key: esmf--8.2.0-${{ runner.os }}-${{ matrix.mpi_type }}-netcdf-${{ matrix.netcdf_version }}3
 
     - name: build-esmf
       if: steps.cache-esmf.outputs.cache-hit != 'true'
       run: |
         set -x
         pushd ~
-        export ESMF_DIR=~/esmf-ESMF_8_1_1
-        wget https://github.com/esmf-org/esmf/archive/ESMF_8_1_1.tar.gz &> /dev/null
-        tar zxf ESMF_8_1_1.tar.gz
-        cd esmf-ESMF_8_1_1
+        export ESMF_DIR=~/esmf-ESMF_8_2_0
+        wget https://github.com/esmf-org/esmf/archive/ESMF_8_2_0.tar.gz &> /dev/null
+        tar zxf ESMF_8_2_0.tar.gz
+        cd esmf-ESMF_8_2_0
         if [[ ${{ matrix.mpi_type}} == "mpich" ]]; then
           export ESMF_COMM=mpich3
         elif [[ ${{ matrix.mpi_type}} == "openmpi" ]]; then

--- a/.github/workflows/netcdf-versions.yml
+++ b/.github/workflows/netcdf-versions.yml
@@ -76,16 +76,16 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/esmf
-        key: esmf-8.1.1-${{ runner.os }}-netcdf-${{ matrix.netcdf_version }}3
+        key: esmf-8.2.0-${{ runner.os }}-netcdf-${{ matrix.netcdf_version }}3
 
     - name: build-esmf
       #if: steps.cache-esmf.outputs.cache-hit != 'true'
       run: |
         pushd ~
-        export ESMF_DIR=~/esmf-ESMF_8_1_1
-        wget https://github.com/esmf-org/esmf/archive/ESMF_8_1_1.tar.gz &> /dev/null
-        tar zxf ESMF_8_1_1.tar.gz
-        cd esmf-ESMF_8_1_1
+        export ESMF_DIR=~/esmf-ESMF_8_2_0
+        wget https://github.com/esmf-org/esmf/archive/ESMF_8_2_0.tar.gz &> /dev/null
+        tar zxf ESMF_8_2_0.tar.gz
+        cd esmf-ESMF_8_2_0
         export ESMF_COMM=mpich3
         export ESMF_INSTALL_BINDIR=bin
         export ESMF_INSTALL_LIBDIR=lib

--- a/modulefiles/build.hera.intel.lua
+++ b/modulefiles/build.hera.intel.lua
@@ -61,7 +61,7 @@ load(pathJoin("netcdf", netcdf_ver))
 nccmp_ver=os.getenv("nccmp_ver") or "1.8.7.0"
 load(pathJoin("nccmp", nccmp_ver))
 
-esmf_ver=os.getenv("esmf_ver") or "8_1_1"
+esmf_ver=os.getenv("esmf_ver") or "8_2_0"
 load(pathJoin("esmf", esmf_ver))
 
 whatis("Description: UFS_UTILS build environment")

--- a/modulefiles/build.jet.intel.lua
+++ b/modulefiles/build.jet.intel.lua
@@ -28,7 +28,7 @@ load(pathJoin("netcdf", netcdf_ver))
 nccmp_ver=os.getenv("nccmp_ver") or "1.8.7.0"
 load(pathJoin("nccmp", nccmp_ver))
 
-esmf_ver=os.getenv("esmf_ver") or "8_1_0_beta_snapshot_27"
+esmf_ver=os.getenv("esmf_ver") or "8_2_0"
 load(pathJoin("esmf", esmf_ver))
 
 w3nco_ver=os.getenv("w3nco_ver") or "2.4.1"

--- a/modulefiles/build.orion.intel.lua
+++ b/modulefiles/build.orion.intel.lua
@@ -58,7 +58,7 @@ load(pathJoin("netcdf", netcdf_ver))
 nccmp_ver=os.getenv("nccmp_ver") or "1.8.7.0"
 load(pathJoin("nccmp", nccmp_ver))
 
-esmf_ver=os.getenv("esmf_ver") or "8_1_0_beta_snapshot_27"
+esmf_ver=os.getenv("esmf_ver") or "8_2_0"
 load(pathJoin("esmf", esmf_ver))
 
 whatis("Description: UFS_UTILS build environment")

--- a/modulefiles/build.wcoss_cray.intel
+++ b/modulefiles/build.wcoss_cray.intel
@@ -31,9 +31,7 @@ setenv ZLIB_ROOT /usrx/local/prod/zlib/1.2.7/intel/haswell
 setenv PNG_ROOT /usrx/local/prod/png/1.2.49/intel/haswell
 setenv Jasper_ROOT /usrx/local/prod/jasper/1.900.1/intel/haswell
 
-#module use /gpfs/hps3/emc/nems/noscrub/emc.nemspara/soft/modulefiles
 module load esmf/820
-#setenv ESMFMKFILE /gpfs/hps3/emc/nems/noscrub/emc.nemspara/soft/esmf/8.0.0/lib/esmf.mk
 setenv NETCDF /opt/cray/netcdf/4.3.3.1/INTEL/14.0
 module rm gcc
 module load gcc/6.3.0

--- a/modulefiles/build.wcoss_cray.intel
+++ b/modulefiles/build.wcoss_cray.intel
@@ -31,9 +31,9 @@ setenv ZLIB_ROOT /usrx/local/prod/zlib/1.2.7/intel/haswell
 setenv PNG_ROOT /usrx/local/prod/png/1.2.49/intel/haswell
 setenv Jasper_ROOT /usrx/local/prod/jasper/1.900.1/intel/haswell
 
-module use /gpfs/hps3/emc/nems/noscrub/emc.nemspara/soft/modulefiles
-#module load esmf/8.0.0
-setenv ESMFMKFILE /gpfs/hps3/emc/nems/noscrub/emc.nemspara/soft/esmf/8.0.0/lib/esmf.mk
+#module use /gpfs/hps3/emc/nems/noscrub/emc.nemspara/soft/modulefiles
+module load esmf/820
+#setenv ESMFMKFILE /gpfs/hps3/emc/nems/noscrub/emc.nemspara/soft/esmf/8.0.0/lib/esmf.mk
 setenv NETCDF /opt/cray/netcdf/4.3.3.1/INTEL/14.0
 module rm gcc
 module load gcc/6.3.0

--- a/modulefiles/build.wcoss_dell_p3.intel.lua
+++ b/modulefiles/build.wcoss_dell_p3.intel.lua
@@ -16,7 +16,7 @@ prepend_path("MODULEPATH", "/usrx/local/nceplibs/dev/hpc-stack/libs/hpc-stack/mo
 hpc_ver=os.getenv("hpc_ver") or "1.1.0"
 load(pathJoin("hpc", hpc_ver))
 
-ips_ver=os.getenv("ips_ver") or "18.0.1.163"
+ips_ver=os.getenv("ips_ver") or "18.0.5.274"
 load(pathJoin("hpc-ips", ips_ver))
 
 impi_ver=os.getenv("impi_ver") or "18.0.1"
@@ -34,16 +34,16 @@ load(pathJoin("hdf5", hdf5_ver))
 netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
 load(pathJoin("netcdf", netcdf_ver))
 
-nccmp_ver=os.getenv("nccmp_ver") or "1.8.7.0"
+nccmp_ver=os.getenv("nccmp_ver") or "1.8.9.0"
 load(pathJoin("nccmp", nccmp_ver))
 
-esmf_ver=os.getenv("esmf_ver") or "8_1_0_beta_snapshot_27"
+esmf_ver=os.getenv("esmf_ver") or "8_2_0"
 load(pathJoin("esmf", esmf_ver))
 
 bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 load(pathJoin("bacio", bacio_ver))
 
-g2_ver=os.getenv("g2_ver") or "3.4.1"
+g2_ver=os.getenv("g2_ver") or "3.4.2"
 load(pathJoin("g2", g2_ver))
 
 ip_ver=os.getenv("ip_ver") or "3.3.3"

--- a/tests/chgres_cube/LSanSuppress.supp
+++ b/tests/chgres_cube/LSanSuppress.supp
@@ -1,2 +1,5 @@
 leak:ESMCI
+leak:ESMC
+leak:esmc
 leak:esmf
+leak:std::vector

--- a/tests/sfc_climo_gen/LSanSuppress.supp
+++ b/tests/sfc_climo_gen/LSanSuppress.supp
@@ -1,2 +1,5 @@
 leak:ESMCI
+leak:ESMC
+leak:esmc
 leak:esmf
+leak:std::vector


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Use ESMF 8.2.0 library. Motivation for this change comes from #143.

## TESTS CONDUCTED: 
Consistency tests have been run on all 5 supported platforms for those utilities that are affected by the ESMF library: `chgres_cube` and `grid_gen`. The results are reported [here](https://github.com/ufs-community/UFS_UTILS/issues/621)

## DEPENDENCIES:
None

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #621
Part of #143.
