### PR TITLE
Develop: chgres_cube -- duplicate vertical levels now causes a quit with error 

### DIFF
--- a/sorc/chgres_cube.fd/atm_input_data.F90
+++ b/sorc/chgres_cube.fd/atm_input_data.F90
@@ -2154,13 +2154,19 @@ implicit none
 
  call quicksort(rlevs,1,lev_input)
 
- do i = 1, lev_input
+ do i = 1, lev_input     
    if (isnative) then
      write(slevs(i), '(i6)') nint(rlevs(i))
      slevs(i) = trim(slevs(i)) // " hybrid"
+     if (i>1) then
+       if (any(slevs(1:i-1)==slevs(i))) call error_handler("Duplicate vertical level entries found.",1)
+     endif
    else
      write(slevs(i), '(f11.2)') rlevs(i)
      slevs(i) = trim(slevs(i)) // " Pa"
+     if (i>1) then
+       if (any(slevs(1:i-1)==slevs(i))) call error_handler("Duplicate vertical level entries found.",1)
+     endif
    endif
  enddo
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
chgres_cube processing of atmospheric data will now quit with an informative error if duplicate vertical levels ate detected in the input file.

## TESTS CONDUCTED: 
All consistency tests pass on Hera. Unit tests and Github actions pass. 

No changes to baselines needed.

## DEPENDENCIES:
N/A

## DOCUMENTATION:
No changes to documentation needed.

## ISSUE: 
Addresses #763 

