### PR TITLE
New MODIS and STATSGO veg/soil data.

### DIFF
--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -525,16 +525,20 @@ The surface climatological data is located here `./fix/fix_sfc_climo <https://no
       * Global 0.05-degree four component monthly snow-free albedo - snowfree_albedo.4comp.0.05.nc
       * Global 1.0-degree categorical slope type - slope_type.1.0.nc
       * Categorical STATSGO soil type
-             * Global 0.03-degree - soil_type.statsgo.0.03.nc
              * Global 0.05-degree - soil_type.statsgo.0.05.nc
-             * CONUS 0.01-degree - soil_type.statsgo.conus.0.01.nc
+             * Global 0.03-degree - soil_type.statsgo.0.03.nc
+             * CONUS 30 sec - soil_type.statsgo.conus.30s.nc
+             * N Hemis 30 sec - soil_type.statsgo.nh.30s.nc
+             * Global 30 sec - soil_type.statsgo.30s.nc
       * Categorical IGBP vegetation type
-             * MODIS-based global 0.03-degree - vegetation_type.modis.igbp.0.03.nc
              * MODIS-based global 0.05-degree - vegetation_type.modis.igbp.0.05.nc
-             * MODIS-based CONUS 0.01-degree - vegetation_type.modis.igbp.conus.0.01.nc
-             * NESDIS VIIRS-based global 0.03-degree - vegetation_type.viirs.igbp.0.03.nc
-             * NESDIS VIIRS-based global 0.05-degree - vegetation_type.viirs.igbp.0.05.nc
+             * MODIS-based global 0.03-degree - vegetation_type.modis.igbp.0.03.nc
+             * MODIS-based CONUS 30 sec - vegetation_type.modis.igbp.conus.30s.nc
+             * MODIS-based N Hemis 30 sec - vegetation_type.modis.igbp.nh.30s.nc
+             * MODIS-based global 30 sec - vegetation_type.modis.igbp.30s.nc
              * NESDIS VIIRS-based global 0.1-degree - vegetation_type.viirs.igbp.0.1.nc
+             * NESDIS VIIRS-based global 0.05-degree - vegetation_type.viirs.igbp.0.05.nc
+             * NESDIS VIIRS-based global 0.03-degree - vegetation_type.viirs.igbp.0.03.nc
              * NESDIS VIIRS-based CONUS 0.01-degree - vegetation_type.viirs.igbp.conus.0.01.nc
       * Global 0.144-degree monthly vegetation greenness in percent - vegetation_greenness.0.144.nc
 

--- a/driver_scripts/driver_grid.hera.sh
+++ b/driver_scripts/driver_grid.hera.sh
@@ -84,7 +84,9 @@ export veg_type_src="modis.igbp.0.05" #  veg type data.
                                 # For the modis-based data, set to:
                                 # 1) "modis.igbp.0.05" for global 5km data
                                 # 2) "modis.igbp.0.03" for global 3km data
-                                # 3) "modis.igbp.conus.0.01" for regional 1km data
+                                # 3) "modis.igbp.conus.30s" for CONUS 30s data
+                                # 4) "modis.igbp.nh.30s" for N Hemis 30s data
+                                # 5) "modis.igbp.30s" for global 30s data
 
 if [ $gtype = uniform ]; then
   export res=96

--- a/driver_scripts/driver_grid.hera.sh
+++ b/driver_scripts/driver_grid.hera.sh
@@ -52,10 +52,11 @@
 #      x/y grid spacing - "delx/y", and halo.
 #   8) Set working directory - TEMP_DIR - and path to the repository
 #      clone - home_dir.
-#   9) Check settings for 'make_gsl_orog' and 'veg_type_src'
-#      below.
-#  10) Submit script: "sbatch $script".
-#  11) All files will be placed in "out_dir".
+#   9) To use GFS orographic drag suite, set 'make_gsl_orog' to true.
+#  10) Set 'soil_veg_src' and 'veg_type_src' to choose the 
+#      soil type and vegetation type data.
+#  11) Submit script: "sbatch $script".
+#  12) All files will be placed in "out_dir".
 #
 #-----------------------------------------------------------------------
 
@@ -77,16 +78,23 @@ export make_gsl_orog=false     # 'true' if user needs 'oro' files for GSL
                                # orographic drag suite
 export veg_type_src="modis.igbp.0.05" #  veg type data.
                                 # For viirs-based vegetation type data, set to:
-                                # 1) "viirs.igbp.0.05" for global 5km data
-                                # 2) "viirs.igbp.0.1" for global 10km data
-                                # 3) "viirs.igbp.0.03" for global 3km data
+                                # 1) "viirs.igbp.0.05" for global 0.05-deg data
+                                # 2) "viirs.igbp.0.1" for global 0.1-deg data
+                                # 3) "viirs.igbp.0.03" for global 0.03-deg data
                                 # 4) "viirs.igbp.conus.0.01" for regional 1km data
                                 # For the modis-based data, set to:
-                                # 1) "modis.igbp.0.05" for global 5km data
-                                # 2) "modis.igbp.0.03" for global 3km data
+                                # 1) "modis.igbp.0.05" for global 0.05-deg data
+                                # 2) "modis.igbp.0.03" for global 0.03-deg data
                                 # 3) "modis.igbp.conus.30s" for CONUS 30s data
                                 # 4) "modis.igbp.nh.30s" for N Hemis 30s data
                                 # 5) "modis.igbp.30s" for global 30s data
+
+export soil_type_src="statsgo.0.05" #  Soil type data. Choices are:
+                                # 1) "statsgo.0.03" for global 0.03-deg data
+                                # 2) "statsgo.0.05" for global 0.05-deg data
+                                # 3) "statsgo.conus.30s" for CONUS 30s data
+                                # 4) "statsgo.nh.30s" for NH 30s data
+                                # 5) "statsgo.30s" for global 30s data
 
 if [ $gtype = uniform ]; then
   export res=96

--- a/driver_scripts/driver_grid.hera.sh
+++ b/driver_scripts/driver_grid.hera.sh
@@ -52,7 +52,7 @@
 #      x/y grid spacing - "delx/y", and halo.
 #   8) Set working directory - TEMP_DIR - and path to the repository
 #      clone - home_dir.
-#   9) To use GFS orographic drag suite, set 'make_gsl_orog' to true.
+#   9) To use the GSL orographic drag suite, set 'make_gsl_orog' to true.
 #  10) Set 'soil_veg_src' and 'veg_type_src' to choose the 
 #      soil type and vegetation type data.
 #  11) Submit script: "sbatch $script".
@@ -73,9 +73,9 @@ module list
 #-----------------------------------------------------------------------
 
 export gtype=uniform           # 'uniform', 'stretch', 'nest', 
-                               # 'regional_gfdl', 'regional_esg'
-export make_gsl_orog=false     # 'true' if user needs 'oro' files for GSL
-                               # orographic drag suite
+                               # 'regional_gfdl', 'regional_esg'.
+export make_gsl_orog=false     # When 'true' will output 'oro' files for
+                               # the GSL orographic drag suite.
 export veg_type_src="modis.igbp.0.05" #  veg type data.
                                 # For viirs-based vegetation type data, set to:
                                 # 1) "viirs.igbp.0.1" for global 0.10-deg data

--- a/driver_scripts/driver_grid.jet.sh
+++ b/driver_scripts/driver_grid.jet.sh
@@ -53,7 +53,7 @@
 #      x/y grid spacing - "delx/y", and halo.
 #   8) Set working directory - TEMP_DIR - and path to the repository
 #      clone - home_dir.
-#   9) To use GFS orographic drag suite, set 'make_gsl_orog' to true.
+#   9) To use the GSL orographic drag suite, set 'make_gsl_orog' to true.
 #  10) Set 'soil_veg_src' and 'veg_type_src' to choose the
 #      soil type and vegetation type data.
 #  11) Submit script: "sbatch $script".
@@ -74,8 +74,8 @@ module list
 
 export gtype=uniform           # 'uniform', 'stretch', 'nest', 
                                # 'regional_gfdl', 'regional_esg'
-export make_gsl_orog=false     # 'true' if user needs 'oro' files for GSL
-                               # orographic drag suite
+export make_gsl_orog=false     # When 'true' will output 'oro' files for
+                               # the GSL orographic drag suite.
 export veg_type_src="modis.igbp.0.05" #  veg type data.
                                 # For viirs-based vegetation type data, set to:
                                 # 1) "viirs.igbp.0.1" for global 0.10-deg data

--- a/driver_scripts/driver_grid.jet.sh
+++ b/driver_scripts/driver_grid.jet.sh
@@ -53,10 +53,11 @@
 #      x/y grid spacing - "delx/y", and halo.
 #   8) Set working directory - TEMP_DIR - and path to the repository
 #      clone - home_dir.
-#   9) Check settings for 'make_gsl_orog' and 'veg_type_src'
-#      below.
-#  10) Submit script: "sbatch $script".
-#  11) All files will be placed in "out_dir".
+#   9) To use GFS orographic drag suite, set 'make_gsl_orog' to true.
+#  10) Set 'soil_veg_src' and 'veg_type_src' to choose the
+#      soil type and vegetation type data.
+#  11) Submit script: "sbatch $script".
+#  12) All files will be placed in "out_dir".
 #
 #-----------------------------------------------------------------------
 
@@ -77,14 +78,23 @@ export make_gsl_orog=false     # 'true' if user needs 'oro' files for GSL
                                # orographic drag suite
 export veg_type_src="modis.igbp.0.05" #  veg type data.
                                 # For viirs-based vegetation type data, set to:
-                                # 1) "viirs.igbp.0.05" for global 5km data
-                                # 2) "viirs.igbp.0.1" for global 10km data
-                                # 3) "viirs.igbp.0.03" for global 3km data
+                                # 1) "viirs.igbp.0.05" for global 0.05-deg data
+                                # 2) "viirs.igbp.0.1" for global 0.1-deg data
+                                # 3) "viirs.igbp.0.03" for global 0.03-deg data
                                 # 4) "viirs.igbp.conus.0.01" for regional 1km data
                                 # For the modis-based data, set to:
-                                # 1) "modis.igbp.0.05" for global 5km data
-                                # 2) "modis.igbp.0.03" for global 3km data
-                                # 3) "modis.igbp.conus.0.01" for regional 1km data
+                                # 1) "modis.igbp.0.05" for global 0.05-deg data
+                                # 2) "modis.igbp.0.03" for global 0.03-deg data
+                                # 3) "modis.igbp.conus.30s" for CONUS 30s data
+                                # 4) "modis.igbp.nh.30s" for N Hemis 30s data
+                                # 5) "modis.igbp.30s" for global 30s data
+
+export soil_type_src="statsgo.0.05" #  Soil type data. Choices are:
+                                # 1) "statsgo.0.03" for global 0.03-deg data
+                                # 2) "statsgo.0.05" for global 0.05-deg data
+                                # 3) "statsgo.conus.30s" for CONUS 30s data
+                                # 4) "statsgo.nh.30s" for NH 30s data
+                                # 5) "statsgo.30s" for global 30s data
 
 if [ $gtype = uniform ]; then
   export res=96

--- a/driver_scripts/driver_grid.orion.sh
+++ b/driver_scripts/driver_grid.orion.sh
@@ -52,10 +52,11 @@
 #      x/y grid spacing - "delx/y", and halo.
 #   8) Set working directory - TEMP_DIR - and path to the repository
 #      clone - home_dir.
-#   9) Check settings for 'make_gsl_orog' and 'veg_type_src'
-#      below.
-#  10) Submit script: "sbatch $script".
-#  11) All files will be placed in "out_dir".
+#   9) To use GFS orographic drag suite, set 'make_gsl_orog' to true.
+#  10) Set 'soil_veg_src' and 'veg_type_src' to choose the
+#      soil type and vegetation type data.
+#  11) Submit script: "sbatch $script".
+#  12) All files will be placed in "out_dir".
 #
 #-----------------------------------------------------------------------
 
@@ -78,14 +79,23 @@ export make_gsl_orog=false     # 'true' if user needs 'oro' files for GSL
 
 export veg_type_src="modis.igbp.0.05" #  veg type data.
                                 # For viirs-based vegetation type data, set to:
-                                # 1) "viirs.igbp.0.05" for global 5km data
-                                # 2) "viirs.igbp.0.1" for global 10km data
-                                # 3) "viirs.igbp.0.03" for global 3km data
+                                # 1) "viirs.igbp.0.05" for global 0.05-deg data
+                                # 2) "viirs.igbp.0.1" for global 0.1-deg data
+                                # 3) "viirs.igbp.0.03" for global 0.03-deg data
                                 # 4) "viirs.igbp.conus.0.01" for regional 1km data
                                 # For the modis-based data, set to:
-                                # 1) "modis.igbp.0.05" for global 5km data
-                                # 2) "modis.igbp.0.03" for global 3km data
-                                # 3) "modis.igbp.conus.0.01" for regional 1km data
+                                # 1) "modis.igbp.0.05" for global 0.05-deg data
+                                # 2) "modis.igbp.0.03" for global 0.03-deg data
+                                # 3) "modis.igbp.conus.30s" for CONUS 30s data
+                                # 4) "modis.igbp.nh.30s" for N Hemis 30s data
+                                # 5) "modis.igbp.30s" for global 30s data
+
+export soil_type_src="statsgo.0.05" #  Soil type data. Choices are:
+                                # 1) "statsgo.0.03" for global 0.03-deg data
+                                # 2) "statsgo.0.05" for global 0.05-deg data
+                                # 3) "statsgo.conus.30s" for CONUS 30s data
+                                # 4) "statsgo.nh.30s" for NH 30s data
+                                # 5) "statsgo.30s" for global 30s data
 
 if [ $gtype = uniform ]; then
   export res=96

--- a/driver_scripts/driver_grid.orion.sh
+++ b/driver_scripts/driver_grid.orion.sh
@@ -52,7 +52,7 @@
 #      x/y grid spacing - "delx/y", and halo.
 #   8) Set working directory - TEMP_DIR - and path to the repository
 #      clone - home_dir.
-#   9) To use GFS orographic drag suite, set 'make_gsl_orog' to true.
+#   9) To use the GSL orographic drag suite, set 'make_gsl_orog' to true.
 #  10) Set 'soil_veg_src' and 'veg_type_src' to choose the
 #      soil type and vegetation type data.
 #  11) Submit script: "sbatch $script".
@@ -74,8 +74,8 @@ module list
 export gtype=regional_esg      # 'uniform', 'stretch', 'nest', 
                                # 'regional_gfdl', 'regional_esg'
 
-export make_gsl_orog=false     # 'true' if user needs 'oro' files for GSL
-                               # orographic drag suite
+export make_gsl_orog=false    # When 'true' will output 'oro' files for 
+                              # the GSL orographic drag suite.
 
 export veg_type_src="modis.igbp.0.05" #  veg type data.
                                 # For viirs-based vegetation type data, set to:

--- a/driver_scripts/driver_grid.wcoss2.sh
+++ b/driver_scripts/driver_grid.wcoss2.sh
@@ -51,10 +51,11 @@
 #      x/y grid spacing - "delx/y", and halo.
 #   8) Set working directory - TEMP_DIR - and path to the repository
 #      clone - home_dir.
-#   9) Check settings for 'make_gsl_orog' and 'veg_type_src'
-#      below.
-#  10) Submit script: "cat $script | bsub".
-#  11) All files will be placed in "out_dir".
+#   9) To use GFS orographic drag suite, set 'make_gsl_orog' to true.
+#  10) Set 'soil_veg_src' and 'veg_type_src' to choose the
+#      soil type and vegetation type data.
+#  11) Submit script: "qsub $script".
+#  12) All files will be placed in "out_dir".
 #
 #-----------------------------------------------------------------------
 
@@ -75,14 +76,23 @@ export make_gsl_orog=false     # 'true' if user needs 'oro' files for GSL
                                # orographic drag suite
 export veg_type_src="modis.igbp.0.05" #  veg type data.
                                 # For viirs-based vegetation type data, set to:
-                                # 1) "viirs.igbp.0.05" for global 5km data
-                                # 2) "viirs.igbp.0.1" for global 10km data
-                                # 3) "viirs.igbp.0.03" for global 3km data
+                                # 1) "viirs.igbp.0.05" for global 0.05-deg data
+                                # 2) "viirs.igbp.0.1" for global 0.1-deg data
+                                # 3) "viirs.igbp.0.03" for global 0.03-deg data
                                 # 4) "viirs.igbp.conus.0.01" for regional 1km data
                                 # For the modis-based data, set to:
-                                # 1) "modis.igbp.0.05" for global 5km data
-                                # 2) "modis.igbp.0.03" for global 3km data
-                                # 3) "modis.igbp.conus.0.01" for regional 1km data
+                                # 1) "modis.igbp.0.05" for global 0.05-deg data
+                                # 2) "modis.igbp.0.03" for global 0.03-deg data
+                                # 3) "modis.igbp.conus.30s" for CONUS 30s data
+                                # 4) "modis.igbp.nh.30s" for N Hemis 30s data
+                                # 5) "modis.igbp.30s" for global 30s data
+
+export soil_type_src="statsgo.0.05" #  Soil type data. Choices are:
+                                # 1) "statsgo.0.03" for global 0.03-deg data
+                                # 2) "statsgo.0.05" for global 0.05-deg data
+                                # 3) "statsgo.conus.30s" for CONUS 30s data
+                                # 4) "statsgo.nh.30s" for NH 30s data
+                                # 5) "statsgo.30s" for global 30s data
 
 if [ $gtype = uniform ]; then
   export res=96

--- a/driver_scripts/driver_grid.wcoss2.sh
+++ b/driver_scripts/driver_grid.wcoss2.sh
@@ -51,7 +51,7 @@
 #      x/y grid spacing - "delx/y", and halo.
 #   8) Set working directory - TEMP_DIR - and path to the repository
 #      clone - home_dir.
-#   9) To use GFS orographic drag suite, set 'make_gsl_orog' to true.
+#   9) To use the GSL orographic drag suite, set 'make_gsl_orog' to true.
 #  10) Set 'soil_veg_src' and 'veg_type_src' to choose the
 #      soil type and vegetation type data.
 #  11) Submit script: "qsub $script".
@@ -72,8 +72,8 @@ module list
 
 export gtype=regional_esg           # 'uniform', 'stretch', 'nest', 
                                # 'regional_gfdl', 'regional_esg'
-export make_gsl_orog=false     # 'true' if user needs 'oro' files for GSL
-                               # orographic drag suite
+export make_gsl_orog=false     # When 'true' will output 'oro' files for
+                               # the GSL orographic drag suite.
 export veg_type_src="modis.igbp.0.05" #  veg type data.
                                 # For viirs-based vegetation type data, set to:
                                 # 1) "viirs.igbp.0.1" for global 0.10-deg data

--- a/ush/sfc_climo_gen.sh
+++ b/ush/sfc_climo_gen.sh
@@ -23,6 +23,8 @@
 # res                           Resolution of cubed-sphere grid
 # SAVE_DIR                      Directory where output is saved
 # WORK_DIR                      Temporary working directory
+# SOIL_TYPE_FILE                Path/name of input soil type data.
+# VEG_TYPE_FILE                 Path/name of input vegetation type data.
 #-------------------------------------------------------------------------
 
 set -eux
@@ -39,6 +41,8 @@ mosaic_file=${mosaic_file:-$FIX_FV3/C${res}_mosaic.nc}
 HALO=${HALO:-0}
 veg_type_src=${veg_type_src:-"modis.igbp.0.05"}
 VEG_TYPE_FILE=${VEG_TYPE_FILE:-${input_sfc_climo_dir}/vegetation_type.${veg_type_src}.nc}
+soil_type_src=${soil_type_src:-"statsgo.0.05"}
+SOIL_TYPE_FILE=${SOIL_TYPE_FILE:-${input_sfc_climo_dir}/soil_type.${soil_type_src}.nc}
 
 if [ ! -d $SAVE_DIR ]; then
   mkdir -p $SAVE_DIR
@@ -65,7 +69,7 @@ input_substrate_temperature_file="${input_sfc_climo_dir}/substrate_temperature.2
 input_maximum_snow_albedo_file="${input_sfc_climo_dir}/maximum_snow_albedo.0.05.nc"
 input_snowfree_albedo_file="${input_sfc_climo_dir}/snowfree_albedo.4comp.0.05.nc"
 input_slope_type_file="${input_sfc_climo_dir}/slope_type.1.0.nc"
-input_soil_type_file="${input_sfc_climo_dir}/soil_type.statsgo.0.05.nc"
+input_soil_type_file="${SOIL_TYPE_FILE}"
 input_vegetation_type_file="${VEG_TYPE_FILE}"
 input_vegetation_greenness_file="${input_sfc_climo_dir}/vegetation_greenness.0.144.nc"
 mosaic_file_mdl="$mosaic_file"

--- a/util/sfc_climo_gen/run.wcoss2.sh
+++ b/util/sfc_climo_gen/run.wcoss2.sh
@@ -46,15 +46,33 @@ export FIX_FV3=${BASE_DIR}/fix/orog/C${res}
 ##HALO=3
 ##export GRIDTYPE=regional
 
-#-------------------------------------
-# Choose which virrs data to use.
-#-------------------------------------
+#-------------------------------------------------------------
+# Choose which soil type and vegetation type data to use.
+#
+# For viirs-based vegetation type data, set to:
+#   1) "viirs.igbp.0.1" for global 0.1-deg data
+#   2) "viirs.igbp.0.05" for global 0.05-deg data
+#   3) "viirs.igbp.0.03" for global 0.03-deg data
+#   4) "viirs.igbp.conus.0.01" for regional 1km data
+#
+# For the modis-based vegetation data, set to:
+#   1) "modis.igbp.0.05" for global 0.05-deg data
+#   2) "modis.igbp.0.03" for global 0.03-deg data
+#   3) "modis.igbp.conus.30s" for CONUS 30s data
+#   4) "modis.igbp.nh.30s" for N Hemis 30s data
+#   5) "modis.igbp.30s" for global 30s data
+#
+# Soil type data
+#   1) "statsgo.0.05" for global 0.05-deg data
+#   2) "statsgo.0.03" for global 0.03-deg data
+#   3) "statsgo.conus.30s" for CONUS 30s data
+#   4) "statsgo.nh.30s" for NH 30s data
+#   5) "statsgo.30s" for global 30s data
+#-------------------------------------------------------------
 
-export veg_type_src="viirs.igbp.0.05"    # Use global 0.05-degree viirs data
-#export veg_type_src="viirs.igbp.0.1"     # Use global 0.1-degree viirs data
-#export veg_type_src="viirs.igbp.0.03"   # Use global 0.03-degree viirs data
-#export veg_type_src="viirs.igbp.conus.0.01"   # Use CONUS 0.01-degree virrs data. Do not
-                                               # use for global grids.
+export veg_type_src="modis.igbp.0.05"
+
+export soil_type_src="statsgo.0.05"
 
 #-------------------------------------
 # Set working directory and directory where output files will be saved.


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Updates to use the MODIS vegetation data and STATSGO soil data at its full 30-sec resolution. Currently, only coarser resolution versions are available. 

## TESTS CONDUCTED: 
- The grid_gen consistency tests were run on all supported machines and passed as expected.
- A test regional CONUS grid was created (1) using the 30 second data and (2) the 0.05-degree data. The model grid soil and vegetation type compared favorably between the two tests.
- @BenjaminBlake-NOAA did his own independent tests.

For more test details, see #702.

## DEPENDENCIES:
The new data files were pushed to the 'fix' directories on all machines by @KateFriedman-NOAA.

## DOCUMENTATION:
New data sources were added to readthedocs.:
https://georgegayno-noaaufs-utils.readthedocs.io/en/feature-vegsoil30s/ufs_utils.html#id57

## ISSUE: 
Fixes #702

