### PR TITLE
AQMv7 EE2 Compliance: Propagate CMAKE_Fortran_FLAGS_DEBUG into chgres_cube

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,14 +50,7 @@ endif()
 
 SET(TEST_FILE_DIR "." CACHE STRING "Check this directory for test files before using FTP.")
 
-# Set the build type.
-if(DEFINED CMAKE_BUILD_TYPE)
-  string(TOUPPER ${CMAKE_BUILD_TYPE} UPPER_CMAKE_BUILD_TYPE)
-else()
-  set(UPPER_CMAKE_BUILD_TYPE "")
-endif()
-
-if(NOT UPPER_CMAKE_BUILD_TYPE MATCHES "^(DEBUG|RELEASE|RELWITHDEBINFO|MINSIZEREL)$")
+if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
   message(STATUS "Setting build type to 'Release' as none was specified.")
   set(CMAKE_BUILD_TYPE
       "Release"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ endif()
 
 SET(TEST_FILE_DIR "." CACHE STRING "Check this directory for test files before using FTP.")
 
+# Set the build type.
 if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
   message(STATUS "Setting build type to 'Release' as none was specified.")
   set(CMAKE_BUILD_TYPE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,8 @@ endif()
 SET(TEST_FILE_DIR "." CACHE STRING "Check this directory for test files before using FTP.")
 
 # Set the build type.
-if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
+string(TOUPPER ${CMAKE_BUILD_TYPE} UPPER_CMAKE_BUILD_TYPE)
+if(NOT UPPER_CMAKE_BUILD_TYPE MATCHES "^(DEBUG|RELEASE|RELWITHDEBINFO|MINSIZEREL)$")
   message(STATUS "Setting build type to 'Release' as none was specified.")
   set(CMAKE_BUILD_TYPE
       "Release"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,12 @@ endif()
 SET(TEST_FILE_DIR "." CACHE STRING "Check this directory for test files before using FTP.")
 
 # Set the build type.
-string(TOUPPER ${CMAKE_BUILD_TYPE} UPPER_CMAKE_BUILD_TYPE)
+if(DEFINED CMAKE_BUILD_TYPE)
+  string(TOUPPER ${CMAKE_BUILD_TYPE} UPPER_CMAKE_BUILD_TYPE)
+else()
+  set(UPPER_CMAKE_BUILD_TYPE "")
+endif()
+
 if(NOT UPPER_CMAKE_BUILD_TYPE MATCHES "^(DEBUG|RELEASE|RELWITHDEBINFO|MINSIZEREL)$")
   message(STATUS "Setting build type to 'Release' as none was specified.")
   set(CMAKE_BUILD_TYPE

--- a/sorc/chgres_cube.fd/CMakeLists.txt
+++ b/sorc/chgres_cube.fd/CMakeLists.txt
@@ -27,6 +27,7 @@ add_subdirectory(msis2.1.fd)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8 -assume byterecl")
+  set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG}")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-0 -fdefault-real-8")
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
To meet EE2 requirements for AQMv7, a change was made to propagate CMAKE_Fortran_FLAGS_DEBUG into chgres_cube.

AQM uses the ufs-srweather-app to call CMake for UFS_UTILS. CMake configuration here: https://github.com/BrianCurtis-NOAA/ufs-srweather-app/blob/ee2_fixes/sorc/CMakeLists.txt#L227C1-L258

NCO requires that Debug builds have `-ftrapuv` and `-check all` in all compile flags for the project.

Upon testing, the -ftrapuv and -check all was set here: https://github.com/ufs-community/UFS_UTILS/blob/2f8675fc85262e9dda77208ae89e6e486a39dbf5/CMakeLists.txt#L67 but it was not making it into (at least) the chgres_cube compile lines.

This one line change fixed that issue.

## TESTS CONDUCTED: 
If there are changes to the build or source code, the tests below must be conducted. Contact a repository manager if you need assistance.

- [ ] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera and WCOSS2).
- [ ] Compile branch on Hera using GNU.
- [X] Compile branch in 'Debug' mode on WCOSS2.
- [ ] Run unit tests locally on any Tier 1 machine.
- [ ] Run relevant consistency tests locally on all Tier 1 machine.

Describe any additional tests performed.

## DEPENDENCIES:
None

## DOCUMENTATION:
None Added

## ISSUE: 
None

