### PR TITLE
Update the GDAS init utility for the new enkf directory

### DIFF
--- a/util/gdas_init/run_pre-v14.chgres.sh
+++ b/util/gdas_init/run_pre-v14.chgres.sh
@@ -31,7 +31,7 @@ else
   CTAR=${CRES_ENKF}
   INPUT_DATA_DIR="${EXTRACT_DIR}/enkf.${yy}${mm}${dd}/${hh}/mem${MEMBER}"
   RADSTAT_DATA_DIR="${EXTRACT_DIR}/enkf.${yy}${mm}${dd}/${hh}/mem${MEMBER}"
-  OUTDIR=$OUTDIR/enkfgdas.${yy}${mm}${dd}/${hh}/atmos/mem${MEMBER}
+  OUTDIR=$OUTDIR/enkfgdas.${yy}${mm}${dd}/${hh}/mem${MEMBER}/atmos
   ATMFILE="siganl_${yy}${mm}${dd}${hh}_mem${MEMBER}"
   SFCFILE="sfcanl_${yy}${mm}${dd}${hh}_mem${MEMBER}"
 fi

--- a/util/gdas_init/run_v14.chgres.sh
+++ b/util/gdas_init/run_v14.chgres.sh
@@ -26,7 +26,7 @@ else
   CTAR=${CRES_ENKF}
   INPUT_DATA_DIR="${EXTRACT_DIR}/enkf.${yy}${mm}${dd}/${hh}/mem${MEMBER}"
   RADSTAT_DATA_DIR="${EXTRACT_DIR}/enkf.${yy}${mm}${dd}/${hh}/mem${MEMBER}"
-  OUTDIR=$OUTDIR/enkfgdas.${yy}${mm}${dd}/${hh}/atmos/mem${MEMBER}
+  OUTDIR=$OUTDIR/enkfgdas.${yy}${mm}${dd}/${hh}/mem${MEMBER}/atmos
   ATMFILE="gdas.t${hh}z.ratmanl.mem${MEMBER}.nemsio"
   SFCFILE="gdas.t${hh}z.sfcanl.mem${MEMBER}.nemsio"
   NSTFILE="gdas.t${hh}z.nstanl.mem${MEMBER}.nemsio"

--- a/util/gdas_init/run_v15.chgres.sh
+++ b/util/gdas_init/run_v15.chgres.sh
@@ -33,7 +33,7 @@ else
   CTAR=${CRES_ENKF}
   INPUT_DATA_DIR="${EXTRACT_DIR}/enkfgdas.${yy_d}${mm_d}${dd_d}/${hh_d}/mem${MEMBER}/RESTART"
   RADSTAT_DATA_DIR="${EXTRACT_DIR}/enkfgdas.${yy}${mm}${dd}/${hh}/mem${MEMBER}"
-  OUTDIR=$OUTDIR/enkfgdas.${yy}${mm}${dd}/${hh}/atmos/mem${MEMBER}
+  OUTDIR=$OUTDIR/enkfgdas.${yy}${mm}${dd}/${hh}/mem${MEMBER}/atmos
 fi
 
 rm -fr $WORKDIR

--- a/util/gdas_init/run_v16.chgres.sh
+++ b/util/gdas_init/run_v16.chgres.sh
@@ -98,7 +98,7 @@ if [ ${MEMBER} == 'gdas' ] || [ ${MEMBER} == 'gfs' ]; then
     cp ${INPUT_DATA_DIR}/*radstat $SAVEDIR/..
   fi
 else  
-  SAVEDIR=$OUTDIR/enkfgdas.${yy}${mm}${dd}/${hh}/atmos/mem${MEMBER}/INPUT
+  SAVEDIR=$OUTDIR/enkfgdas.${yy}${mm}${dd}/${hh}/mem${MEMBER}/atmos/INPUT
   copy_data
   touch $SAVEDIR/../enkfgdas.t${hh}z.loginc.txt
 fi

--- a/util/gdas_init/run_v16retro.chgres.sh
+++ b/util/gdas_init/run_v16retro.chgres.sh
@@ -116,7 +116,7 @@ else
   else
     MEMBER_CH="0${MEMBER}"
   fi
-  SAVEDIR=$OUTDIR/enkfgdas.${yy}${mm}${dd}/${hh}/atmos/mem${MEMBER_CH}/INPUT
+  SAVEDIR=$OUTDIR/enkfgdas.${yy}${mm}${dd}/${hh}/mem${MEMBER_CH}/atmos/INPUT
   copy_data
   touch $SAVEDIR/../enkfgdas.t${hh}z.loginc.txt
   MEMBER=$(( $MEMBER + 1 ))


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Update the chgres run scripts for the new ENKF output directory path.

## TESTS CONDUCTED: 
Tested on Hera for the following cases:

- 2017071900 (GFS v13)
- 2019061100 (GFS v14)
- 2021032000 (GFS v15)
- 2023012400 (GFS v16)
- 2021031900 (GFS v16 retro)

@DavidHuber-NOAA Did his own tests. See #762.

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #762