### PR TITLE
Update atmosphere.F90 add "action='read'" to Fortran file open statement

### DIFF
--- a/sorc/chgres_cube.fd/atmosphere.F90
+++ b/sorc/chgres_cube.fd/atmosphere.F90
@@ -1260,7 +1260,7 @@
 
  print*
  print*,"OPEN VERTICAL COORD FILE: ", trim(vcoord_file_target_grid)
- open(14, file=trim(vcoord_file_target_grid), form='formatted', iostat=istat)
+ open(14, file=trim(vcoord_file_target_grid), form='formatted', iostat=istat, action='read')
  if (istat /= 0) then
    call error_handler("OPENING VERTICAL COORD FILE", istat)
  endif


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Add "action='read'" to Fortran file open statement in chgres_cube's `atmosphere.F90` to fix the issue described in https://github.com/ufs-community/UFS_UTILS/issues/869.

## TESTS CONDUCTED: 

- [x] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera and WCOSS2). Done using b529162.
- [x] Compile branch on Hera using GNU.  Done using b529162.
- [x] Compile branch in 'Debug' mode on WCOSS2.  Done using b529162.
- [x] Run unit tests locally on any Tier 1 machine.  Done on Hera using b529162.
- [x] Run relevant consistency tests locally on all Tier 1 machine. Done on Hera using b529162.

Describe any additional tests performed.

- [x] Compiled on AWS ParallelCluster with Intel 2021.4.0, ran successfully as part of JEDI-Skylab

## DEPENDENCIES:

n/a

## DOCUMENTATION:

n/a

## ISSUE: 

Resolves https://github.com/ufs-community/UFS_UTILS/issues/869