### PR TITLE
Add to develop branch readme, scripts and code to create bnu soil texture data

### DIFF
--- a/util/bnu_soil_gen/Makefile
+++ b/util/bnu_soil_gen/Makefile
@@ -1,0 +1,10 @@
+#
+
+NETCDF_INC = -I${NETCDF}/include
+NETCDF_LIB = -L${NETCDF}/lib -lnetcdf -lnetcdff
+
+F90 = ifort
+
+soil_fill: soil_fill.f90
+	$(F90) $(FFLAGS) -o $(@) $(NETCDF_INC) soil_fill.f90 $(NETCDF_LIB)
+

--- a/util/bnu_soil_gen/README
+++ b/util/bnu_soil_gen/README
@@ -1,0 +1,144 @@
+
+Steps to create soil texture class dataset from BNU sand/silt/clay data source
+
+All processing scripts and code are run on NOAA hera HPC
+
+=======================================
+
+1. download original sand,silt,clay data from here:
+	http://globalchange.bnu.edu.cn/research/soilw
+
+6 files needed:
+
+CLAY1.nc  SAND1.nc  SILT1.nc
+CLAY2.nc  SAND2.nc  SILT2.nc
+
+documentation: Shangguan, W., Dai, Y., Duan, Q., Liu, B. and Yuan, H., 2014. A Global Soil Data Set for Earth System Modeling. Journal of Advances in Modeling Earth Systems, 6: 249-263 .
+
+data notes: 
+- horizontal resolution is ~global 30", 84N -> 56S
+- vertical resolution: 8 layers to the depth of 2.3 m:
+    0     - 0.045 m
+    0.045 - 0.091 m
+    0.091 - 0.166 m
+    0.166 - 0.289 m
+    0.289 - 0.493 m
+    0.493 - 0.829 m
+    0.829 - 1.383 m
+    1.383 - 2.296 m
+
+store 6 files in a directory named original/
+
+=======================================
+
+2. convert to texture using NCL; based on USDA soil texture triangle
+
+NCL does not handle the large size of this data so the process is split into 30deg x 30deg tiles
+
+The code produces a texture class for layers 0-1m and 1-2m.
+
+create a directory name tiles/
+
+since there is no data at either pole, run three separate scripts:
+
+convert_to_texture.ncl       : create tiles from 30S to 60N
+convert_to_texture_Spole.ncl : create tile  from 30S to 60S
+convert_to_texture_Npole.ncl : create tile  from 60N to 90N
+
+Reduced lat organization in the BNU dataset:
+
+lat(beg) = 83.99578
+lat(end) = -55.99583
+
+That is, centroids of 84N - 56S, i.e., 90N-60N and 30S-60S are only partially covered.
+
+=======================================
+
+3. stitch tiles, fill missing and make consistent with viirs vegetation
+
+fill in missing value with these rules based on VIIRS land:
+
+where land is snow/ice, soil texture = 16
+where water           , soil texture = 14
+
+If missing, search an 11x11 region and use dominant of 12 categories.
+
+If still missing, search a 51x51 region and use dominant of 12 categories.
+
+If still missing, search a 201x201 region and use dominant of 12 categories.
+
+If still missing, set to loam.
+
+fortran code (soil_fill.f90) run on hera with:
+
+module load intel/2022.2.0 netcdf/4.7.0
+make
+./soil_fill
+
+output notes:
+
+ Num missing before fill:      2536964
+ Num missing after fill #1:      61684
+ Num missing after fill #2:      22021
+ Num missing after fill #3:      19103
+ Num missing after filling:          0
+
+The file dataset only uses the 0-1m texture class.
+
+output file will be named bnu_soil.nc
+
+=======================================
+
+4. final formatting to use in ufs_utils
+
+a. create 30s soil file template from viirs vegetation file
+
+cp VEG_LOCATION/vegetation_type.viirs.igbp.30s.nc soil_type.bnu.30s.nc
+
+b. run a bunch of nco commands to get the metadata and naming correct for soil type
+
+ncrename -O -h -v vegetation_type,soil_type soil_type.bnu.30s.nc 
+ncatted -h -a landice_category,soil_type,m,i,16 soil_type.bnu.30s.nc
+ncatted -h -a class_01,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a class_02,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a class_03,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a class_04,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a class_05,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a class_06,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a class_07,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a class_08,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a class_09,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a class_10,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a class_11,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a class_12,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a class_13,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a class_14,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a class_15,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a class_16,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a class_17,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a class_18,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a class_19,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a class_20,soil_type,d,,, soil_type.bnu.30s.nc
+ncatted -h -a source,global,m,c,"BNU SOIL TYPE" soil_type.bnu.30s.nc
+ncatted -h -a description,global,d,,, soil_type.bnu.30s.nc
+ncatted -h -a data_source,global,d,,, soil_type.bnu.30s.nc
+ncatted -h -a primary_developer,global,d,,, soil_type.bnu.30s.nc
+ncatted -h -a developer,global,d,,, soil_type.bnu.30s.nc
+ncatted -h -a nesdis_poc,global,d,,, soil_type.bnu.30s.nc
+ncatted -h -a contributor,global,d,,, soil_type.bnu.30s.nc
+ncatted -h -a primary_documentation,global,d,,, soil_type.bnu.30s.nc
+ncatted -h -a additional_documentation,global,d,,, soil_type.bnu.30s.nc
+ncatted -h -a units,lat,c,c,"degrees_north" soil_type.bnu.30s.nc
+ncatted -h -a units,lon,c,c,"degrees_east" soil_type.bnu.30s.nc
+
+c. replace soil type data from processed file into template file
+
+ncks -A -h -v soil_type bnu_soil.nc soil_type.bnu.30s.nc
+
+d. to save 90+% space compress
+
+ncks -O -h -4 -L 1 soil_type.bnu.30s.nc soil_type.bnu.30s.nc
+
+e. dataset is stored here
+
+hera:/scratch2/NCEPDEV/land/data/input_data/soil_type

--- a/util/bnu_soil_gen/README
+++ b/util/bnu_soil_gen/README
@@ -131,6 +131,19 @@ ncatted -h -a additional_documentation,global,d,,, soil_type.bnu.30s.nc
 ncatted -h -a units,lat,c,c,"degrees_north" soil_type.bnu.30s.nc
 ncatted -h -a units,lon,c,c,"degrees_east" soil_type.bnu.30s.nc
 
+ncatted -h -a class_01,soil_type,c,c,"sand" soil_type.bnu.30s.nc
+ncatted -h -a class_02,soil_type,c,c,"loamy sand" soil_type.bnu.30s.nc
+ncatted -h -a class_03,soil_type,c,c,"sandy loam" soil_type.bnu.30s.nc
+ncatted -h -a class_04,soil_type,c,c,"silt loam" soil_type.bnu.30s.nc
+ncatted -h -a class_05,soil_type,c,c,"silt" soil_type.bnu.30s.nc
+ncatted -h -a class_06,soil_type,c,c,"loam" soil_type.bnu.30s.nc
+ncatted -h -a class_07,soil_type,c,c,"sandy clay loam" soil_type.bnu.30s.nc
+ncatted -h -a class_08,soil_type,c,c,"silty clay loam" soil_type.bnu.30s.nc
+ncatted -h -a class_09,soil_type,c,c,"clay loam" soil_type.bnu.30s.nc
+ncatted -h -a class_10,soil_type,c,c,"sandy clay" soil_type.bnu.30s.nc
+ncatted -h -a class_11,soil_type,c,c,"silty clay" soil_type.bnu.30s.nc
+ncatted -h -a class_12,soil_type,c,c,"clay" soil_type.bnu.30s.nc
+
 c. replace soil type data from processed file into template file
 
 ncks -A -h -v soil_type bnu_soil.nc soil_type.bnu.30s.nc

--- a/util/bnu_soil_gen/convert_to_texture.ncl
+++ b/util/bnu_soil_gen/convert_to_texture.ncl
@@ -1,0 +1,164 @@
+load "$NCARG_ROOT/lib/ncarg/nclex/gsun/gsn_code.ncl"
+load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"
+load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"  
+
+begin
+
+latnames = (/"+60","+30","+00","-30"/)
+lonnames = (/"-180","-150","-120","-090","-060","-030","+000","+030","+060","+090","+120","+150","+180"/)
+wtshal = (/0.045,0.046,0.075,0.123,0.204,0.336,0.171/)
+wtdeep = (/0.383,0.617/)
+
+do ilat = 0,2
+do ilon = 0,11
+
+  latbeg = ilat*30*120 + 24*120
+  latend = ilat*30*120 + 24*120 + 30*120 - 1
+  lonbeg = ilon*30*120
+  lonend = ilon*30*120 + 30*120 - 1
+
+  filename = "lat_"+latnames(ilat)+"_"+latnames(ilat+1)+"_lon_"+lonnames(ilon)+"_"+lonnames(ilon+1)
+  print("Starting: "+filename)
+
+  infile = addfile("original/CLAY1.nc","r")
+    inclay1 = infile->CLAY(0,latbeg:latend,lonbeg:lonend)
+    inclay2 = infile->CLAY(1,latbeg:latend,lonbeg:lonend)
+    inclay3 = infile->CLAY(2,latbeg:latend,lonbeg:lonend)
+    inclay4 = infile->CLAY(3,latbeg:latend,lonbeg:lonend)
+  infile = addfile("original/CLAY2.nc","r")
+    inclay5 = infile->CLAY(0,latbeg:latend,lonbeg:lonend)
+    inclay6 = infile->CLAY(1,latbeg:latend,lonbeg:lonend)
+    inclay7 = infile->CLAY(2,latbeg:latend,lonbeg:lonend)
+    inclay8 = infile->CLAY(3,latbeg:latend,lonbeg:lonend)
+  infile = addfile("original/SAND1.nc","r")
+    insand1 = infile->SAND(0,latbeg:latend,lonbeg:lonend)
+    insand2 = infile->SAND(1,latbeg:latend,lonbeg:lonend)
+    insand3 = infile->SAND(2,latbeg:latend,lonbeg:lonend)
+    insand4 = infile->SAND(3,latbeg:latend,lonbeg:lonend)
+  infile = addfile("original/SAND2.nc","r")
+    insand5 = infile->SAND(0,latbeg:latend,lonbeg:lonend)
+    insand6 = infile->SAND(1,latbeg:latend,lonbeg:lonend)
+    insand7 = infile->SAND(2,latbeg:latend,lonbeg:lonend)
+    insand8 = infile->SAND(3,latbeg:latend,lonbeg:lonend)
+  infile = addfile("original/SILT1.nc","r")
+    insilt1 = infile->SILT(0,latbeg:latend,lonbeg:lonend)
+    insilt2 = infile->SILT(1,latbeg:latend,lonbeg:lonend)
+    insilt3 = infile->SILT(2,latbeg:latend,lonbeg:lonend)
+    insilt4 = infile->SILT(3,latbeg:latend,lonbeg:lonend)
+  infile = addfile("original/SILT2.nc","r")
+    insilt5 = infile->SILT(0,latbeg:latend,lonbeg:lonend)
+    insilt6 = infile->SILT(1,latbeg:latend,lonbeg:lonend)
+    insilt7 = infile->SILT(2,latbeg:latend,lonbeg:lonend)
+    insilt8 = infile->SILT(3,latbeg:latend,lonbeg:lonend)
+
+sand_top = new((/3600,3600/),float)
+silt_top = new((/3600,3600/),float)
+clay_top = new((/3600,3600/),float)
+sand_bot = new((/3600,3600/),float)
+silt_bot = new((/3600,3600/),float)
+clay_bot = new((/3600,3600/),float)
+
+sand_top = wtshal(0) * insand1 + wtshal(1) * insand2 + wtshal(2) * insand3 + wtshal(3) * insand4 + wtshal(4) * insand5 + wtshal(5) * insand6 + wtshal(6) * insand7
+silt_top = wtshal(0) * insilt1 + wtshal(1) * insilt2 + wtshal(2) * insilt3 + wtshal(3) * insilt4 + wtshal(4) * insilt5 + wtshal(5) * insilt6 + wtshal(6) * insilt7
+clay_top = wtshal(0) * inclay1 + wtshal(1) * inclay2 + wtshal(2) * inclay3 + wtshal(3) * inclay4 + wtshal(4) * inclay5 + wtshal(5) * inclay6 + wtshal(6) * inclay7
+
+sand_top = mask(sand_top,sand_top.ge.0.and.sand_top.le.100,True)
+silt_top = mask(silt_top,silt_top.ge.0.and.silt_top.le.100,True)
+clay_top = mask(clay_top,clay_top.ge.0.and.clay_top.le.100,True)
+
+sand_bot = wtdeep(0) * insand7 + wtdeep(1) * insand8
+silt_bot = wtdeep(0) * insilt7 + wtdeep(1) * insilt8
+clay_bot = wtdeep(0) * inclay7 + wtdeep(1) * inclay8
+
+sand_bot = mask(sand_bot,sand_bot.ge.0.and.sand_bot.le.100,True)
+silt_bot = mask(silt_bot,silt_bot.ge.0.and.silt_bot.le.100,True)
+clay_bot = mask(clay_bot,clay_bot.ge.0.and.clay_bot.le.100,True)
+
+soil_texture_top = new((/3600,3600/),integer)
+  soil_texture_top@_FillValue = -999
+soil_texture_bot = new((/3600,3600/),integer)
+  soil_texture_bot@_FillValue = -999
+
+; SOILPARM:1  sand
+
+soil_texture_top = where((silt_top + 1.5*clay_top) .lt. 15, 1, soil_texture_top) 
+soil_texture_bot = where((silt_bot + 1.5*clay_bot) .lt. 15, 1, soil_texture_bot) 
+
+; SOILPARM:2  loamy sand
+
+soil_texture_top = where((silt_top + 1.5*clay_top .ge. 15) .and. (silt_top + 2*clay_top .lt. 30), 2, soil_texture_top)
+soil_texture_bot = where((silt_bot + 1.5*clay_bot .ge. 15) .and. (silt_bot + 2*clay_bot .lt. 30), 2, soil_texture_bot)
+
+; SOILPARM:3  sandy loam
+
+soil_texture_top = where((clay_top .ge. 7 .and. clay_top .lt. 20) .and. (sand_top .gt. 52) .and. ((silt_top + 2*clay_top) .ge. 30) .or. (clay_top .lt. 7 .and. silt_top .lt. 50 .and. (silt_top+2*clay_top).ge.30), 3, soil_texture_top)
+soil_texture_bot = where((clay_bot .ge. 7 .and. clay_bot .lt. 20) .and. (sand_bot .gt. 52) .and. ((silt_bot + 2*clay_bot) .ge. 30) .or. (clay_bot .lt. 7 .and. silt_bot .lt. 50 .and. (silt_bot+2*clay_bot).ge.30), 3, soil_texture_bot)
+
+; SOILPARM:6  loam
+
+soil_texture_top = where((clay_top .ge. 7 .and. clay_top .lt. 27) .and. (silt_top .ge. 28 .and. silt_top .lt. 50) .and. (sand_top .le. 52), 6, soil_texture_top)
+soil_texture_bot = where((clay_bot .ge. 7 .and. clay_bot .lt. 27) .and. (silt_bot .ge. 28 .and. silt_bot .lt. 50) .and. (sand_bot .le. 52), 6, soil_texture_bot)
+
+; SOILPARM:4  silt loam
+
+soil_texture_top = where((silt_top .ge. 50 .and. (clay_top .ge. 12 .and. clay_top .lt. 27)) .or. ((silt_top .ge. 50 .and. silt_top .lt. 80) .and. clay_top .lt. 12), 4, soil_texture_top)
+soil_texture_bot = where((silt_bot .ge. 50 .and. (clay_bot .ge. 12 .and. clay_bot .lt. 27)) .or. ((silt_bot .ge. 50 .and. silt_bot .lt. 80) .and. clay_bot .lt. 12), 4, soil_texture_bot)
+
+; SOILPARM:5  silt
+
+soil_texture_top = where(silt_top .ge. 80 .and. clay_top .lt. 12, 5, soil_texture_top)
+soil_texture_bot = where(silt_bot .ge. 80 .and. clay_bot .lt. 12, 5, soil_texture_bot)
+
+; SOILPARM:7  sandy clay loam
+
+soil_texture_top = where((clay_top .ge. 20 .and. clay_top .lt. 35) .and. (silt_top .lt. 28) .and. (sand_top .gt. 45), 7, soil_texture_top) 
+soil_texture_bot = where((clay_bot .ge. 20 .and. clay_bot .lt. 35) .and. (silt_bot .lt. 28) .and. (sand_bot .gt. 45), 7, soil_texture_bot) 
+
+; SOILPARM:9  clay loam
+
+soil_texture_top = where((clay_top .ge. 27 .and. clay_top .lt. 40) .and. (sand_top .gt. 20 .and. sand_top .le. 45), 9, soil_texture_top)
+soil_texture_bot = where((clay_bot .ge. 27 .and. clay_bot .lt. 40) .and. (sand_bot .gt. 20 .and. sand_bot .le. 45), 9, soil_texture_bot)
+
+; SOILPARM:8  silty clay loam
+
+soil_texture_top = where((clay_top .ge. 27 .and. clay_top .lt. 40) .and. (sand_top  .le. 20), 8, soil_texture_top)
+soil_texture_bot = where((clay_bot .ge. 27 .and. clay_bot .lt. 40) .and. (sand_bot  .le. 20), 8, soil_texture_bot)
+
+; SOILPARM:10 sandy clay
+
+soil_texture_top = where(clay_top .ge. 35 .and. sand_top .gt. 45, 10, soil_texture_top)
+soil_texture_bot = where(clay_bot .ge. 35 .and. sand_bot .gt. 45, 10, soil_texture_bot)
+
+; SOILPARM:11 silty clay
+
+soil_texture_top = where(clay_top .ge. 40 .and. silt_top .ge. 40, 11, soil_texture_top)
+soil_texture_bot = where(clay_bot .ge. 40 .and. silt_bot .ge. 40, 11, soil_texture_bot)
+
+; SOILPARM:12 clay
+
+soil_texture_top = where(clay_top .ge. 40 .and. sand_top .le. 45 .and. silt_top .lt. 40, 12, soil_texture_top)
+soil_texture_bot = where(clay_bot .ge. 40 .and. sand_bot .le. 45 .and. silt_bot .lt. 40, 12, soil_texture_bot)
+
+soil_texture_top = mask(soil_texture_top,soil_texture_top.ge.0,True)
+soil_texture_bot = mask(soil_texture_bot,soil_texture_bot.ge.0,True)
+
+outname = "tiles/"+filename+".nc"
+ system("if [ -e "+outname+" ]; then rm -f "+outname+ ";fi")
+outfile = addfile(outname,"c")
+outfile->soil_texture_top = soil_texture_top(::-1,:)
+outfile->soil_texture_bot = soil_texture_bot(::-1,:)
+
+delete(sand_top)
+delete(silt_top)
+delete(clay_top)
+delete(sand_bot)
+delete(silt_bot)
+delete(clay_bot)
+delete(soil_texture_top)
+delete(soil_texture_bot)
+
+end do
+end do
+
+end
+

--- a/util/bnu_soil_gen/convert_to_texture_Npole.ncl
+++ b/util/bnu_soil_gen/convert_to_texture_Npole.ncl
@@ -1,0 +1,166 @@
+load "$NCARG_ROOT/lib/ncarg/nclex/gsun/gsn_code.ncl"
+load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"
+load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"  
+
+begin
+
+latnames = (/"+90","+60"/)
+lonnames = (/"-180","-150","-120","-090","-060","-030","+000","+030","+060","+090","+120","+150","+180"/)
+wtshal = (/0.045,0.046,0.075,0.123,0.204,0.336,0.171/)
+wtdeep = (/0.383,0.617/)
+
+do ilat = 0,0
+do ilon = 0,11
+
+  latbeg = 0
+  latend = 24*120 - 1   ; original data available to 84N
+  lonbeg = ilon*30*120
+  lonend = ilon*30*120 + 30*120 - 1
+
+  filename = "lat_"+latnames(ilat)+"_"+latnames(ilat+1)+"_lon_"+lonnames(ilon)+"_"+lonnames(ilon+1)
+  print("Starting: "+filename)
+
+  infile = addfile("original/CLAY1.nc","r")
+    inclay1 = infile->CLAY(0,latbeg:latend,lonbeg:lonend)
+    inclay2 = infile->CLAY(1,latbeg:latend,lonbeg:lonend)
+    inclay3 = infile->CLAY(2,latbeg:latend,lonbeg:lonend)
+    inclay4 = infile->CLAY(3,latbeg:latend,lonbeg:lonend)
+  infile = addfile("original/CLAY2.nc","r")
+    inclay5 = infile->CLAY(0,latbeg:latend,lonbeg:lonend)
+    inclay6 = infile->CLAY(1,latbeg:latend,lonbeg:lonend)
+    inclay7 = infile->CLAY(2,latbeg:latend,lonbeg:lonend)
+    inclay8 = infile->CLAY(3,latbeg:latend,lonbeg:lonend)
+  infile = addfile("original/SAND1.nc","r")
+    insand1 = infile->SAND(0,latbeg:latend,lonbeg:lonend)
+    insand2 = infile->SAND(1,latbeg:latend,lonbeg:lonend)
+    insand3 = infile->SAND(2,latbeg:latend,lonbeg:lonend)
+    insand4 = infile->SAND(3,latbeg:latend,lonbeg:lonend)
+  infile = addfile("original/SAND2.nc","r")
+    insand5 = infile->SAND(0,latbeg:latend,lonbeg:lonend)
+    insand6 = infile->SAND(1,latbeg:latend,lonbeg:lonend)
+    insand7 = infile->SAND(2,latbeg:latend,lonbeg:lonend)
+    insand8 = infile->SAND(3,latbeg:latend,lonbeg:lonend)
+  infile = addfile("original/SILT1.nc","r")
+    insilt1 = infile->SILT(0,latbeg:latend,lonbeg:lonend)
+    insilt2 = infile->SILT(1,latbeg:latend,lonbeg:lonend)
+    insilt3 = infile->SILT(2,latbeg:latend,lonbeg:lonend)
+    insilt4 = infile->SILT(3,latbeg:latend,lonbeg:lonend)
+  infile = addfile("original/SILT2.nc","r")
+    insilt5 = infile->SILT(0,latbeg:latend,lonbeg:lonend)
+    insilt6 = infile->SILT(1,latbeg:latend,lonbeg:lonend)
+    insilt7 = infile->SILT(2,latbeg:latend,lonbeg:lonend)
+    insilt8 = infile->SILT(3,latbeg:latend,lonbeg:lonend)
+
+sand_top = new((/3600,3600/),float)
+silt_top = new((/3600,3600/),float)
+clay_top = new((/3600,3600/),float)
+sand_bot = new((/3600,3600/),float)
+silt_bot = new((/3600,3600/),float)
+clay_bot = new((/3600,3600/),float)
+
+; 720 here because 6 (degrees) * 120 (pixels per degree) for 84N - 90N
+
+sand_top(latbeg+720:latend+720,:) = wtshal(0) * insand1 + wtshal(1) * insand2 + wtshal(2) * insand3 + wtshal(3) * insand4 + wtshal(4) * insand5 + wtshal(5) * insand6 + wtshal(6) * insand7
+silt_top(latbeg+720:latend+720,:) = wtshal(0) * insilt1 + wtshal(1) * insilt2 + wtshal(2) * insilt3 + wtshal(3) * insilt4 + wtshal(4) * insilt5 + wtshal(5) * insilt6 + wtshal(6) * insilt7
+clay_top(latbeg+720:latend+720,:) = wtshal(0) * inclay1 + wtshal(1) * inclay2 + wtshal(2) * inclay3 + wtshal(3) * inclay4 + wtshal(4) * inclay5 + wtshal(5) * inclay6 + wtshal(6) * inclay7
+
+sand_top = mask(sand_top,sand_top.ge.0.and.sand_top.le.100,True)
+silt_top = mask(silt_top,silt_top.ge.0.and.silt_top.le.100,True)
+clay_top = mask(clay_top,clay_top.ge.0.and.clay_top.le.100,True)
+
+sand_bot(latbeg+720:latend+720,:) = wtdeep(0) * insand7 + wtdeep(1) * insand8
+silt_bot(latbeg+720:latend+720,:) = wtdeep(0) * insilt7 + wtdeep(1) * insilt8
+clay_bot(latbeg+720:latend+720,:) = wtdeep(0) * inclay7 + wtdeep(1) * inclay8
+
+sand_bot = mask(sand_bot,sand_bot.ge.0.and.sand_bot.le.100,True)
+silt_bot = mask(silt_bot,silt_bot.ge.0.and.silt_bot.le.100,True)
+clay_bot = mask(clay_bot,clay_bot.ge.0.and.clay_bot.le.100,True)
+
+soil_texture_top = new((/3600,3600/),integer)
+  soil_texture_top@_FillValue = -999
+soil_texture_bot = new((/3600,3600/),integer)
+  soil_texture_bot@_FillValue = -999
+
+; SOILPARM:1  sand
+
+soil_texture_top = where((silt_top + 1.5*clay_top) .lt. 15, 1, soil_texture_top) 
+soil_texture_bot = where((silt_bot + 1.5*clay_bot) .lt. 15, 1, soil_texture_bot) 
+
+; SOILPARM:2  loamy sand
+
+soil_texture_top = where((silt_top + 1.5*clay_top .ge. 15) .and. (silt_top + 2*clay_top .lt. 30), 2, soil_texture_top)
+soil_texture_bot = where((silt_bot + 1.5*clay_bot .ge. 15) .and. (silt_bot + 2*clay_bot .lt. 30), 2, soil_texture_bot)
+
+; SOILPARM:3  sandy loam
+
+soil_texture_top = where((clay_top .ge. 7 .and. clay_top .lt. 20) .and. (sand_top .gt. 52) .and. ((silt_top + 2*clay_top) .ge. 30) .or. (clay_top .lt. 7 .and. silt_top .lt. 50 .and. (silt_top+2*clay_top).ge.30), 3, soil_texture_top)
+soil_texture_bot = where((clay_bot .ge. 7 .and. clay_bot .lt. 20) .and. (sand_bot .gt. 52) .and. ((silt_bot + 2*clay_bot) .ge. 30) .or. (clay_bot .lt. 7 .and. silt_bot .lt. 50 .and. (silt_bot+2*clay_bot).ge.30), 3, soil_texture_bot)
+
+; SOILPARM:6  loam
+
+soil_texture_top = where((clay_top .ge. 7 .and. clay_top .lt. 27) .and. (silt_top .ge. 28 .and. silt_top .lt. 50) .and. (sand_top .le. 52), 6, soil_texture_top)
+soil_texture_bot = where((clay_bot .ge. 7 .and. clay_bot .lt. 27) .and. (silt_bot .ge. 28 .and. silt_bot .lt. 50) .and. (sand_bot .le. 52), 6, soil_texture_bot)
+
+; SOILPARM:4  silt loam
+
+soil_texture_top = where((silt_top .ge. 50 .and. (clay_top .ge. 12 .and. clay_top .lt. 27)) .or. ((silt_top .ge. 50 .and. silt_top .lt. 80) .and. clay_top .lt. 12), 4, soil_texture_top)
+soil_texture_bot = where((silt_bot .ge. 50 .and. (clay_bot .ge. 12 .and. clay_bot .lt. 27)) .or. ((silt_bot .ge. 50 .and. silt_bot .lt. 80) .and. clay_bot .lt. 12), 4, soil_texture_bot)
+
+; SOILPARM:5  silt
+
+soil_texture_top = where(silt_top .ge. 80 .and. clay_top .lt. 12, 5, soil_texture_top)
+soil_texture_bot = where(silt_bot .ge. 80 .and. clay_bot .lt. 12, 5, soil_texture_bot)
+
+; SOILPARM:7  sandy clay loam
+
+soil_texture_top = where((clay_top .ge. 20 .and. clay_top .lt. 35) .and. (silt_top .lt. 28) .and. (sand_top .gt. 45), 7, soil_texture_top) 
+soil_texture_bot = where((clay_bot .ge. 20 .and. clay_bot .lt. 35) .and. (silt_bot .lt. 28) .and. (sand_bot .gt. 45), 7, soil_texture_bot) 
+
+; SOILPARM:9  clay loam
+
+soil_texture_top = where((clay_top .ge. 27 .and. clay_top .lt. 40) .and. (sand_top .gt. 20 .and. sand_top .le. 45), 9, soil_texture_top)
+soil_texture_bot = where((clay_bot .ge. 27 .and. clay_bot .lt. 40) .and. (sand_bot .gt. 20 .and. sand_bot .le. 45), 9, soil_texture_bot)
+
+; SOILPARM:8  silty clay loam
+
+soil_texture_top = where((clay_top .ge. 27 .and. clay_top .lt. 40) .and. (sand_top  .le. 20), 8, soil_texture_top)
+soil_texture_bot = where((clay_bot .ge. 27 .and. clay_bot .lt. 40) .and. (sand_bot  .le. 20), 8, soil_texture_bot)
+
+; SOILPARM:10 sandy clay
+
+soil_texture_top = where(clay_top .ge. 35 .and. sand_top .gt. 45, 10, soil_texture_top)
+soil_texture_bot = where(clay_bot .ge. 35 .and. sand_bot .gt. 45, 10, soil_texture_bot)
+
+; SOILPARM:11 silty clay
+
+soil_texture_top = where(clay_top .ge. 40 .and. silt_top .ge. 40, 11, soil_texture_top)
+soil_texture_bot = where(clay_bot .ge. 40 .and. silt_bot .ge. 40, 11, soil_texture_bot)
+
+; SOILPARM:12 clay
+
+soil_texture_top = where(clay_top .ge. 40 .and. sand_top .le. 45 .and. silt_top .lt. 40, 12, soil_texture_top)
+soil_texture_bot = where(clay_bot .ge. 40 .and. sand_bot .le. 45 .and. silt_bot .lt. 40, 12, soil_texture_bot)
+
+soil_texture_top = mask(soil_texture_top,soil_texture_top.ge.0,True)
+soil_texture_bot = mask(soil_texture_bot,soil_texture_bot.ge.0,True)
+
+outname = "tiles/"+filename+".nc"
+ system("if [ -e "+outname+" ]; then rm -f "+outname+ ";fi")
+outfile = addfile(outname,"c")
+outfile->soil_texture_top = soil_texture_top(::-1,:)
+outfile->soil_texture_bot = soil_texture_bot(::-1,:)
+
+delete(sand_top)
+delete(silt_top)
+delete(clay_top)
+delete(sand_bot)
+delete(silt_bot)
+delete(clay_bot)
+delete(soil_texture_top)
+delete(soil_texture_bot)
+
+end do
+end do
+
+end
+

--- a/util/bnu_soil_gen/convert_to_texture_Spole.ncl
+++ b/util/bnu_soil_gen/convert_to_texture_Spole.ncl
@@ -1,0 +1,166 @@
+load "$NCARG_ROOT/lib/ncarg/nclex/gsun/gsn_code.ncl"
+load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"
+load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"  
+
+begin
+
+latnames = (/"-30","-60"/)
+lonnames = (/"-180","-150","-120","-090","-060","-030","+000","+030","+060","+090","+120","+150","+180"/)
+wtshal = (/0.045,0.046,0.075,0.123,0.204,0.336,0.171/)
+wtdeep = (/0.383,0.617/)
+
+do ilat = 0,0
+do ilon = 0,11
+
+  latbeg = 24*120 + 3*30*120 + 0             ; these used for access in global data
+  latend = 24*120 + 3*30*120 + 26*120 - 1
+  latbeg0 = 0                                ; these used for access in 30x30 tile
+  latend0 = 26*120 - 1
+  lonbeg = ilon*30*120
+  lonend = ilon*30*120 + 30*120 - 1
+
+  filename = "lat_"+latnames(ilat)+"_"+latnames(ilat+1)+"_lon_"+lonnames(ilon)+"_"+lonnames(ilon+1)
+  print("Starting: "+filename)
+
+  infile = addfile("original/CLAY1.nc","r")
+    inclay1 = infile->CLAY(0,latbeg:latend,lonbeg:lonend)
+    inclay2 = infile->CLAY(1,latbeg:latend,lonbeg:lonend)
+    inclay3 = infile->CLAY(2,latbeg:latend,lonbeg:lonend)
+    inclay4 = infile->CLAY(3,latbeg:latend,lonbeg:lonend)
+  infile = addfile("original/CLAY2.nc","r")
+    inclay5 = infile->CLAY(0,latbeg:latend,lonbeg:lonend)
+    inclay6 = infile->CLAY(1,latbeg:latend,lonbeg:lonend)
+    inclay7 = infile->CLAY(2,latbeg:latend,lonbeg:lonend)
+    inclay8 = infile->CLAY(3,latbeg:latend,lonbeg:lonend)
+  infile = addfile("original/SAND1.nc","r")
+    insand1 = infile->SAND(0,latbeg:latend,lonbeg:lonend)
+    insand2 = infile->SAND(1,latbeg:latend,lonbeg:lonend)
+    insand3 = infile->SAND(2,latbeg:latend,lonbeg:lonend)
+    insand4 = infile->SAND(3,latbeg:latend,lonbeg:lonend)
+  infile = addfile("original/SAND2.nc","r")
+    insand5 = infile->SAND(0,latbeg:latend,lonbeg:lonend)
+    insand6 = infile->SAND(1,latbeg:latend,lonbeg:lonend)
+    insand7 = infile->SAND(2,latbeg:latend,lonbeg:lonend)
+    insand8 = infile->SAND(3,latbeg:latend,lonbeg:lonend)
+  infile = addfile("original/SILT1.nc","r")
+    insilt1 = infile->SILT(0,latbeg:latend,lonbeg:lonend)
+    insilt2 = infile->SILT(1,latbeg:latend,lonbeg:lonend)
+    insilt3 = infile->SILT(2,latbeg:latend,lonbeg:lonend)
+    insilt4 = infile->SILT(3,latbeg:latend,lonbeg:lonend)
+  infile = addfile("original/SILT2.nc","r")
+    insilt5 = infile->SILT(0,latbeg:latend,lonbeg:lonend)
+    insilt6 = infile->SILT(1,latbeg:latend,lonbeg:lonend)
+    insilt7 = infile->SILT(2,latbeg:latend,lonbeg:lonend)
+    insilt8 = infile->SILT(3,latbeg:latend,lonbeg:lonend)
+
+sand_top = new((/3600,3600/),float)
+silt_top = new((/3600,3600/),float)
+clay_top = new((/3600,3600/),float)
+sand_bot = new((/3600,3600/),float)
+silt_bot = new((/3600,3600/),float)
+clay_bot = new((/3600,3600/),float)
+
+sand_top(latbeg0:latend0,:) = wtshal(0) * insand1 + wtshal(1) * insand2 + wtshal(2) * insand3 + wtshal(3) * insand4 + wtshal(4) * insand5 + wtshal(5) * insand6 + wtshal(6) * insand7
+silt_top(latbeg0:latend0,:) = wtshal(0) * insilt1 + wtshal(1) * insilt2 + wtshal(2) * insilt3 + wtshal(3) * insilt4 + wtshal(4) * insilt5 + wtshal(5) * insilt6 + wtshal(6) * insilt7
+clay_top(latbeg0:latend0,:) = wtshal(0) * inclay1 + wtshal(1) * inclay2 + wtshal(2) * inclay3 + wtshal(3) * inclay4 + wtshal(4) * inclay5 + wtshal(5) * inclay6 + wtshal(6) * inclay7
+
+sand_top = mask(sand_top,sand_top.ge.0.and.sand_top.le.100,True)
+silt_top = mask(silt_top,silt_top.ge.0.and.silt_top.le.100,True)
+clay_top = mask(clay_top,clay_top.ge.0.and.clay_top.le.100,True)
+
+sand_bot(latbeg0:latend0,:) = wtdeep(0) * insand7 + wtdeep(1) * insand8
+silt_bot(latbeg0:latend0,:) = wtdeep(0) * insilt7 + wtdeep(1) * insilt8
+clay_bot(latbeg0:latend0,:) = wtdeep(0) * inclay7 + wtdeep(1) * inclay8
+
+sand_bot = mask(sand_bot,sand_bot.ge.0.and.sand_bot.le.100,True)
+silt_bot = mask(silt_bot,silt_bot.ge.0.and.silt_bot.le.100,True)
+clay_bot = mask(clay_bot,clay_bot.ge.0.and.clay_bot.le.100,True)
+
+soil_texture_top = new((/3600,3600/),integer)
+  soil_texture_top@_FillValue = -999
+soil_texture_bot = new((/3600,3600/),integer)
+  soil_texture_bot@_FillValue = -999
+
+; SOILPARM:1  sand
+
+soil_texture_top = where((silt_top + 1.5*clay_top) .lt. 15, 1, soil_texture_top) 
+soil_texture_bot = where((silt_bot + 1.5*clay_bot) .lt. 15, 1, soil_texture_bot) 
+
+; SOILPARM:2  loamy sand
+
+soil_texture_top = where((silt_top + 1.5*clay_top .ge. 15) .and. (silt_top + 2*clay_top .lt. 30), 2, soil_texture_top)
+soil_texture_bot = where((silt_bot + 1.5*clay_bot .ge. 15) .and. (silt_bot + 2*clay_bot .lt. 30), 2, soil_texture_bot)
+
+; SOILPARM:3  sandy loam
+
+soil_texture_top = where((clay_top .ge. 7 .and. clay_top .lt. 20) .and. (sand_top .gt. 52) .and. ((silt_top + 2*clay_top) .ge. 30) .or. (clay_top .lt. 7 .and. silt_top .lt. 50 .and. (silt_top+2*clay_top).ge.30), 3, soil_texture_top)
+soil_texture_bot = where((clay_bot .ge. 7 .and. clay_bot .lt. 20) .and. (sand_bot .gt. 52) .and. ((silt_bot + 2*clay_bot) .ge. 30) .or. (clay_bot .lt. 7 .and. silt_bot .lt. 50 .and. (silt_bot+2*clay_bot).ge.30), 3, soil_texture_bot)
+
+; SOILPARM:6  loam
+
+soil_texture_top = where((clay_top .ge. 7 .and. clay_top .lt. 27) .and. (silt_top .ge. 28 .and. silt_top .lt. 50) .and. (sand_top .le. 52), 6, soil_texture_top)
+soil_texture_bot = where((clay_bot .ge. 7 .and. clay_bot .lt. 27) .and. (silt_bot .ge. 28 .and. silt_bot .lt. 50) .and. (sand_bot .le. 52), 6, soil_texture_bot)
+
+; SOILPARM:4  silt loam
+
+soil_texture_top = where((silt_top .ge. 50 .and. (clay_top .ge. 12 .and. clay_top .lt. 27)) .or. ((silt_top .ge. 50 .and. silt_top .lt. 80) .and. clay_top .lt. 12), 4, soil_texture_top)
+soil_texture_bot = where((silt_bot .ge. 50 .and. (clay_bot .ge. 12 .and. clay_bot .lt. 27)) .or. ((silt_bot .ge. 50 .and. silt_bot .lt. 80) .and. clay_bot .lt. 12), 4, soil_texture_bot)
+
+; SOILPARM:5  silt
+
+soil_texture_top = where(silt_top .ge. 80 .and. clay_top .lt. 12, 5, soil_texture_top)
+soil_texture_bot = where(silt_bot .ge. 80 .and. clay_bot .lt. 12, 5, soil_texture_bot)
+
+; SOILPARM:7  sandy clay loam
+
+soil_texture_top = where((clay_top .ge. 20 .and. clay_top .lt. 35) .and. (silt_top .lt. 28) .and. (sand_top .gt. 45), 7, soil_texture_top) 
+soil_texture_bot = where((clay_bot .ge. 20 .and. clay_bot .lt. 35) .and. (silt_bot .lt. 28) .and. (sand_bot .gt. 45), 7, soil_texture_bot) 
+
+; SOILPARM:9  clay loam
+
+soil_texture_top = where((clay_top .ge. 27 .and. clay_top .lt. 40) .and. (sand_top .gt. 20 .and. sand_top .le. 45), 9, soil_texture_top)
+soil_texture_bot = where((clay_bot .ge. 27 .and. clay_bot .lt. 40) .and. (sand_bot .gt. 20 .and. sand_bot .le. 45), 9, soil_texture_bot)
+
+; SOILPARM:8  silty clay loam
+
+soil_texture_top = where((clay_top .ge. 27 .and. clay_top .lt. 40) .and. (sand_top  .le. 20), 8, soil_texture_top)
+soil_texture_bot = where((clay_bot .ge. 27 .and. clay_bot .lt. 40) .and. (sand_bot  .le. 20), 8, soil_texture_bot)
+
+; SOILPARM:10 sandy clay
+
+soil_texture_top = where(clay_top .ge. 35 .and. sand_top .gt. 45, 10, soil_texture_top)
+soil_texture_bot = where(clay_bot .ge. 35 .and. sand_bot .gt. 45, 10, soil_texture_bot)
+
+; SOILPARM:11 silty clay
+
+soil_texture_top = where(clay_top .ge. 40 .and. silt_top .ge. 40, 11, soil_texture_top)
+soil_texture_bot = where(clay_bot .ge. 40 .and. silt_bot .ge. 40, 11, soil_texture_bot)
+
+; SOILPARM:12 clay
+
+soil_texture_top = where(clay_top .ge. 40 .and. sand_top .le. 45 .and. silt_top .lt. 40, 12, soil_texture_top)
+soil_texture_bot = where(clay_bot .ge. 40 .and. sand_bot .le. 45 .and. silt_bot .lt. 40, 12, soil_texture_bot)
+
+soil_texture_top = mask(soil_texture_top,soil_texture_top.ge.0,True)
+soil_texture_bot = mask(soil_texture_bot,soil_texture_bot.ge.0,True)
+
+outname = "tiles/"+filename+".nc"
+ system("if [ -e "+outname+" ]; then rm -f "+outname+ ";fi")
+outfile = addfile(outname,"c")
+outfile->soil_texture_top = soil_texture_top(::-1,:)
+outfile->soil_texture_bot = soil_texture_bot(::-1,:)
+
+delete(sand_top)
+delete(silt_top)
+delete(clay_top)
+delete(sand_bot)
+delete(silt_bot)
+delete(clay_bot)
+delete(soil_texture_top)
+delete(soil_texture_bot)
+
+end do
+end do
+
+end
+

--- a/util/bnu_soil_gen/soil_fill.f90
+++ b/util/bnu_soil_gen/soil_fill.f90
@@ -1,0 +1,210 @@
+use netcdf
+implicit none
+
+character*3, parameter  :: level    = "top"  ! top or bot
+integer, parameter      :: numlat   = 21600, numlon   = 43200
+integer, parameter      :: numlatt  = 3600 , numlont  = 3600
+
+integer(kind=1), dimension(:,:), allocatable :: soil_texture, veg_class
+integer,         dimension(numlont,numlatt)  :: insoil
+
+character*3 :: latnames(0:6)  = (/"-90","-60","-30","+00","+30","+60","+90"/)
+character*4 :: lonnames(0:12) = (/"-180","-150","-120","-090","-060","-030", &
+                           "+000","+030","+060","+090","+120","+150","+180"/)
+
+integer :: countmax,countwater,countsnow,countcur,isoil,maxtype,num_missing
+integer :: iret, ncid, varid(2), dimid(3)  ! Variables for NetCDF access
+
+integer(kind=1), parameter :: missing = -9
+integer :: itile,jtile,i,j,imax,imin,jmax,jmin
+character (len=128)  :: filename
+
+allocate(soil_texture(numlon,numlat))
+allocate(veg_class   (numlon,numlat))
+
+do jtile = 0,5     ! 30deg x 30deg tiles
+do itile = 0,11
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! create name for soil files
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+filename = "lat_"//latnames(jtile+1)//"_"//latnames(jtile)//"_lon_"//lonnames(itile)//"_"//lonnames(itile+1)//".nc"
+print*, "Reading: ",trim(filename)
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! read in netcdf soil data
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+if(jtile > 0) then
+
+  iret = nf90_open("tiles/"//trim(filename),NF90_NOWRITE,ncid)
+    if(iret /= nf90_noerr) stop "error opening file"
+  if(level == "top") iret = nf90_inq_varid(ncid,"soil_texture_top",varid(1)) 
+  if(level == "bot") iret = nf90_inq_varid(ncid,"soil_texture_bot",varid(1)) 
+    if(iret /= nf90_noerr) stop "error accessing soil variable"
+
+  iret = nf90_get_var(ncid,varid(1),insoil) 
+    if(iret /= nf90_noerr) stop "error reading soil"
+
+  iret = nf90_close(ncid)
+
+else
+
+  insoil = -9   ! set texture to missing for 60S-90S
+
+end if
+
+where(insoil < 0) insoil = -9
+
+soil_texture(itile*3600+1:(itile+1)*3600,jtile*3600+1:(jtile+1)*3600) = insoil
+
+end do  ! itile loop
+end do  ! jtile loop
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! read in netcdf vegclass data
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+filename = "/scratch2/NCEPDEV/land/data/input_data/vegetation_type/vegetation_type.viirs.igbp.30s.nc"
+print*, "Reading: ",filename
+
+  iret = nf90_open(filename,NF90_NOWRITE,ncid)
+    if(iret /= nf90_noerr) stop "error opening file"
+  iret = nf90_inq_varid(ncid,"vegetation_type",varid(1)) 
+    if(iret /= nf90_noerr) stop "error accessing veg variable"
+
+  iret = nf90_get_var(ncid,varid(1),veg_class,start=(/1,1,1/),count=(/43200,21600,1/)) 
+    if(iret /= nf90_noerr) stop "error reading veg"
+
+  iret = nf90_close(ncid)
+  
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! do some checking
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  where(soil_texture < 0 .and. veg_class == 15) soil_texture = 16  ! set ice to 16
+  where(soil_texture < 0 .and. veg_class == 17) soil_texture = 14  ! set water to 14
+  where(soil_texture < 0 .and. veg_class == -9) soil_texture = 14  ! set water to 14
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! first check 10x10
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  num_missing = count(soil_texture < 0)
+  print *, "Num missing before fill: ", num_missing
+  if(num_missing > 0) then
+    do i = 1,43200
+    do j = 1,21600
+      if(soil_texture(i,j) < 0) then
+       imax = min(i+5,43200)
+       imin = max(i-5,1)
+       jmax = min(j+5,21600)
+       jmin = max(j-5,1)
+       countmax = 0
+       maxtype = -1
+       do isoil = 1,12
+         countcur = count(soil_texture(imin:imax,jmin:jmax) == isoil)
+	 if(countcur > countmax) maxtype = isoil
+	 if(countcur > countmax) countmax = countcur
+       end do
+       if(countmax > 0) soil_texture(i,j) = maxtype
+      end if
+    end do
+    end do
+  end if
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! next check 50x50
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  num_missing = count(soil_texture < 0)
+  print *, "Num missing after fill #1: ", num_missing
+  if(num_missing > 0) then
+    do i = 1,43200
+    do j = 1,21600
+      if(soil_texture(i,j) < 0) then
+       imax = min(i+50,43200)
+       imin = max(i-50,1)
+       jmax = min(j+50,21600)
+       jmin = max(j-50,1)
+       countmax = 0
+       maxtype = -1
+       do isoil = 1,12
+         countcur = count(soil_texture(imin:imax,jmin:jmax) == isoil)
+	 if(countcur > countmax) maxtype = isoil
+	 if(countcur > countmax) countmax = countcur
+       end do
+       if(countmax > 0) soil_texture(i,j) = maxtype
+      end if
+    end do
+    end do
+  end if
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! next check 200x200
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  num_missing = count(soil_texture < 0)
+  print *, "Num missing after fill #2: ", num_missing
+  if(num_missing > 0) then
+    do i = 1,43200
+    do j = 1,21600
+      if(soil_texture(i,j) < 0) then
+       imax = min(i+200,43200)
+       imin = max(i-200,1)
+       jmax = min(j+200,21600)
+       jmin = max(j-200,1)
+       countmax = 0
+       maxtype = -1
+       do isoil = 1,12
+         countcur = count(soil_texture(imin:imax,jmin:jmax) == isoil)
+	 if(countcur > countmax) maxtype = isoil
+	 if(countcur > countmax) countmax = countcur
+       end do
+       if(countmax > 0) soil_texture(i,j) = maxtype
+      end if
+    end do
+    end do
+    print *, "Num missing after fill #3: ",count(soil_texture < 0)
+  end if
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! next just fill with loam type
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  where(soil_texture < 0) soil_texture = 6
+
+  print *, "Num missing after filling: ",count(soil_texture < 0)
+  if(count(soil_texture < 0) > 0) stop "too many missing"
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! for ufs_utils use, set water to missing
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  where(soil_texture == 14) soil_texture = missing
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! write out in netcdf format
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  iret = nf90_create("bnu_soil.nc", NF90_CLOBBER, ncid)
+    if(iret /= nf90_noerr) stop "error creating file"
+
+  iret = nf90_def_dim(ncid, "idim", 43200, dimid(1))
+  iret = nf90_def_dim(ncid, "jdim", 21600, dimid(2))
+  iret = nf90_def_dim(ncid, "time", 1    , dimid(3))
+
+!  iret = nf90_def_var(ncid,  "veg"    , NF90_BYTE, dimid, varid(1))
+  iret = nf90_def_var(ncid,  "soil_type"   , NF90_BYTE, dimid, varid(2))
+      iret = nf90_put_att(ncid, varid(2), "missing_value", missing)
+      iret = nf90_put_att(ncid, varid(2), "landice_category", 16)
+
+  iret = nf90_enddef(ncid)
+
+!  iret = nf90_put_var(ncid, varid(1), veg_class)
+  iret = nf90_put_var(ncid, varid(2), soil_texture, start = (/1,1,1/), count = (/43200,21600,1/))
+  
+  iret = nf90_close(ncid)
+
+end


### PR DESCRIPTION
This PR adds documentation for how to create BNU soil texture class data from the original sand/silt/clay percentages. 

## DESCRIPTION OF CHANGES: 
Add a directory to utils/ that documents the process of creating the BNU soil texture class data. No changes to the main UFS_UTILS code are made.

## TESTS CONDUCTED: 

- @RongqianYang-NOAA tested final product in UFS_UTILS on C96, C384 and C768 grids

## DEPENDENCIES:

None

## DOCUMENTATION:

Documentation specific to the utility added in util/bnu_soil_gen

## ISSUE: 

Related issue #705 


