### PR TITLE
Update modules on Cheyenne, build.cheyenne.intel

### DIFF
--- a/modulefiles/build.cheyenne.intel
+++ b/modulefiles/build.cheyenne.intel
@@ -4,15 +4,19 @@
 
 module purge
 module load ncarenv/1.3
-module load intel/19.1.1
-module load mpt/2.19
+module load intel/2022.1
+module load mpt/2.25
 module load ncarcompilers/0.5.0
-module load cmake/3.16.4
+module load cmake/3.22.0
 
-module use -a /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v2.0.0/intel-19.1.1/mpt-2.19/modules
+module use -a /glade/work/epicufsrt/GMTB/tools/intel/2022.1/hpc-stack-v1.2.0_6eb6/modulefiles/stack
+module load hpc/1.2.0
+module load hpc-intel/2022.1
+module load hpc-mpt/2.25
+
 
 module load bacio/2.4.1
-module load g2/3.4.1
+module load g2/3.4.3
 module load ip/3.3.3
 module load nemsio/2.5.2
 module load sp/2.3.3
@@ -21,8 +25,7 @@ module load sigio/2.3.2
 
 module load sfcio/1.4.1
 module load netcdf/4.7.4
-
-setenv ESMFMKFILE /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v2.0.0/intel-19.1.1/mpt-2.19/lib64/esmf.mk
+module load esmf/8.3.0b09
 
 setenv CMAKE_C_COMPILER icc
 setenv CMAKE_Fortran_COMPILER ifort


### PR DESCRIPTION
Updating modules used on  Cheyenne, according to the issue reported in 
https://github.com/ufs-community/UFS_UTILS/issues/645
Intel 2022 compiler, mpt/2.25

## DESCRIPTION OF CHANGES: 
Module builds with Intel compilers, module intel/2022.1 
mpt/2.25
cmake/3.22
Needed to update the modules and sync the UFS components on different systems.
Changes in this pull request are for Cheyenne only where the modules in the hpc-stack have been built and could be found in /glade/work/epicufsrt/GMTB/tools/intel/2022.1/hpc-stack-v1.2.0_6eb6/modulefiles/stack
 
Use of ESMFMAKEFILE is replaced by loading the module esmf/8.3.0b09

## TESTS CONDUCTED: 
Test conducted as described in https://github.com/ufs-community/ufs-srweather-app/pull/250

## DEPENDENCIES:
No dependencies, but another PR for the ufs-srweather-model depends on the current update
ufs-community/ufs-srweather-model/pull/250

## DOCUMENTATION:
No need in additional documentation changes

## ISSUE: 
If this PR is resolving or referencing the issue mentioned in #645 issues, in this repository.

## CONTRIBUTORS (optional): 
[EdwardSnyder-NOAA](https://github.com/EdwardSnyder-NOAA) 