### PR TITLE
Revert length of 'mosaic_name' in make_solo_mosaic.c

### DIFF
--- a/sorc/fre-nctools.fd/tools/make_solo_mosaic/make_solo_mosaic.c
+++ b/sorc/fre-nctools.fd/tools/make_solo_mosaic/make_solo_mosaic.c
@@ -81,7 +81,7 @@ int main (int argc, char *argv[])
   int contact_tile1_jstart[MAXCONTACT], contact_tile1_jend[MAXCONTACT];
   int contact_tile2_istart[MAXCONTACT], contact_tile2_iend[MAXCONTACT];
   int contact_tile2_jstart[MAXCONTACT], contact_tile2_jend[MAXCONTACT];
-  char mosaic_name[128] = "solo_mosaic";
+  char mosaic_name[STRING] = "solo_mosaic";
   char grid_descriptor[128] = "";
   int c, i, n, m, l, errflg;
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Revert length of character variable 'mosaic_name' in make_solo_mosaic.c to its previous value (before 6af8f1a).

## TESTS CONDUCTED: 

- [x] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera and WCOSS2).
- [x] Compile branch on Hera using GNU.
- [x] Compile branch in 'Debug' mode on WCOSS2.
- [x] Run unit tests locally on any Tier 1 machine.
- [x] Run grid_gen consistency tests locally on all Tier 1 machine.

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #823.
