### PR TITLE
Update S4 module files

### DIFF
--- a/modulefiles/build.s4.intel.lua
+++ b/modulefiles/build.s4.intel.lua
@@ -2,17 +2,16 @@ help([[
 Load environment to compile UFS_UTILS on S4 using Intel
 ]])
 
-load(pathJoin("license_intel","S4"))
-prepend_path("MODULEPATH", "/data/prod/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/data/prod/jedi/spack-stack/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core")
 
-hpc_ver=os.getenv("hpc_ver") or "1.2.0"
-load(pathJoin("hpc", hpc_ver))
+stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
+load(pathJoin("stack-intel", hpc_intel_ver))
 
-hpc_intel_ver=os.getenv("hpc_intel_ver") or "2022.1"
-load(pathJoin("hpc-intel", hpc_intel_ver))
+stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.0"
+load(pathJoin("stack-intel-oneapi-mpi", impi_ver))
 
-impi_ver=os.getenv("impi_ver") or "2022.1"
-load(pathJoin("hpc-impi", impi_ver))
+cmake_ver=os.getenv("cmake_ver") or "3.23.1"
+load(pathJoin("cmake", cmake_ver))
 
 bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 load(pathJoin("bacio", bacio_ver))
@@ -20,7 +19,7 @@ load(pathJoin("bacio", bacio_ver))
 g2_ver=os.getenv("g2_ver") or "3.4.5"
 load(pathJoin("g2", g2_ver))
 
-ip_ver=os.getenv("ip_ver") or "3.3.3"
+ip_ver=os.getenv("ip_ver") or "4.3.0"
 load(pathJoin("ip", ip_ver))
 
 nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
@@ -29,8 +28,8 @@ load(pathJoin("nemsio", nemsio_ver))
 sp_ver=os.getenv("sp_ver") or "2.3.3"
 load(pathJoin("sp", sp_ver))
 
-w3nco_ver=os.getenv("w3nco_ver") or "2.4.1"
-load(pathJoin("w3nco", w3nco_ver))
+w3emc_ver=os.getenv("w3emc_ver") or "2.10.0"
+load(pathJoin("w3emc", w3emc_ver))
 
 sfcio_ver=os.getenv("sfcio_ver") or "1.4.1"
 load(pathJoin("sfcio", sfcio_ver))
@@ -38,22 +37,25 @@ load(pathJoin("sfcio", sfcio_ver))
 sigio_ver=os.getenv("sigio_ver") or "2.3.2"
 load(pathJoin("sigio", sigio_ver))
 
-zlib_ver=os.getenv("zlib_ver") or "1.2.11"
+zlib_ver=os.getenv("zlib_ver") or "1.2.13"
 load(pathJoin("zlib", zlib_ver))
 
-png_ver=os.getenv("png_ver") or "1.6.35"
+png_ver=os.getenv("png_ver") or "1.6.37"
 load(pathJoin("libpng", png_ver))
 
-hdf5_ver=os.getenv("hdf5_ver") or "1.10.6"
-load(pathJoin("hdf5", hdf5_ver))
+netcdf_c_ver=os.getenv("netcdf_c_ver") or "4.9.2"
+load(pathJoin("netcdf-c", netcdf_c_ver))
 
-netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
-load(pathJoin("netcdf", netcdf_ver))
+netcdf_fortran_ver=os.getenv("netcdf_fortran_ver") or "4.6.0"
+load(pathJoin("netcdf-fortran", netcdf_fortran_ver))
 
-nccmp_ver=os.getenv("nccmp_ver") or "1.8.9.0"
+nccmp_ver=os.getenv("nccmp_ver") or "1.9.0.1"
 load(pathJoin("nccmp", nccmp_ver))
 
-esmf_ver=os.getenv("esmf_ver") or "8.2.1b04"
+esmf_ver=os.getenv("esmf_ver") or "8.4.2"
 load(pathJoin("esmf", esmf_ver))
+
+nco_ver=os.getenv("nco_ver") or "5.0.6"
+load(pathJoin("nco", nco_ver))
 
 whatis("Description: UFS_UTILS build environment")

--- a/util/gdas_init/driver.s4.sh
+++ b/util/gdas_init/driver.s4.sh
@@ -15,11 +15,6 @@ module load build.$target.$compiler
 module list
 
 # Needed for NDATE utility
-module load license_intel/S4
-module use /data/prod/hpc-stack/modulefiles/stack
-module load hpc/1.1.0
-module load hpc-intel/18.0.4
-module load hpc-impi/18.0.4
 module load prod_util/1.2.2
 
 PROJECT_CODE=star


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This updates the module file for S4 to upgrade to spack-stack libraries to match the tier-1, non-production platforms.

## TESTS CONDUCTED: 

- [x] Ran global_cycle within the global-workflow.
- [x] Ran gdas_init on S4

Since this test is isolated to S4, which does not have tests available, I did not run any of the following:
- [ ] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera and WCOSS2).
- [ ] Compile branch on Hera using GNU.
- [ ] Compile branch in 'Debug' mode on WCOSS2.
- [ ] Run unit tests locally on any Tier 1 machine.
- [ ] Run relevant consistency tests locally on all Tier 1 machine.

## ISSUE: 
Fixes #875

## CONTRIBUTORS (optional): 
@souopgui