### PR TITLE
Fix bug in "link_fixdirs.sh"

### DIFF
--- a/fix/link_fixdirs.sh
+++ b/fix/link_fixdirs.sh
@@ -16,6 +16,8 @@ fi
 if [ $RUN_ENVIR != emc -a $RUN_ENVIR != nco ]; then
     set +x
     echo '***ERROR*** unsupported run environment'
+    echo ' Must choose either "nco" or "emc".'
+    exit 1
 fi
 
 if [ $machine != wcoss2 -a $machine != hera -a $machine != jet -a $machine != orion -a $machine != s4 ]; then
@@ -27,7 +29,7 @@ fi
 
 LINK="ln -fs"
 SLINK="ln -fs"
-[[ $RUN_ENVIR = nco ]] && LINK="cp -rp"
+[[ $RUN_ENVIR = nco ]] && LINK="cp -rpL"
 
 pwd=$(pwd -P)
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Add exit if a bad $RUN_ENVIR is provided to "link_fixdirs.sh".

## TESTS CONDUCTED: 
Tested on Orion by providing a bad $RUN_ENVIR. Script exited with error message.

## DEPENDENCIES:
None

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #700.



