### PR TITLE
Move to Intel 2022 on Jet, Hera and Orion

### DIFF
--- a/modulefiles/build.hera.intel.lua
+++ b/modulefiles/build.hera.intel.lua
@@ -10,25 +10,25 @@ load(pathJoin("hpss", hpss_ver))
 
 prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack")
 
-hpc_ver=os.getenv("hpc_ver") or "1.1.0"
+hpc_ver=os.getenv("hpc_ver") or "1.2.0"
 load(pathJoin("hpc", hpc_ver))
 
-hpc_intel_ver=os.getenv("hpc_intel_ver") or "18.0.5.274"
+hpc_intel_ver=os.getenv("hpc_intel_ver") or "2022.1.2"
 load(pathJoin("hpc-intel", hpc_intel_ver))
 
-impi_ver=os.getenv("impi_ver") or "2018.0.4"
+impi_ver=os.getenv("impi_ver") or "2022.1.2"
 load(pathJoin("hpc-impi", impi_ver))
 
 bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 load(pathJoin("bacio", bacio_ver))
 
-g2_ver=os.getenv("g2_ver") or "3.4.3"
+g2_ver=os.getenv("g2_ver") or "3.4.5"
 load(pathJoin("g2", g2_ver))
 
 ip_ver=os.getenv("ip_ver") or "3.3.3"
 load(pathJoin("ip", ip_ver))
 
-nemsio_ver=os.getenv("nemsio_ver") or "2.5.2"
+nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
 load(pathJoin("nemsio", nemsio_ver))
 
 sp_ver=os.getenv("sp_ver") or "2.3.3"
@@ -47,7 +47,7 @@ zlib_ver=os.getenv("zlib_ver") or "1.2.11"
 load(pathJoin("zlib", zlib_ver))
 
 png_ver=os.getenv("png_ver") or "1.6.35"
-load(pathJoin("png", png_ver))
+load(pathJoin("libpng", png_ver))
 
 hdf5_ver=os.getenv("hdf5_ver") or "1.10.6"
 load(pathJoin("hdf5", hdf5_ver))
@@ -55,10 +55,10 @@ load(pathJoin("hdf5", hdf5_ver))
 netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
 load(pathJoin("netcdf", netcdf_ver))
 
-nccmp_ver=os.getenv("nccmp_ver") or "1.8.7.0"
+nccmp_ver=os.getenv("nccmp_ver") or "1.8.9.0"
 load(pathJoin("nccmp", nccmp_ver))
 
-esmf_ver=os.getenv("esmf_ver") or "8_2_0"
+esmf_ver=os.getenv("esmf_ver") or "8.2.1b04"
 load(pathJoin("esmf", esmf_ver))
 
 whatis("Description: UFS_UTILS build environment")

--- a/modulefiles/build.jet.intel.lua
+++ b/modulefiles/build.jet.intel.lua
@@ -10,13 +10,13 @@ load(pathJoin("hpss", hpss_ver))
 
 prepend_path("MODULEPATH", "/lfs4/HFIP/hfv3gfs/nwprod/hpc-stack/libs/modulefiles/stack")
 
-hpc_ver=os.getenv("hpc_ver") or "1.1.0"
+hpc_ver=os.getenv("hpc_ver") or "1.2.0"
 load(pathJoin("hpc", hpc_ver))
 
-hpc_intel_ver=os.getenv("hpc_intel_ver") or "18.0.5.274"
+hpc_intel_ver=os.getenv("hpc_intel_ver") or "2022.1.2"
 load(pathJoin("hpc-intel", hpc_intel_ver))
 
-impi_ver=os.getenv("impi_ver") or "2018.4.274"
+impi_ver=os.getenv("impi_ver") or "2022.1.2"
 load(pathJoin("hpc-impi", impi_ver))
 
 hdf5_ver=os.getenv("hdf5_ver") or "1.10.6"
@@ -25,10 +25,10 @@ load(pathJoin("hdf5", hdf5_ver))
 netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
 load(pathJoin("netcdf", netcdf_ver))
 
-nccmp_ver=os.getenv("nccmp_ver") or "1.8.7.0"
+nccmp_ver=os.getenv("nccmp_ver") or "1.8.9.0"
 load(pathJoin("nccmp", nccmp_ver))
 
-esmf_ver=os.getenv("esmf_ver") or "8_2_0"
+esmf_ver=os.getenv("esmf_ver") or "8.2.0"
 load(pathJoin("esmf", esmf_ver))
 
 w3nco_ver=os.getenv("w3nco_ver") or "2.4.1"
@@ -49,10 +49,10 @@ load(pathJoin("sigio", sigio_ver))
 sfcio_ver=os.getenv("sfcio_ver") or "1.4.1"
 load(pathJoin("sfcio", sfcio_ver))
 
-nemsio_ver=os.getenv("nemsio_ver") or "2.5.2"
+nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
 load(pathJoin("nemsio", nemsio_ver))
 
-g2_ver=os.getenv("g2_ver") or "3.4.3"
+g2_ver=os.getenv("g2_ver") or "3.4.5"
 load(pathJoin("g2", g2_ver))
 
 prod_util_ver=os.getenv("prod_util_ver") or "1.2.2"

--- a/modulefiles/build.orion.intel.lua
+++ b/modulefiles/build.orion.intel.lua
@@ -7,25 +7,25 @@ load(pathJoin("cmake", cmake_ver))
 
 prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack")
 
-hpc_ver=os.getenv("hpc_ver") or "1.1.0"
+hpc_ver=os.getenv("hpc_ver") or "1.2.0"
 load(pathJoin("hpc", hpc_ver))
 
-hpc_intel_ver=os.getenv("hpc_intel_ver") or "2018.4"
+hpc_intel_ver=os.getenv("hpc_intel_ver") or "2022.1.2"
 load(pathJoin("hpc-intel", hpc_intel_ver))
 
-impi_ver=os.getenv("impi_ver") or "2018.4"
+impi_ver=os.getenv("impi_ver") or "2022.1.2"
 load(pathJoin("hpc-impi", impi_ver))
 
 bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 load(pathJoin("bacio", bacio_ver))
 
-g2_ver=os.getenv("g2_ver") or "3.4.3"
+g2_ver=os.getenv("g2_ver") or "3.4.5"
 load(pathJoin("g2", g2_ver))
 
 ip_ver=os.getenv("ip_ver") or "3.3.3"
 load(pathJoin("ip", ip_ver))
 
-nemsio_ver=os.getenv("nemsio_ver") or "2.5.2"
+nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
 load(pathJoin("nemsio", nemsio_ver))
 
 sp_ver=os.getenv("sp_ver") or "2.3.3"
@@ -44,7 +44,7 @@ zlib_ver=os.getenv("zlib_ver") or "1.2.11"
 load(pathJoin("zlib", zlib_ver))
 
 png_ver=os.getenv("png_ver") or "1.6.35"
-load(pathJoin("png", png_ver))
+load(pathJoin("libpng", png_ver))
 
 hdf5_ver=os.getenv("hdf5_ver") or "1.10.6"
 load(pathJoin("hdf5", hdf5_ver))
@@ -52,10 +52,10 @@ load(pathJoin("hdf5", hdf5_ver))
 netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
 load(pathJoin("netcdf", netcdf_ver))
 
-nccmp_ver=os.getenv("nccmp_ver") or "1.8.7.0"
+nccmp_ver=os.getenv("nccmp_ver") or "1.8.9.0"
 load(pathJoin("nccmp", nccmp_ver))
 
-esmf_ver=os.getenv("esmf_ver") or "8_2_0"
+esmf_ver=os.getenv("esmf_ver") or "8.2.0"
 load(pathJoin("esmf", esmf_ver))
 
 whatis("Description: UFS_UTILS build environment")

--- a/sorc/grid_tools.fd/filter_topo.fd/CMakeLists.txt
+++ b/sorc/grid_tools.fd/filter_topo.fd/CMakeLists.txt
@@ -5,7 +5,7 @@ set(exe_src
     filter_topo.F90)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -assume byterecl -real_size 64 -fno-alias -stack_temps -safe_cray_ptr -ftz")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -assume byterecl -real-size 64 -fno-alias -stack-temps -safe-cray-ptr -ftz")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-0 -fdefault-real-8")
 endif()


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Update Hera, Jet and Orion build modules to use Intel 2022 compiler and hpc-stack v1.2.0.
Replace some deprecated compiler flags.

## TESTS CONDUCTED: 
All regression tests passed on Jet, Hera and Orion.

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #634

## CONTRIBUTORS (optional): 
NCEPLIBS team.

