### PR TITLE
Fix macOS CI workflow

### DIFF
--- a/.github/workflows/linux-mac-nceplibs-mpi.yml
+++ b/.github/workflows/linux-mac-nceplibs-mpi.yml
@@ -45,7 +45,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/mpi
-        key: mpi-${{ matrix.mpi_type }}-${{ runner.os }}-1
+        key: mpi-${{ matrix.mpi_type }}-${{ runner.os }}
 
     - name: build-mpi
       if: steps.cache-mpi.outputs.cache-hit != 'true'
@@ -75,7 +75,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/netcdf
-        key: netcdf-c-${{ matrix.netcdf_version }}-${{ runner.os }}-${{ matrix.mpi_type }}3
+        key: netcdf-c-${{ matrix.netcdf_version }}-${{ runner.os }}-${{ matrix.mpi_type }}-1
 
     - name: build-hdf5
       if: steps.cache-netcdf.outputs.cache-hit != 'true'

--- a/.github/workflows/linux-mac-nceplibs-mpi.yml
+++ b/.github/workflows/linux-mac-nceplibs-mpi.yml
@@ -14,7 +14,7 @@ jobs:
       CXX: g++-9
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-11, ubuntu-latest]
         compiler: [gcc-9]
         nceplibs_version: [develop, 1.4.0]
         mpi_type: [mpich, openmpi]
@@ -29,7 +29,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install libpng-dev
           sudo apt-get install libjpeg-dev
-        elif [[ ${{ matrix.os }} == "macos-latest" ]]; then
+        elif [[ ${{ matrix.os }} == "macos-11" ]]; then
           brew update
           brew install wget
           brew install jpeg-turbo
@@ -39,6 +39,7 @@ jobs:
             sudo ln -sf /usr/local/bin/gfortran-10 /usr/local/bin/gfortran
           fi
         fi
+        python3 -m pip install gcovr
 
     - name: cache-mpi
       id: cache-mpi
@@ -63,7 +64,7 @@ jobs:
           cd openmpi-4.1.1
           if [[ ${{ matrix.os }} == "ubuntu-latest" ]]; then
             ./configure --prefix=$HOME/mpi --enable-mpi-fortran --enable-mpi-cxx
-          elif [[ ${{ matrix.os }} == "macos-latest" ]]; then
+          elif [[ ${{ matrix.os }} == "macos-11" ]]; then
             ./configure --prefix=$HOME/mpi --enable-mpi-fortran --enable-mpi-cxx --enable-two-level-namespace
           fi
           make -j2

--- a/.github/workflows/linux-mac-nceplibs-mpi.yml
+++ b/.github/workflows/linux-mac-nceplibs-mpi.yml
@@ -123,7 +123,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/esmf
-        key: esmf--8.2.0-${{ runner.os }}-${{ matrix.mpi_type }}-netcdf-${{ matrix.netcdf_version }}-1
+        key: esmf--8.2.0-${{ runner.os }}-${{ matrix.mpi_type }}-netcdf-${{ matrix.netcdf_version }}3
 
     - name: build-esmf
       if: steps.cache-esmf.outputs.cache-hit != 'true'
@@ -156,7 +156,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/jasper
-        key: jasper-2.0.25-${{ runner.os }}-1
+        key: jasper-2.0.25-${{ runner.os }}3
 
     - name: build-jasper
       if: steps.cache-jasper.outputs.cache-hit != 'true'
@@ -189,7 +189,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/nceplibs
-        key: nceplibs-${{ matrix.nceplibs_version }}-${{ runner.os }}-${{ matrix.mpi_type }}-${{ hashFiles('nceplibs/hash.txt') }}-1
+        key: nceplibs-${{ matrix.nceplibs_version }}-${{ runner.os }}-${{ matrix.mpi_type }}-${{ hashFiles('nceplibs/hash.txt') }}3
 
     - name: build-nceplibs
       if: steps.cache-nceplibs.outputs.cache-hit != 'true'

--- a/.github/workflows/linux-mac-nceplibs-mpi.yml
+++ b/.github/workflows/linux-mac-nceplibs-mpi.yml
@@ -75,7 +75,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/netcdf
-        key: netcdf-c-${{ matrix.netcdf_version }}-${{ runner.os }}-${{ matrix.mpi_type }}-1
+        key: netcdf-c-${{ matrix.netcdf_version }}-${{ runner.os }}-${{ matrix.mpi_type }}3
 
     - name: build-hdf5
       if: steps.cache-netcdf.outputs.cache-hit != 'true'
@@ -123,7 +123,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/esmf
-        key: esmf--8.2.0-${{ runner.os }}-${{ matrix.mpi_type }}-netcdf-${{ matrix.netcdf_version }}3
+        key: esmf--8.2.0-${{ runner.os }}-${{ matrix.mpi_type }}-netcdf-${{ matrix.netcdf_version }}-1
 
     - name: build-esmf
       if: steps.cache-esmf.outputs.cache-hit != 'true'
@@ -156,7 +156,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/jasper
-        key: jasper-2.0.25-${{ runner.os }}3
+        key: jasper-2.0.25-${{ runner.os }}-1
 
     - name: build-jasper
       if: steps.cache-jasper.outputs.cache-hit != 'true'
@@ -189,7 +189,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/nceplibs
-        key: nceplibs-${{ matrix.nceplibs_version }}-${{ runner.os }}-${{ matrix.mpi_type }}-${{ hashFiles('nceplibs/hash.txt') }}3
+        key: nceplibs-${{ matrix.nceplibs_version }}-${{ runner.os }}-${{ matrix.mpi_type }}-${{ hashFiles('nceplibs/hash.txt') }}-1
 
     - name: build-nceplibs
       if: steps.cache-nceplibs.outputs.cache-hit != 'true'

--- a/.github/workflows/linux-mac-nceplibs-mpi.yml
+++ b/.github/workflows/linux-mac-nceplibs-mpi.yml
@@ -39,7 +39,6 @@ jobs:
             sudo ln -sf /usr/local/bin/gfortran-10 /usr/local/bin/gfortran
           fi
         fi
-        python3 -m pip install gcovr
 
     - name: cache-mpi
       id: cache-mpi

--- a/.github/workflows/linux-mac-nceplibs-mpi.yml
+++ b/.github/workflows/linux-mac-nceplibs-mpi.yml
@@ -45,7 +45,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/mpi
-        key: mpi-${{ matrix.mpi_type }}-${{ runner.os }}
+        key: mpi-${{ matrix.mpi_type }}-${{ runner.os }}-1
 
     - name: build-mpi
       if: steps.cache-mpi.outputs.cache-hit != 'true'


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The macOS workflows are breaking. They were using the macos-latest, but the install of 'gcovr' (used for compute test coverage) started breaking in the last two weeks. Since test coverage is already included in the 'debug-docs-test_coverage.yml' workflow, it was decided to remove 'gcovr'. However, the workflow then started breaking in other locations. (See #712 for details). More work will be needed to get macos-latest to work. As a temporary workaround, a switch was made to use macos-11.

## TESTS CONDUCTED: 
The cache keys were temporarily adjusted to force recompilation of all steps. Everything worked. See:
dd4c2f1, 7041c13, and 9b26862.

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A

## ISSUE: 
Part of #712.

