### PR TITLE
Increase pull data timeout

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ function(PULL_DATA THE_URL THE_FILE)
       ${CMAKE_CURRENT_BINARY_DIR}/data/${THE_FILE}
       SHOW_PROGRESS
       STATUS status
-      INACTIVITY_TIMEOUT 30
+      INACTIVITY_TIMEOUT 120
       )
     list(GET status 0 status_num)
     if(NOT status_num EQUAL 0 OR NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${THE_FILE}")


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Tests would often fail because the data would not finish transferring before the timeout threshold was reached. That timeout is now increased so data should finish transferring in time.

## TESTS CONDUCTED: 
- [x] cmake tests all pass on Hera for Intel

## DEPENDENCIES:
None

## DOCUMENTATION:
None

## ISSUE: 
Fixes #691

