### PR TITLE
Allow build flexibility for ufs-utils utilities.

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -68,7 +68,7 @@ BUILD_DIR=${BUILD_DIR:-"${DIR_ROOT}/build"}
 [[ ${BUILD_CLEAN:-"YES"} =~ [yYtT] ]] && rm -rf "$BUILD_DIR"
 mkdir -p "${BUILD_DIR}" && cd "${BUILD_DIR}"
 
-cmake "${CMAKE_FLAGS}" "${CMAKE_OPTS}" "${DIR_ROOT}"
+cmake ${CMAKE_FLAGS} ${CMAKE_OPTS} "${DIR_ROOT}"
 
 make -j "${BUILD_JOBS:-8}" VERBOSE="${BUILD_VERBOSE:-}"
 make install
@@ -76,4 +76,4 @@ make install
 #ctest
 #ctest -I 4,5
 
-exit
+exit 0

--- a/build_all.sh
+++ b/build_all.sh
@@ -8,53 +8,69 @@
 
 set -eux
 
+# Get the root of the cloned ufs-utils directory
+if [[ $(uname -s) == Darwin ]]; then
+  readonly DIR_ROOT=$(cd "$(dirname "$(greadlink -f -n "${BASH_SOURCE[0]}" )" )" && pwd -P)
+else
+  readonly DIR_ROOT=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )" && pwd -P)
+fi
+
+# User Options
 target=${target:-"NULL"}
 compiler=${compiler:-"intel"}
 PW_CSP=${PW_CSP:-} # TODO: This is an implementation from EPIC and consistent with the UFS WM build system.
-export MOD_PATH
 
 if [[ "$target" == "linux.*" || "$target" == "macosx.*" ]]; then
- unset -f module
- set +x
- source ./modulefiles/build.$target > /dev/null
- set -x
+  unset -f module
+  set +x
+  source "${DIR_ROOT}/modulefiles/build.${target}" > /dev/null
+  set -x
 else
- set +x
- source ./sorc/machine-setup.sh
- if [[ "${target}" == "noaacloud" ]]; then
-  #TODO: This will need to be revisited once the EPIC supported-stacks come online.
-  #TODO: This is a hack due to how the spack-stack module files are generated; there may be a better way to do this.
-  source /contrib/global-workflow/spack-stack/envs/spack_2021.0.3.env
- else
-  module use ./modulefiles
- fi
- module load build.$target.$compiler > /dev/null
- module list
+  set +x
+  source "${DIR_ROOT}/sorc/machine-setup.sh"
+  if [[ "${target}" == "noaacloud" ]]; then
+    #TODO: This will need to be revisited once the EPIC supported-stacks come online.
+    #TODO: This is a hack due to how the spack-stack module files are generated; there may be a better way to do this.
+    source /contrib/global-workflow/spack-stack/envs/spack_2021.0.3.env
+  else
+    module use "${DIR_ROOT}/modulefiles"
+  fi
+  module load "build.$target.$compiler" > /dev/null
+  module list
  set -x
 fi
 
 # Ensure the submodules have been initialized.
 
-if [[ ! -d ./ccpp-physics/physics ]]; then
+if [[ ! -d "${DIR_ROOT}/ccpp-physics/physics" ]]; then
+  cd "${DIR_ROOT}"
   git submodule init
   git submodule update
 fi
 
+# Collect BUILD Options
+CMAKE_FLAGS+=" -DCMAKE_BUILD_TYPE=${BUILD_TYPE:-Release}"
+
+# Install options; destination for built executables, libraries, CMake Package config
+CMAKE_FLAGS+=" -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX:-${DIR_ROOT}} -DCMAKE_INSTALL_BINDIR=${INSTALL_BINDIR:-exec}"
+
+# Testing options
 # The unit test data download is part of the build system. Not all machines can
 # access the EMC ftp site, so turn off the build (-DBUILD_TESTING=OFF) of the units tests accordingly.
 # Those with access to the EMC ftp site are: Orion and Hera.
-
-CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=../ -DCMAKE_INSTALL_BINDIR=exec -DBUILD_TESTING=OFF"
+CMAKE_FLAGS+=" -DBUILD_TESTING=${BUILD_TESTING:-OFF}"
 
 # Allow users of this script to provide CMake options e.g. -DGFS=ON|OFF to build GFS specific utilities only
 CMAKE_OPTS=${CMAKE_OPTS:-}
 
-rm -fr ./build
-mkdir ./build && cd ./build
+# Re-use or create a new BUILD_DIR (Default: create new BUILD_DIR)
+BUILD_DIR=${BUILD_DIR:-"${DIR_ROOT}/build"}
+[[ ${BUILD_CLEAN:-"YES"} =~ [yYtT] ]] && rm -rf "$BUILD_DIR"
+mkdir -p "${BUILD_DIR}" && cd "${BUILD_DIR}"
 
-cmake .. ${CMAKE_FLAGS} ${CMAKE_OPTS}
+cmake "${CMAKE_FLAGS}" "${CMAKE_OPTS}" "${DIR_ROOT}"
 
-make -j ${BUILD_JOBS:-8} VERBOSE=${BUILD_VERBOSE:-}
+make -j "${BUILD_JOBS:-8}" VERBOSE="${BUILD_VERBOSE:-}"
 make install
 
 #ctest


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR:
- allows a user the flexibility to call the `build_all.sh` script from anywhere; thereby relaxing the need to cd into the cloned ufs_utils directory.  This capability is used in the build system for the GFS and GEFS.
- allows the user to specify a build directory (the default is retained as `./build`)
- allows a user to reuse a previously created build directory (the default is to create a new `./build` directory with every execution of `build_all.sh as was before)
- allows user to provide an installation prefix (the default is retained as the current directory)

The default behaviors have not been altered in this PR.  Users should see no impact with this change.

## TESTS CONDUCTED: 

- [x] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera and WCOSS2).
- [x] Compile branch on Hera using GNU.
- [x] Compile branch in 'Debug' mode on WCOSS2.
- [x] Run unit tests locally on any Tier 1 machine. (Done on Hera.)

Describe any additional tests performed.
The executables created from `develop` and this branch are identical.  No additional tests were performed.

## DEPENDENCIES:
None

## DOCUMENTATION:
No updates are necessary.

