### PR TITLE
chgres_cube - Call routine 'convert_omega' on all MPI tasks

### DIFF
--- a/sorc/chgres_cube.fd/input_data.F90
+++ b/sorc/chgres_cube.fd/input_data.F90
@@ -2457,6 +2457,7 @@
 !! @author George Gayno NCEP/EMC   
  subroutine read_input_atm_grib2_file(localpet)
 
+ use mpi
  use wgrib2api
  
  use grib2_util, only                   : rh2spfh, rh2spfh_gfs, convert_omega
@@ -2909,6 +2910,8 @@ call read_winds(the_file,inv_file,u_tmp_3d,v_tmp_3d, localpet)
    enddo
  endif
 
+ call mpi_bcast(conv_omega,1,MPI_LOGICAL,0,MPI_COMM_WORLD,rc)
+
  if (localpet == 0) print*,"- CALL FieldScatter FOR INPUT DZDT."
  call ESMF_FieldScatter(dzdt_input_grid, dummy3d, rootpet=0, rc=rc)
  if(ESMF_logFoundError(rcToCheck=rc,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
@@ -3081,7 +3084,7 @@ else
                     farrayPtr=presptr, rc=rc)
   if(ESMF_logFoundError(rcToCheck=rc,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
     call error_handler("IN FieldGet", rc)
-    
+
   call convert_omega(wptr,presptr,tptr,qptr,clb,cub)
   
  endif


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
When using certain GRIB2 data as input, the vertical velocity must be converted from omega to dzdt. This conversion is controlled by the logical 'conv_omega'. However, that logical is not being set on all MPI tasks. As a result, vertical velocity is only being converted on part of the grid.

## TESTS CONDUCTED: 
See #626 for details.

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #626
