### PR TITLE
Add WCOSS2 support for tests

### DIFF
--- a/cmake/LibMPI.cmake
+++ b/cmake/LibMPI.cmake
@@ -47,7 +47,9 @@ function (platform_name RETURN_VARIABLE)
 
   # wcoss2
   elseif (SITENAME MATCHES "^along01" OR
-      SITENAME MATCHES "^alogin02")
+      SITENAME MATCHES "^alogin02" OR
+      SITENAME MATCHES "^clogin" OR
+      SITENAME MATCHES "^dlogin")
 
     set (${RETURN_VARIABLE} "wcoss2" PARENT_SCOPE)
 

--- a/cmake/mpiexec.wcoss2
+++ b/cmake/mpiexec.wcoss2
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Arguments:
+#
+#   $1  - Number of MPI Tasks
+#   $2+ - Executable and its arguments
+#
+
+ACCOUNT=GFS-DEV
+QUEUE=dev
+
+NP=$1
+shift
+
+qsub -A $ACCOUNT -q $QUEUE -l select=1:ncpus=$NP:mem=1GB -l place=vscatter -l walltime=00:10:00 $@


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
No mpiexec script to submit jobs had been added to run the test suite on WCOSS2. Now one has been added, and other necessary updates to recognize Cactus and Dogwood have been made.

## TESTS CONDUCTED: 
- [x] All cmake tests pass on Cactus

## DEPENDENCIES:
None

## DOCUMENTATION:
If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files in the docs/source directory as supporting material.

## ISSUE: 
Fixes #690

