### PR TITLE
Orog gsl improvements

### DIFF
--- a/sorc/orog_mask_tools.fd/orog_gsl.fd/module_gsl_oro_data_lg_scale.f90
+++ b/sorc/orog_mask_tools.fd/orog_gsl.fd/module_gsl_oro_data_lg_scale.f90
@@ -611,9 +611,15 @@ do j = 1,dimY_FV3
       nu = 0
       nd = 0
       do jj = 1,jj_m
-         do ii = 1,ii_m/2   ! left half of box
-            if ( zs(ii,jj) > zs_mean ) nu = nu + 1
-         end do
+         if(mod(ii_m,2).eq.0.) then
+           do ii = 1,ii_m/2   ! left half of box
+              if ( zs(ii,jj) > zs_mean ) nu = nu + 1
+           end do
+         else
+           do ii = 1,ii_m/2+1   ! left half of box
+              if ( zs(ii,jj) > zs_mean ) nu = nu + 1
+           end do
+         endif
          do ii = ii_m/2 + 1, ii_m  ! right half of box
             if ( zs(ii,jj) > zs_mean ) nd = nd + 1
          end do
@@ -628,11 +634,19 @@ do j = 1,dimY_FV3
       ! OA2 -- orographic asymmetry in South direction
       nu = 0
       nd = 0
-      do jj = 1,jj_m/2   ! bottom half of box
-         do ii = 1,ii_m
-            if ( zs(ii,jj) > zs_mean ) nu = nu + 1
-         end do
-      end do
+      if(mod(jj_m,2).eq.0.) then
+        do jj = 1,jj_m/2   ! bottom half of box
+           do ii = 1,ii_m
+              if ( zs(ii,jj) > zs_mean ) nu = nu + 1
+           end do
+        end do
+      else
+        do jj = 1,jj_m/2+1   ! bottom half of box
+           do ii = 1,ii_m
+              if ( zs(ii,jj) > zs_mean ) nu = nu + 1
+           end do
+        end do
+      endif
       do jj = jj_m/2 + 1,jj_m   ! top half of box
          do ii = 1, ii_m
             if ( zs(ii,jj) > zs_mean ) nd = nd + 1
@@ -651,10 +665,12 @@ do j = 1,dimY_FV3
       ratio = real(jj_m,real_kind)/real(ii_m,real_kind)
       do jj = 1,jj_m
          do ii = 1,ii_m
-            if ( nint(real(ii,real_kind)*ratio) < (jj_m - jj) ) then
+            if ( nint(real(ii,real_kind)*ratio) <= (jj_m - jj + 1) ) then
                ! south-west half of box
                if ( zs(ii,jj) > zs_mean ) nu = nu + 1
-            else      ! north-east half of box
+            endif
+            if ( nint(real(ii,real_kind)*ratio) >= (jj_m - jj + 1) ) then
+               ! north-east half of box
                if ( zs(ii,jj) > zs_mean ) nd = nd + 1
             end if
          end do
@@ -672,10 +688,12 @@ do j = 1,dimY_FV3
       ratio = real(jj_m,real_kind)/real(ii_m,real_kind)
       do jj = 1,jj_m
          do ii = 1,ii_m
-            if ( nint(real(ii,real_kind)*ratio) < jj ) then
+            if ( nint(real(ii,real_kind)*ratio) <= jj ) then
                ! north-west half of box
                if ( zs(ii,jj) > zs_mean ) nu = nu + 1
-            else      ! south-east half of box
+            end if
+            if ( nint(real(ii,real_kind)*ratio) >= jj ) then
+                ! south-east half of box
                if ( zs(ii,jj) > zs_mean ) nd = nd + 1
             end if
          end do

--- a/sorc/orog_mask_tools.fd/orog_gsl.fd/module_gsl_oro_data_sm_scale.f90
+++ b/sorc/orog_mask_tools.fd/orog_gsl.fd/module_gsl_oro_data_sm_scale.f90
@@ -558,9 +558,15 @@ do j = 1,dimY_FV3
       nu = 0
       nd = 0
       do jj = 1,jj_m
-         do ii = 1,ii_m/2   ! left half of box
-            if ( zs(ii,jj) > zs_mean ) nu = nu + 1
-         end do
+         if(mod(ii_m,2).eq.0.) then
+           do ii = 1,ii_m/2   ! left half of box
+              if ( zs(ii,jj) > zs_mean ) nu = nu + 1
+           end do
+         else
+           do ii = 1,ii_m/2+1   ! left half of box
+              if ( zs(ii,jj) > zs_mean ) nu = nu + 1
+           end do
+         endif
          do ii = ii_m/2 + 1, ii_m  ! right half of box
             if ( zs(ii,jj) > zs_mean ) nd = nd + 1
          end do
@@ -575,11 +581,19 @@ do j = 1,dimY_FV3
       ! OA2 -- orographic asymmetry in South direction
       nu = 0
       nd = 0
-      do jj = 1,jj_m/2   ! bottom half of box
-         do ii = 1,ii_m
-            if ( zs(ii,jj) > zs_mean ) nu = nu + 1
-         end do
-      end do
+      if(mod(jj_m,2).eq.0.) then
+        do jj = 1,jj_m/2   ! bottom half of box
+           do ii = 1,ii_m
+              if ( zs(ii,jj) > zs_mean ) nu = nu + 1
+           end do
+        end do
+      else
+        do jj = 1,jj_m/2+1   ! bottom half of box
+           do ii = 1,ii_m
+              if ( zs(ii,jj) > zs_mean ) nu = nu + 1
+           end do
+        end do
+      endif
       do jj = jj_m/2 + 1,jj_m   ! top half of box
          do ii = 1, ii_m
             if ( zs(ii,jj) > zs_mean ) nd = nd + 1
@@ -598,10 +612,12 @@ do j = 1,dimY_FV3
       ratio = real(jj_m,real_kind)/real(ii_m,real_kind)
       do jj = 1,jj_m
          do ii = 1,ii_m
-            if ( nint(real(ii,real_kind)*ratio) < (jj_m - jj) ) then
+            if ( nint(real(ii,real_kind)*ratio) <= (jj_m - jj + 1) ) then
                ! south-west half of box
                if ( zs(ii,jj) > zs_mean ) nu = nu + 1
-            else      ! north-east half of box
+            endif
+            if ( nint(real(ii,real_kind)*ratio) >= (jj_m - jj + 1) ) then
+               ! north-east half of box
                if ( zs(ii,jj) > zs_mean ) nd = nd + 1
             end if
          end do
@@ -619,10 +635,12 @@ do j = 1,dimY_FV3
       ratio = real(jj_m,real_kind)/real(ii_m,real_kind)
       do jj = 1,jj_m
          do ii = 1,ii_m
-            if ( nint(real(ii,real_kind)*ratio) < jj ) then
+            if ( nint(real(ii,real_kind)*ratio) <= jj ) then
                ! north-west half of box
                if ( zs(ii,jj) > zs_mean ) nu = nu + 1
-            else      ! south-east half of box
+            end if
+            if ( nint(real(ii,real_kind)*ratio) >= jj ) then
+                ! south-east half of box
                if ( zs(ii,jj) > zs_mean ) nd = nd + 1
             end if
          end do


### PR DESCRIPTION
[OA3_fixes.pdf](https://github.com/ufs-community/UFS_UTILS/files/10147776/OA3_fixes.pdf)
## DESCRIPTION OF CHANGES: 
The orographic asymmetry (OA) fields generated by orog_gsl have a negative bias, especially for high resolution grids. The issue is that with higher-resolution grids, there are fewer fine-grid (5km spacing for large-scale fields, and 1km for small-scale fields) topographic data points within each model grid cell to use for sampling and determining the statistical properties, such as OA. Songyou Hong (NOAA/PSL) discovered that the cause of the negative bias is due to the case when there are an odd number of fine-grid points along a cardinal direction relative to the model grid cell. The limits of the "do-loops" for OA calculation cause fewer points to be sampled in one-half of the grid cell than the other. Songyou found a fix to this problem, which is to modify the limits of the "do-loops" when there are an odd number of fine-grid points along a cardinal direction so that the number of points in each half of the grid are the same.  Details of the fix are described in issue [#716](https://github.com/ufs-community/UFS_UTILS/issues/716).
Plots of the orographic asymmetry in the South-West direction (OA3) are shown [here](https://github.com/ufs-community/UFS_UTILS/files/10147776/OA3_fixes.pdf).  The old baseline fields show a negative bias (too much blue shading), especially for the "large-scale" field, which uses a coarser sub-grid topographic data set and results in larger sampling error.  The new fields display a more random field, which varies between -1 and 1, which is the desired result.

## TESTS CONDUCTED: 
Contingency tests were run on Hera with the Intel compiler.  The tests were run with the script UFS_UTILS/reg_tests/grid_gen/driver.hera.sh.  All tests passed except for the "REGIONAL GSL GWD TEST", which is expected because this PR changes the baseline results.  The test log "consistency.log05" is on Hera at:
/scratch1/BMC/wrfruc/mtoy/git_local/UFS_UTILS/reg_tests/grid_gen

The differences from the baseline were only due to the "OA1,OA2,OA3,OA4" variables, as expected.  The following lines from "consistency.log05 show this:
+ /scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/intel-2022.1.2/nccmp/1.8.9.0/bin/nccmp -dmfqS C772_oro_data_ls.tile7.halo0.nc /scratch1/NCEPDEV/nems/role.ufsutils/ufs_utils/reg_tests/grid_gen/baseline_data/regional.gsl.gwd/C772_oro_data_ls.tile7.halo0.nc
Variable Group Count     Sum  AbsSum       Min Max    Range     Mean   StdDev
oa1      /     21981 8205.24 8205.24 0.0357143   1 0.964286 0.373288 0.165789
oa2      /     37232 13395.9 13395.9  0.047619   1 0.952381 0.359795 0.153006
oa3      /     49106 42914.1 42914.1  0.178571   2  1.82143 0.873908 0.268177
oa4      /     47601 18064.9 18064.9 0.0357143   1 0.964286 0.379508 0.179291

+ /scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/intel-2022.1.2/nccmp/1.8.9.0/bin/nccmp -dmfqS C772_oro_data_ss.tile7.halo0.nc /scratch1/NCEPDEV/nems/role.ufsutils/ufs_utils/reg_tests/grid_gen/baseline_data/regional.gsl.gwd/C772_oro_data_ss.tile7.halo0.nc
Variable Group Count     Sum  AbsSum         Min      Max    Range      Mean    StdDev
oa1      /     21914 1305.27 1305.27 0.000137746 0.236949 0.236811 0.0595634 0.0332465
oa2      /       794 62.2958 62.2958 0.000238895 0.198674 0.198435 0.0784582 0.0375766
oa3      /     48203 10020.6 10020.6 0.000925064 0.675325   0.6744  0.207883 0.0718323
oa4      /     48157    3474    3474 0.000163794 0.302521 0.302357  0.072139 0.0354685

The new baselines are on Hera at:
/scratch1/NCEPDEV/nems/role.ufsutils/ufs_utils/reg_tests/grid_gen/baseline_data/regional.gsl.gwd/C772_oro_data_ls.tile7.halo0.nc
and
/scratch1/NCEPDEV/nems/role.ufsutils/ufs_utils/reg_tests/grid_gen/baseline_data/regional.gsl.gwd/C772_oro_data_ss.tile7.halo0.nc



## DEPENDENCIES:
None

## DOCUMENTATION:
N/A

## ISSUE: 
This PR fixes issue [#716](https://github.com/ufs-community/UFS_UTILS/issues/716).

## CONTRIBUTORS: 
Thank you to Songyou Hong (songyou.hong@noaa.gov) (NOAA/PSL) for contributing the code fix.

