### PR TITLE
Point to new input orography directory.

### DIFF
--- a/fix/link_fixdirs.sh
+++ b/fix/link_fixdirs.sh
@@ -43,7 +43,7 @@ elif [ $machine = "jet" ]; then
 elif [ $machine = "orion" ]; then
     FIX_DIR="/work/noaa/global/glopara/fix"
 elif [ $machine = "wcoss2" ]; then
-    FIX_DIR="/lfs/h2/emc/global/save/emc.global/FIX/fix"
+    FIX_DIR="/lfs/h2/emc/global/noscrub/emc.global/FIX/fix"
 elif [ $machine = "s4" ]; then
     FIX_DIR="/data/prod/glopara/fix"
 fi

--- a/fix/link_fixdirs.sh
+++ b/fix/link_fixdirs.sh
@@ -52,13 +52,17 @@ am_ver=${am_ver:-20220805}
 orog_ver=${orog_ver:-20220805}
 sfc_climo_ver=${sfc_climo_ver:-20221017}
 
-for dir in am orog sfc_climo; do
+for dir in am orog orog_raw sfc_climo; do
     if [ -d $dir ]; then
       [[ $RUN_ENVIR = nco ]] && chmod -R 755 $dir
       rm -rf $dir
     fi
-    fix_ver="${dir}_ver"
-    $LINK $FIX_DIR/$dir/${!fix_ver} ${dir}
+    if [ $dir = "orog_raw" ]; then
+      $LINK $FIX_DIR/raw/orog ${dir}
+    else
+      fix_ver="${dir}_ver"
+      $LINK $FIX_DIR/$dir/${!fix_ver} ${dir}
+    fi
 done
 
 exit 0

--- a/ush/fv3gfs_driver_grid.sh
+++ b/ush/fv3gfs_driver_grid.sh
@@ -102,7 +102,7 @@ export out_dir=${out_dir:?}
 export home_dir=${home_dir:-"$PWD/../"}
 export script_dir=$home_dir/ush
 export exec_dir=${exec_dir:-"$home_dir/exec"}
-export topo=$home_dir/fix/orog
+export topo=$home_dir/fix/orog_raw
 
 export NCDUMP=${NCDUMP:-ncdump}
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The 'fix' data required by the grid generation programs is moving to a new directory. This requires some minor script updates.

## TESTS CONDUCTED: 
The new 'fix' directory structure was created under my own space of Cactus. The grid generation driver script was successfully run. And all repository consistency tests were successfully run. See the comments for more details.

## DEPENDENCIES:
Coordinate with @KateFriedman-NOAA, who maintains the 'fix' directories.

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #757.

