### PR TITLE
Use new ESMF v8.4.1 library on WCOSS2.

### DIFF
--- a/modulefiles/build.wcoss2.intel.lua
+++ b/modulefiles/build.wcoss2.intel.lua
@@ -69,10 +69,8 @@ load(pathJoin("gsl", gsl_ver))
 nco_ver=os.getenv("nco_ver") or "4.9.7"
 load(pathJoin("nco", nco_ver))
 
-setenv("HPC_OPT","/apps/ops/para/libs")
-prepend_path("MODULEPATH", "/apps/ops/para/libs/modulefiles/compiler/intel/19.1.3.304")
-prepend_path("MODULEPATH", "/apps/ops/para/libs/modulefiles/mpi/intel/19.1.3.304/cray-mpich/8.1.7")
-esmf_ver=os.getenv("esmf_ver") or "8.4.0b08"
+prepend_path("MODULEPATH", "/apps/dev/lmodules/intel_cray_mpich/19.1.3.304/cray-mpich/8.1.4")
+esmf_ver=os.getenv("esmf_ver") or "8.4.1"
 load(pathJoin("esmf", esmf_ver))
 
 whatis("Description: UFS_UTILS build environment")


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Update the WCOSS2 build module to load ESMF v8.4.1.

## TESTS CONDUCTED: 
All consistency tests were run on Cactus and passed.

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #798.

