### PR TITLE
Enable testing on Github Actions

### DIFF
--- a/.github/workflows/gcc.yaml
+++ b/.github/workflows/gcc.yaml
@@ -1,0 +1,111 @@
+name: GCC Linux Build
+on: [push, pull_request, workflow_dispatch]
+
+
+# Use custom shell with -l so .bash_profile is sourced
+# without having to do it in manually every step
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
+env:
+  cache_key: gcc
+  CC: gcc-10
+  FC: gfortran-10
+  CXX: g++-10
+
+# The jobs are split into:
+# 1. a dependency build step (setup), and
+# 2. a UFS-utils build step (build)
+# 3. a future UFS-utils test step (test)
+# The setup is run once and the environment is cached,
+# so each build of UFS-utils can reuse the cached dependencies to save time (and compute).
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout-ufs_utils  # This is for getting spack.yaml
+        uses: actions/checkout@v2
+        with:
+            path: ufs_utils
+
+      # Cache spack, compiler and dependencies
+      - name: cache-env
+        id: cache-env
+        uses: actions/cache@v2
+        with:
+          path: |
+            spack
+            ~/.spack
+          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ufs_utils/ci/spack.yaml') }}
+
+      # Install dependencies using Spack
+      - name: install-dependencies-with-spack
+        if: steps.cache-env.outputs.cache-hit != 'true'
+        run: |
+          git clone -c feature.manyFiles=true https://github.com/JCSDA/spack.git
+          source spack/share/spack/setup-env.sh
+          spack env create ufs_utils-env ufs_utils/ci/spack.yaml
+          spack env activate ufs_utils-env
+          sudo apt install cmake
+          spack external find
+          spack add mpich@3.4.2
+          spack concretize
+          spack install -v --fail-fast --dirty
+          spack clean --all
+
+  build:
+    needs: setup
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout-ufs_utils
+        uses: actions/checkout@v2
+        with:
+            path: ufs_utils
+
+      - name: cache-env
+        id: cache-env
+        uses: actions/cache@v2
+        with:
+          path: |
+            spack
+            ~/.spack
+          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ufs_utils/ci/spack.yaml') }}
+
+      - name: build-ufs_utils
+        run: |
+          source spack/share/spack/setup-env.sh
+          spack env activate ufs_utils-env
+          export CC=mpicc
+          export FC=mpif90
+          cd ufs_utils
+          mkdir -p build && cd build
+          cmake -DCMAKE_INSTALL_PREFIX=../install ..
+          make -j2 VERBOSE=1
+          make install
+          ctest --verbose --rerun-failed --output-on-failure
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: cache-env
+        id: cache-env
+        uses: actions/cache@v2
+        with:
+          path: |
+            spack
+            ~/.spack
+          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ufs_utils/ci/spack.yaml') }}
+
+      - name: ctest
+        run: |
+          source spack/share/spack/setup-env.sh
+          spack env activate ufs_utils-env
+          cd ufs_utils
+          cd build
+          ctest --verbose --rerun-failed --output-on-failure

--- a/.github/workflows/gcc.yaml
+++ b/.github/workflows/gcc.yaml
@@ -16,8 +16,7 @@ env:
 
 # The jobs are split into:
 # 1. a dependency build step (setup), and
-# 2. a UFS-utils build step (build)
-# 3. a future UFS-utils test step (test)
+# 2. a UFS-utils build and test step (ufs_utils)
 # The setup is run once and the environment is cached,
 # so each subsequent build and test of UFS-utils can reuse the cached
 # dependencies to save time (and compute).
@@ -27,11 +26,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: checkout-ufs_utils
+      - name: checkout  # this is to get the ci/spack.yaml file
         uses: actions/checkout@v3
         with:
             path: ufs_utils
-            submodules: true
 
       # Cache spack, compiler and dependencies
       - name: cache-env
@@ -58,11 +56,17 @@ jobs:
           spack install -v --fail-fast --dirty
           spack clean --all
 
-  build:
+  ufs_utils:
     needs: setup
     runs-on: ubuntu-latest
 
     steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+            path: ufs_utils
+            submodules: recursive
+
       - name: cache-env
         id: cache-env
         uses: actions/cache@v2
@@ -72,7 +76,7 @@ jobs:
             ~/.spack
           key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ufs_utils/ci/spack.yaml') }}
 
-      - name: build-ufs_utils
+      - name: build
         run: |
           source spack/share/spack/setup-env.sh
           spack env activate ufs_utils-env
@@ -83,20 +87,6 @@ jobs:
           cmake -DCMAKE_INSTALL_PREFIX=../install ..
           make -j2 VERBOSE=1
           make install
-
-  test:
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: cache-env
-        id: cache-env
-        uses: actions/cache@v2
-        with:
-          path: |
-            spack
-            ~/.spack
-          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ufs_utils/ci/spack.yaml') }}
 
       - name: ctest
         run: |

--- a/.github/workflows/intel.yaml
+++ b/.github/workflows/intel.yaml
@@ -112,4 +112,4 @@ jobs:
           spack env activate ufs_utils-env
           cd ufs_utils
           cd build
-
+          ctest --verbose --rerun-failed --output-on-failure

--- a/.github/workflows/intel.yaml
+++ b/.github/workflows/intel.yaml
@@ -1,33 +1,36 @@
-name: GCC Linux Build and Test
+name: Intel Linux Build and Test
 on: [push, pull_request, workflow_dispatch]
 
-
-# Use custom shell with -l so .bash_profile is sourced
+# Use custom shell with -l so .bash_profile is sourced which loads intel/oneapi/setvars.sh
 # without having to do it in manually every step
 defaults:
   run:
     shell: bash -leo pipefail {0}
 
+# Set I_MPI_CC/F90 so Intel MPI wrapper uses icc/ifort instead of gcc/gfortran
 env:
-  cache_key: gcc
-  CC: gcc-10
-  FC: gfortran-10
-  CXX: g++-10
+  cache_key: intel
+  CC: icc
+  FC: ifort
+  CXX: icpc
+  I_MPI_CC: icc
+  I_MPI_F90: ifort
 
 # The jobs are split into:
 # 1. a dependency build step (setup), and
 # 2. a UFS-utils build step (build)
-# 3. a future UFS-utils test step (test)
+# 3. a UFS-utils test step (test)
 # The setup is run once and the environment is cached,
 # so each subsequent build and test of UFS-utils can reuse the cached
 # dependencies to save time (and compute).
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: checkout-ufs_utils
+        if: steps.cache-env.outputs.cache-hit != 'true'
         uses: actions/checkout@v3
         with:
             path: ufs_utils
@@ -36,48 +39,64 @@ jobs:
       # Cache spack, compiler and dependencies
       - name: cache-env
         id: cache-env
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             spack
             ~/.spack
+            /opt/intel
           key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ufs_utils/ci/spack.yaml') }}
+
+      - name: install-intel-compilers
+        run: |
+          wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+          sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+          echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+          sudo apt-get update
+          sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-mpi-devel intel-oneapi-openmp intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+          echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
 
       # Install dependencies using Spack
       - name: install-dependencies-with-spack
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
-          git clone -c feature.manyFiles=true https://github.com/JCSDA/spack.git
+          git clone -c feature.manyFiles=true https://github.com/NOAA-EMC/spack.git
           source spack/share/spack/setup-env.sh
           spack env create ufs_utils-env ufs_utils/ci/spack.yaml
           spack env activate ufs_utils-env
+          spack compiler find
           sudo apt install cmake
           spack external find
-          spack add mpich@3.4.2
+          spack add intel-oneapi-mpi
           spack concretize
-          spack install -v --fail-fast --dirty
+          spack install --dirty -v --fail-fast
           spack clean --all
 
   build:
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
+      - name: install-intel
+        run: |
+          echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
+
       - name: cache-env
         id: cache-env
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             spack
             ~/.spack
+            /opt/intel
           key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ufs_utils/ci/spack.yaml') }}
 
       - name: build-ufs_utils
         run: |
           source spack/share/spack/setup-env.sh
           spack env activate ufs_utils-env
-          export CC=mpicc
-          export FC=mpif90
+          export CC=mpiicc
+          export FC=mpiifort
           cd ufs_utils
           mkdir -p build && cd build
           cmake -DCMAKE_INSTALL_PREFIX=../install ..
@@ -104,4 +123,4 @@ jobs:
           spack env activate ufs_utils-env
           cd ufs_utils
           cd build
-          ctest --verbose --rerun-failed --output-on-failure
+

--- a/.github/workflows/intel.yaml
+++ b/.github/workflows/intel.yaml
@@ -18,8 +18,7 @@ env:
 
 # The jobs are split into:
 # 1. a dependency build step (setup), and
-# 2. a UFS-utils build step (build)
-# 3. a UFS-utils test step (test)
+# 2. a UFS-utils build and test step (ufs_utils)
 # The setup is run once and the environment is cached,
 # so each subsequent build and test of UFS-utils can reuse the cached
 # dependencies to save time (and compute).
@@ -29,12 +28,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - name: checkout-ufs_utils
-        if: steps.cache-env.outputs.cache-hit != 'true'
+      - name: checkout  # this is to get the ci/spack.yaml file
         uses: actions/checkout@v3
         with:
             path: ufs_utils
-            submodules: true
 
       # Cache spack, compiler and dependencies
       - name: cache-env
@@ -72,7 +69,7 @@ jobs:
           spack install --dirty -v --fail-fast
           spack clean --all
 
-  build:
+  ufs_utils:
     needs: setup
     runs-on: ubuntu-20.04
 
@@ -80,6 +77,12 @@ jobs:
       - name: install-intel
         run: |
           echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
+
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+            path: ufs_utils
+            submodules: recursive
 
       - name: cache-env
         id: cache-env
@@ -91,7 +94,7 @@ jobs:
             /opt/intel
           key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ufs_utils/ci/spack.yaml') }}
 
-      - name: build-ufs_utils
+      - name: build
         run: |
           source spack/share/spack/setup-env.sh
           spack env activate ufs_utils-env
@@ -102,20 +105,6 @@ jobs:
           cmake -DCMAKE_INSTALL_PREFIX=../install ..
           make -j2 VERBOSE=1
           make install
-
-  test:
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: cache-env
-        id: cache-env
-        uses: actions/cache@v2
-        with:
-          path: |
-            spack
-            ~/.spack
-          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ufs_utils/ci/spack.yaml') }}
 
       - name: ctest
         run: |

--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -1,0 +1,23 @@
+# Spack environment file to build UFS utilities dependencies
+spack:
+  packages:
+    all:
+      compiler:
+      - intel
+      - gcc@10:10
+  specs:
+  - netcdf-c@4.7.4
+  - netcdf-fortran@4.5.3
+  - bacio@2.4.1
+  - g2@3.4.5
+  - ip@3.3.3
+  - nemsio@2.5.4
+  - sp@2.3.3
+  - w3emc@2.9.2
+  - sfcio@1.4.1
+  - sigio@2.3.2
+  - nccmp@1.9.0.1
+  - esmf@8.4.2~debug
+  view: true
+  concretizer:
+    unify: true

--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -17,7 +17,8 @@ spack:
   - sfcio@1.4.1
   - sigio@2.3.2
   - nccmp@1.9.0.1
-  - esmf@8.4.2~debug
+  - parallelio@2.5.9+fortran~pnetcdf
+  - esmf@8.4.2~debug~xerces+external-parallelio
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The tests in Github Actions on this repo are broken.
This PR enables build and ctest of the ufs-utils on Github Actions with GCC 10 and Intel One API powered by spack.

This PR adds:
- dependencies of ufs-utils to be built via spack
- a workflow for GCC and Intel respectively that builds the dependencies with spack, caches them and then builds ufs-utils.  If the build is successful, ctests are also run.

IMO, the staging and downloading of the test data can be significantly improved and caching can be leveraged so that every subsequent push or PR does not force downloading the test data if there has been no change.  This can alleviate load on the servers hosting the test data (EMC FTP sites).

## TESTS CONDUCTED:
The changes in this PR have no impacts on the use of ufs-utils on on-prem platforms.  No tests were run on any of the NOAA platforms.
- [ ] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera and WCOSS2).
- [ ] Compile branch on Hera using GNU.
- [ ] Compile branch in 'Debug' mode on WCOSS2.
- [ ] Run unit tests locally on any Tier 1 machine.
- [ ] Run relevant consistency tests locally on all Tier 1 machine.

Describe any additional tests performed.
Tests are added as part of github actions and they pass.

The deprecated tests from .github/workflows can be deleted but are left here for the repository maintainers.

## DEPENDENCIES:
None

## DOCUMENTATION:
None

## ISSUE: 
Fixes #668 

## CONTRIBUTORS (optional): 
None
