### PR TITLE
Updates required to build using ufs_utils on NOAA CSP AWS PW.

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -10,6 +10,7 @@ set -eux
 
 target=${target:-"NULL"}
 compiler=${compiler:-"intel"}
+PW_CSP=${PW_CSP:-} # TODO: This is an implementation from EPIC and consistent with the UFS WM build system.
 export MOD_PATH
 
 if [[ "$target" == "linux.*" || "$target" == "macosx.*" ]]; then
@@ -17,6 +18,15 @@ if [[ "$target" == "linux.*" || "$target" == "macosx.*" ]]; then
  set +x
  source ./modulefiles/build.$target > /dev/null
  set -x
+#TODO: This will need to be revisited once the EPIC supported-stacks come online.
+elif [[ "${PW_CSP}" == "aws" ]]; then
+  module use /contrib/global-workflow/spack-stack/envs/ufsutils/install/modulefiles/Core
+  module load stack-intel
+  module load stack-intel-oneapi-mpi
+  module use ./modulefiles
+  module load build.noaacloud.intel
+  module list
+  set -x
 else
  set +x
  source ./sorc/machine-setup.sh

--- a/build_all.sh
+++ b/build_all.sh
@@ -18,20 +18,16 @@ if [[ "$target" == "linux.*" || "$target" == "macosx.*" ]]; then
  set +x
  source ./modulefiles/build.$target > /dev/null
  set -x
-#TODO: This will need to be revisited once the EPIC supported-stacks come online.
-#elif [[ "${target}" == "noaacloud" ]]; then
-#  set +x
-#  module use /contrib/global-workflow/spack-stack/envs/ufsutils/install/modulefiles/Core
-#  module load stack-intel
-#  module load stack-intel-oneapi-mpi
-#  module use ./modulefiles
-#  module load build.noaacloud.intel
-#  module list
-#  set -x
 else
  set +x
  source ./sorc/machine-setup.sh
- module use ./modulefiles
+ if [[ "${target}" == "noaacloud" ]]; then
+  #TODO: This will need to be revisited once the EPIC supported-stacks come online.
+  #TODO: This is a hack due to how the spack-stack module files are generated; there may be a better way to do this.
+  source /contrib/global-workflow/spack-stack/envs/spack_2021.0.3.env
+ else
+  module use ./modulefiles
+ fi
  module load build.$target.$compiler > /dev/null
  module list
  set -x

--- a/build_all.sh
+++ b/build_all.sh
@@ -19,14 +19,15 @@ if [[ "$target" == "linux.*" || "$target" == "macosx.*" ]]; then
  source ./modulefiles/build.$target > /dev/null
  set -x
 #TODO: This will need to be revisited once the EPIC supported-stacks come online.
-elif [[ "${PW_CSP}" == "aws" ]]; then
-  module use /contrib/global-workflow/spack-stack/envs/ufsutils/install/modulefiles/Core
-  module load stack-intel
-  module load stack-intel-oneapi-mpi
-  module use ./modulefiles
-  module load build.noaacloud.intel
-  module list
-  set -x
+#elif [[ "${target}" == "noaacloud" ]]; then
+#  set +x
+#  module use /contrib/global-workflow/spack-stack/envs/ufsutils/install/modulefiles/Core
+#  module load stack-intel
+#  module load stack-intel-oneapi-mpi
+#  module use ./modulefiles
+#  module load build.noaacloud.intel
+#  module list
+#  set -x
 else
  set +x
  source ./sorc/machine-setup.sh

--- a/modulefiles/build.noaacloud.intel.lua
+++ b/modulefiles/build.noaacloud.intel.lua
@@ -1,5 +1,5 @@
 help([[ 
-Load environment to compile UFS_UTILS on NOAA CSP using Intel
+Load environment to compile UFS_UTILS on NOAA CSPs using Intel
 ]])
 
 cmake_ver=os.getenv("cmake_ver") or "3.16.1"

--- a/modulefiles/build.noaacloud.intel.lua
+++ b/modulefiles/build.noaacloud.intel.lua
@@ -13,6 +13,9 @@ load(pathJoin("intel", hpc_intel_ver))
 impi_ver=os.getenv("impi_ver") or "2021.3.0"
 load(pathJoin("impi", impi_ver))
 
+module load stack-intel
+module load stack-intel-oneapi-mpi
+
 bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 load(pathJoin("bacio", bacio_ver))
 

--- a/modulefiles/build.noaacloud.intel.lua
+++ b/modulefiles/build.noaacloud.intel.lua
@@ -5,19 +5,11 @@ Load environment to compile UFS_UTILS on NOAA CSPs using Intel
 cmake_ver=os.getenv("cmake_ver") or "3.16.1"
 load(pathJoin("cmake", cmake_ver))
 
-prepend_path("MODULEPATH", "/contrib/global-workflow/spack-stack/envs/ufsutils/install/modulefiles/Core")
--- load(pathJoin("intel", "2021.3.0"))
--- load(path
-
-
 hpc_intel_ver=os.getenv("hpc_intel_ver") or "2021.3.0"
 load(pathJoin("intel", hpc_intel_ver))
 
 impi_ver=os.getenv("impi_ver") or "2021.3.0"
 load(pathJoin("impi", impi_ver))
-
--- module load stack-intel
--- module load stack-intel-oneapi-mpi
 
 bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 load(pathJoin("bacio", bacio_ver))

--- a/modulefiles/build.noaacloud.intel.lua
+++ b/modulefiles/build.noaacloud.intel.lua
@@ -6,6 +6,9 @@ cmake_ver=os.getenv("cmake_ver") or "3.16.1"
 load(pathJoin("cmake", cmake_ver))
 
 prepend_path("MODULEPATH", "/contrib/global-workflow/spack-stack/envs/ufsutils/install/modulefiles/Core")
+-- load(pathJoin("intel", "2021.3.0"))
+-- load(path
+
 
 hpc_intel_ver=os.getenv("hpc_intel_ver") or "2021.3.0"
 load(pathJoin("intel", hpc_intel_ver))
@@ -13,8 +16,8 @@ load(pathJoin("intel", hpc_intel_ver))
 impi_ver=os.getenv("impi_ver") or "2021.3.0"
 load(pathJoin("impi", impi_ver))
 
-module load stack-intel
-module load stack-intel-oneapi-mpi
+-- module load stack-intel
+-- module load stack-intel-oneapi-mpi
 
 bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 load(pathJoin("bacio", bacio_ver))

--- a/modulefiles/build.noaacloud.intel.lua
+++ b/modulefiles/build.noaacloud.intel.lua
@@ -1,0 +1,61 @@
+help([[ 
+Load environment to compile UFS_UTILS on NOAA CSP using Intel
+]])
+
+cmake_ver=os.getenv("cmake_ver") or "3.16.1"
+load(pathJoin("cmake", cmake_ver))
+
+prepend_path("MODULEPATH", "/contrib/global-workflow/spack-stack/envs/ufsutils/install/modulefiles/Core")
+
+hpc_intel_ver=os.getenv("hpc_intel_ver") or "2021.3.0"
+load(pathJoin("intel", hpc_intel_ver))
+
+impi_ver=os.getenv("impi_ver") or "2021.3.0"
+load(pathJoin("impi", impi_ver))
+
+bacio_ver=os.getenv("bacio_ver") or "2.4.1"
+load(pathJoin("bacio", bacio_ver))
+
+g2_ver=os.getenv("g2_ver") or "3.4.5"
+load(pathJoin("g2", g2_ver))
+
+ip_ver=os.getenv("ip_ver") or "4.0.0"
+load(pathJoin("ip", ip_ver))
+
+nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
+load(pathJoin("nemsio", nemsio_ver))
+
+sp_ver=os.getenv("sp_ver") or "2.3.3"
+load(pathJoin("sp", sp_ver))
+
+w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
+load(pathJoin("w3emc", w3emc_ver))
+
+sfcio_ver=os.getenv("sfcio_ver") or "1.4.1"
+load(pathJoin("sfcio", sfcio_ver))
+
+sigio_ver=os.getenv("sigio_ver") or "2.3.2"
+load(pathJoin("sigio", sigio_ver))
+
+zlib_ver=os.getenv("zlib_ver") or "1.2.11"
+load(pathJoin("zlib", zlib_ver))
+
+png_ver=os.getenv("png_ver") or "1.6.35"
+load(pathJoin("libpng", png_ver))
+
+hdf5_ver=os.getenv("hdf5_ver") or "1.10.6"
+load(pathJoin("hdf5", hdf5_ver))
+
+netcdf_ver=os.getenv("netcdf_ver") or "4.6.1"
+load(pathJoin("netcdf", netcdf_ver))
+
+nccmp_ver=os.getenv("nccmp_ver") or "1.8.9.0"
+load(pathJoin("nccmp", nccmp_ver))
+
+esmf_ver=os.getenv("esmf_ver") or "8.4.0b08"
+load(pathJoin("esmf", esmf_ver))
+
+nco_ver=os.getenv("nco_ver") or "4.9.1"
+load(pathJoin("nco", nco_ver))
+
+whatis("Description: UFS_UTILS build environment")

--- a/sorc/machine-setup.sh
+++ b/sorc/machine-setup.sh
@@ -99,7 +99,8 @@ elif [[ -d /data/prod ]] ; then
     target=s4
     module purge
 elif [[ -z ${PW_CSP} ]]; then
-    if [[ "${PW_CSP}" == "aws" ]]; then
+    if [[ "${PW_CSP}" == "aws" ]]; then # TODO: Add other CSPs here.
+	target=noaacloud
         module purge
     else
         echo WARNING: UNSUPPORTED CSP PLATFORM 1>&2; exit 99

--- a/sorc/machine-setup.sh
+++ b/sorc/machine-setup.sh
@@ -100,7 +100,6 @@ elif [[ -d /data/prod ]] ; then
     module purge
 elif [[ -z ${PW_CSP} ]]; then
     if [[ "${PW_CSP}" == "aws" ]]; then
-        target=noaacloud
         module purge
     else
         echo WARNING: UNSUPPORTED CSP PLATFORM 1>&2; exit 99

--- a/sorc/machine-setup.sh
+++ b/sorc/machine-setup.sh
@@ -98,7 +98,15 @@ elif [[ -d /data/prod ]] ; then
     fi
     target=s4
     module purge
+elif [[ -z ${PW_CSP} ]]; then
+    if [[ "${PW_CSP}" == "aws" ]]; then
+        target=noaacloud
+        module purge
+    else
+        echo WARNING: UNSUPPORTED CSP PLATFORM 1>&2; exit 99
+    fi
 else
+
     echo WARNING: UNKNOWN PLATFORM 1>&2
 fi
 

--- a/sorc/machine-setup.sh
+++ b/sorc/machine-setup.sh
@@ -98,7 +98,7 @@ elif [[ -d /data/prod ]] ; then
     fi
     target=s4
     module purge
-elif [[ -z ${PW_CSP} ]]; then
+elif [[ "$(dnsdomainname)" =~ "pw" ]]; then
     if [[ "${PW_CSP}" == "aws" ]]; then # TODO: Add other CSPs here.
 	target=noaacloud
         module purge


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR provides support to build the UFS_UTILS for the NOAA cloud-service providers (CSP) platforms. The software stack has been created using a spack-stack template specific to the UFS_UTILS. EPIC has been tasked with stack support for the CSP but it is not yet available at the time of this PR. Instead, the stack has been created by the global-workflow team and staged accordingly on the NOAA CSP AWS Parallel Works (PW) platform. The stack, currently, resides at `/contrib/global-workflow/spack-stack` on NOAA CSP AWS PW.

The changes suggested in this PR allow the build system, `build_all.csh`, to recognize if the respective platform is a NOAA CSP platform. This feature is specified by setting the environment variable `PW_CSP` to a supported CSP (currently only `aws`) value.  

## TESTS CONDUCTED: 
If there are changes to the build or source code, the tests below must be conducted. Contact a repository manager if you need assistance.

- [x] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera and WCOSS2).
- [x] Compile branch on Hera using GNU.
- [x] Compile branch in 'Debug' mode on WCOSS2.
- [x] Compile branch using Intel on NOAA CSP AWS PW.

## ISSUE: 
This PR addresses issue #831. 


