### PR TITLE
Update GDAS Initialization utility for recent HPSS tarball name change

### DIFF
--- a/util/gdas_init/config
+++ b/util/gdas_init/config
@@ -57,7 +57,7 @@ mm=03
 dd=21
 hh=06
 
-use_v16retro=yes
+use_v16retro=no
 
 LEVS=65
 

--- a/util/gdas_init/get_v16.data.sh
+++ b/util/gdas_init/get_v16.data.sh
@@ -4,6 +4,10 @@
 # Retrieve gfs v16 data.  v16 was officially implemented on 12 UTC
 # March 22, 2021.  However, the way the switch over was done,
 # the 'prod' v16 tarballs started March 21, 2021 06Z.
+#
+# Starting at June 27, 2022 00z, the tarball names were changed.
+# Older files had 'prod' in their name. Newer files has 'v16.2'
+# in their name.
 #----------------------------------------------------------------------
 
 bundle=$1
@@ -20,6 +24,23 @@ mm_m6=$(echo $date10_m6 | cut -c5-6)
 dd_m6=$(echo $date10_m6 | cut -c7-8)
 hh_m6=$(echo $date10_m6 | cut -c9-10)
 
+if [ $yy$mm$dd$hh -ge 2022062700 ]; then
+  version="v16.2"
+else
+  version="prod"
+fi
+
+#----------------------------------------------------------------------
+# Account for tarball file name changes starting at
+# June 27, 2022 at 00z.
+#----------------------------------------------------------------------
+
+if [ ${yy_m6}${mm_m6}${dd_m6}${hh_m6} -ge 2022062700 ]; then
+  version_enkf="v16.2"
+else
+  version_enkf="prod"
+fi
+
 #----------------------------------------------------------------------
 # Get the atm and sfc 'anl' netcdf files from the gfs or gdas
 # tarball.
@@ -29,14 +50,10 @@ if [ "$bundle" = "gdas" ] || [ "$bundle" = "gfs" ]; then
 
   if [ "$bundle" = "gdas" ] ; then
     directory=/NCEPPROD/hpssprod/runhistory/rh${yy}/${yy}${mm}/${yy}${mm}${dd}
-    file=com_gfs_prod_gdas.${yy}${mm}${dd}_${hh}.gdas_nc.tar
+    file=com_gfs_${version}_gdas.${yy}${mm}${dd}_${hh}.gdas_nc.tar
   else
     directory=/NCEPPROD/hpssprod/runhistory/rh${yy}/${yy}${mm}/${yy}${mm}${dd}
-    if [ $yy$mm$dd$hh -ge 2022062700 ]; then
-      file=com_gfs_v16.2_gfs.${yy}${mm}${dd}_${hh}.gfs_nca.tar
-    else
-      file=com_gfs_prod_gfs.${yy}${mm}${dd}_${hh}.gfs_nca.tar
-    fi
+    file=com_gfs_${version}_gfs.${yy}${mm}${dd}_${hh}.gfs_nca.tar
   fi
 
   rm -f ./list.hires*
@@ -61,7 +78,7 @@ if [ "$bundle" = "gdas" ] || [ "$bundle" = "gfs" ]; then
   if [ "$bundle" = "gdas" ] ; then
 
     directory=/NCEPPROD/hpssprod/runhistory/rh${yy}/${yy}${mm}/${yy}${mm}${dd}
-    file=com_gfs_prod_gdas.${yy}${mm}${dd}_${hh}.gdas_restart.tar
+    file=com_gfs_${version}_gdas.${yy}${mm}${dd}_${hh}.gdas_restart.tar
 
     htar -xvf $directory/$file ./gdas.${yy}${mm}${dd}/${hh}/atmos/gdas.t${hh}z.abias
     rc=$?
@@ -92,7 +109,7 @@ else
   group=$bundle
 
   directory=/NCEPPROD/hpssprod/runhistory/5year/rh${yy_m6}/${yy_m6}${mm_m6}/${yy_m6}${mm_m6}${dd_m6}
-  file=com_gfs_prod_enkfgdas.${yy_m6}${mm_m6}${dd_m6}_${hh_m6}.enkfgdas_${group}.tar
+  file=com_gfs_${version_enkf}_enkfgdas.${yy_m6}${mm_m6}${dd_m6}_${hh_m6}.enkfgdas_${group}.tar
 
   rm -f ./list*.${group}
   htar -tvf  $directory/$file > ./list1.${group}

--- a/util/gdas_init/get_v16.data.sh
+++ b/util/gdas_init/get_v16.data.sh
@@ -32,7 +32,11 @@ if [ "$bundle" = "gdas" ] || [ "$bundle" = "gfs" ]; then
     file=com_gfs_prod_gdas.${yy}${mm}${dd}_${hh}.gdas_nc.tar
   else
     directory=/NCEPPROD/hpssprod/runhistory/rh${yy}/${yy}${mm}/${yy}${mm}${dd}
-    file=com_gfs_prod_gfs.${yy}${mm}${dd}_${hh}.gfs_nca.tar
+    if [ $yy$mm$dd$hh -ge 2022062700 ]; then
+      file=com_gfs_v16.2_gfs.${yy}${mm}${dd}_${hh}.gfs_nca.tar
+    else
+      file=com_gfs_prod_gfs.${yy}${mm}${dd}_${hh}.gfs_nca.tar
+    fi
   fi
 
   rm -f ./list.hires*


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The names of the HPSS GFS v16 tar balls changed on July 27, 2022/00z. Update utility accordingly.

## TESTS CONDUCTED: 
The utility was tested on Hera for the following dates:
- June 26, 2022/18z (GFS and GDAS)
- June 27, 2022/00z (GFS and GDAS)
- June 27, 2022/06z (GDAS)

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #662.

