### PR TITLE
update to allow 4 character specifiers in filenames for post weights

### DIFF
--- a/reg_tests/cpld_gridgen/RegressionTests_hera.intel.log
+++ b/reg_tests/cpld_gridgen/RegressionTests_hera.intel.log
@@ -1,8 +1,8 @@
-Thu Oct 26 17:23:32 UTC 2023
+Fri Dec 15 20:03:43 UTC 2023
 Start Regression test
 
-Working dir = /scratch1/NCEPDEV/stmp4/Denise.Worthen/CPLD_GRIDGEN/rt_198243/025
-Baseline dir = /scratch1/NCEPDEV/nems/role.ufsutils/ufs_utils/reg_tests/cpld_gridgen/baseline_data/025.new
+Working dir = /scratch1/NCEPDEV/stmp4/Denise.Worthen/CPLD_GRIDGEN/rt_148527/025
+Baseline dir = /scratch1/NCEPDEV/stmp4/Denise.Worthen/CPLD_GRIDGEN/BASELINE/025
 
 Checking test 025 results ....
 Comparing Bu.mx025_SCRIP.nc........OK
@@ -21,25 +21,25 @@ Comparing grid_cice_NEMS_mx025.nc........OK
 Comparing kmtu_cice_NEMS_mx025.nc........OK
 Comparing mesh.mx025.nc........OK
 Comparing rect.0p25_SCRIP.nc........OK
-Comparing rect.0p5_SCRIP.nc........OK
-Comparing rect.1p0_SCRIP.nc........OK
-Comparing rect.5p0_SCRIP.nc........OK
+Comparing rect.0p50_SCRIP.nc........OK
+Comparing rect.1p00_SCRIP.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
 Comparing tripole.mx025.Bu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx025.Ct.to.rect.0p25.bilinear.nc........OK
 Comparing tripole.mx025.Ct.to.rect.0p25.conserve.nc........OK
-Comparing tripole.mx025.Ct.to.rect.0p5.bilinear.nc........OK
-Comparing tripole.mx025.Ct.to.rect.0p5.conserve.nc........OK
-Comparing tripole.mx025.Ct.to.rect.1p0.bilinear.nc........OK
-Comparing tripole.mx025.Ct.to.rect.1p0.conserve.nc........OK
-Comparing tripole.mx025.Ct.to.rect.5p0.bilinear.nc........OK
-Comparing tripole.mx025.Ct.to.rect.5p0.conserve.nc........OK
+Comparing tripole.mx025.Ct.to.rect.0p50.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.rect.0p50.conserve.nc........OK
+Comparing tripole.mx025.Ct.to.rect.1p00.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.rect.1p00.conserve.nc........OK
+Comparing tripole.mx025.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.rect.5p00.conserve.nc........OK
 Comparing tripole.mx025.Cu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx025.Cv.to.Ct.bilinear.nc........OK
 Comparing tripole.mx025.nc........OK
 
 
-Working dir = /scratch1/NCEPDEV/stmp4/Denise.Worthen/CPLD_GRIDGEN/rt_198243/050
-Baseline dir = /scratch1/NCEPDEV/nems/role.ufsutils/ufs_utils/reg_tests/cpld_gridgen/baseline_data/050.new
+Working dir = /scratch1/NCEPDEV/stmp4/Denise.Worthen/CPLD_GRIDGEN/rt_148527/050
+Baseline dir = /scratch1/NCEPDEV/stmp4/Denise.Worthen/CPLD_GRIDGEN/BASELINE/050
 
 Checking test 050 results ....
 Comparing Bu.mx050_SCRIP.nc........OK
@@ -58,24 +58,24 @@ Comparing Cv.mx050_SCRIP.nc........OK
 Comparing grid_cice_NEMS_mx050.nc........OK
 Comparing kmtu_cice_NEMS_mx050.nc........OK
 Comparing mesh.mx050.nc........OK
-Comparing rect.0p5_SCRIP.nc........OK
-Comparing rect.1p0_SCRIP.nc........OK
-Comparing rect.5p0_SCRIP.nc........OK
+Comparing rect.0p50_SCRIP.nc........OK
+Comparing rect.1p00_SCRIP.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
 Comparing tripole.mx025.Ct.to.mx050.Ct.neareststod.nc........OK
 Comparing tripole.mx050.Bu.to.Ct.bilinear.nc........OK
-Comparing tripole.mx050.Ct.to.rect.0p5.bilinear.nc........OK
-Comparing tripole.mx050.Ct.to.rect.0p5.conserve.nc........OK
-Comparing tripole.mx050.Ct.to.rect.1p0.bilinear.nc........OK
-Comparing tripole.mx050.Ct.to.rect.1p0.conserve.nc........OK
-Comparing tripole.mx050.Ct.to.rect.5p0.bilinear.nc........OK
-Comparing tripole.mx050.Ct.to.rect.5p0.conserve.nc........OK
+Comparing tripole.mx050.Ct.to.rect.0p50.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.rect.0p50.conserve.nc........OK
+Comparing tripole.mx050.Ct.to.rect.1p00.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.rect.1p00.conserve.nc........OK
+Comparing tripole.mx050.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.rect.5p00.conserve.nc........OK
 Comparing tripole.mx050.Cu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx050.Cv.to.Ct.bilinear.nc........OK
 Comparing tripole.mx050.nc........OK
 
 
-Working dir = /scratch1/NCEPDEV/stmp4/Denise.Worthen/CPLD_GRIDGEN/rt_198243/100
-Baseline dir = /scratch1/NCEPDEV/nems/role.ufsutils/ufs_utils/reg_tests/cpld_gridgen/baseline_data/100.new
+Working dir = /scratch1/NCEPDEV/stmp4/Denise.Worthen/CPLD_GRIDGEN/rt_148527/100
+Baseline dir = /scratch1/NCEPDEV/stmp4/Denise.Worthen/CPLD_GRIDGEN/BASELINE/100
 
 Checking test 100 results ....
 Comparing Bu.mx100_SCRIP.nc........OK
@@ -94,22 +94,22 @@ Comparing Cv.mx100_SCRIP.nc........OK
 Comparing grid_cice_NEMS_mx100.nc........OK
 Comparing kmtu_cice_NEMS_mx100.nc........OK
 Comparing mesh.mx100.nc........OK
-Comparing rect.1p0_SCRIP.nc........OK
-Comparing rect.5p0_SCRIP.nc........OK
+Comparing rect.1p00_SCRIP.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
 Comparing tripole.mx025.Ct.to.mx100.Ct.neareststod.nc........OK
 Comparing tripole.mx100.Bu.to.Ct.bilinear.nc........OK
-Comparing tripole.mx100.Ct.to.rect.1p0.bilinear.nc........OK
-Comparing tripole.mx100.Ct.to.rect.1p0.conserve.nc........OK
-Comparing tripole.mx100.Ct.to.rect.5p0.bilinear.nc........OK
-Comparing tripole.mx100.Ct.to.rect.5p0.conserve.nc........OK
+Comparing tripole.mx100.Ct.to.rect.1p00.bilinear.nc........OK
+Comparing tripole.mx100.Ct.to.rect.1p00.conserve.nc........OK
+Comparing tripole.mx100.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx100.Ct.to.rect.5p00.conserve.nc........OK
 Comparing tripole.mx100.Cu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx100.Cv.to.Ct.bilinear.nc........OK
 Comparing tripole.mx100.nc........OK
 Comparing ufs.topo_edits_011818.nc........OK
 
 
-Working dir = /scratch1/NCEPDEV/stmp4/Denise.Worthen/CPLD_GRIDGEN/rt_198243/500
-Baseline dir = /scratch1/NCEPDEV/nems/role.ufsutils/ufs_utils/reg_tests/cpld_gridgen/baseline_data/500.new
+Working dir = /scratch1/NCEPDEV/stmp4/Denise.Worthen/CPLD_GRIDGEN/rt_148527/500
+Baseline dir = /scratch1/NCEPDEV/stmp4/Denise.Worthen/CPLD_GRIDGEN/BASELINE/500
 
 Checking test 500 results ....
 Comparing Bu.mx500_SCRIP.nc........OK
@@ -128,16 +128,16 @@ Comparing Cv.mx500_SCRIP.nc........OK
 Comparing grid_cice_NEMS_mx500.nc........OK
 Comparing kmtu_cice_NEMS_mx500.nc........OK
 Comparing mesh.mx500.nc........OK
-Comparing rect.5p0_SCRIP.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
 Comparing tripole.mx025.Ct.to.mx500.Ct.neareststod.nc........OK
 Comparing tripole.mx500.Bu.to.Ct.bilinear.nc........OK
-Comparing tripole.mx500.Ct.to.rect.5p0.bilinear.nc........OK
-Comparing tripole.mx500.Ct.to.rect.5p0.conserve.nc........OK
+Comparing tripole.mx500.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx500.Ct.to.rect.5p00.conserve.nc........OK
 Comparing tripole.mx500.Cu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx500.Cv.to.Ct.bilinear.nc........OK
 Comparing tripole.mx500.nc........OK
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Oct 26 17:46:20 UTC 2023
-Elapsed time: 00h:24m:25s. Have a nice day!
+Fri Dec 15 20:29:09 UTC 2023
+Elapsed time: 00h:25m:28s. Have a nice day!

--- a/reg_tests/cpld_gridgen/RegressionTests_jet.intel.log
+++ b/reg_tests/cpld_gridgen/RegressionTests_jet.intel.log
@@ -1,8 +1,8 @@
-Thu Oct 26 18:20:27 UTC 2023
+Sat Dec 16 18:41:27 UTC 2023
 Start Regression test
 
-Working dir = /lfs4/HFIP/h-nems/Denise.Worthen/CPLD_GRIDGEN/rt_55026/025
-Baseline dir = /lfs4/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/reg_tests/cpld_gridgen/baseline_data/025.new
+Working dir = /lfs4/HFIP/h-nems/Denise.Worthen/CPLD_GRIDGEN/rt_97163/025
+Baseline dir = /lfs4/HFIP/h-nems/Denise.Worthen/CPLD_GRIDGEN/BASELINE/025
 
 Checking test 025 results ....
 Comparing Bu.mx025_SCRIP.nc........OK
@@ -21,25 +21,25 @@ Comparing grid_cice_NEMS_mx025.nc........OK
 Comparing kmtu_cice_NEMS_mx025.nc........OK
 Comparing mesh.mx025.nc........OK
 Comparing rect.0p25_SCRIP.nc........OK
-Comparing rect.0p5_SCRIP.nc........OK
-Comparing rect.1p0_SCRIP.nc........OK
-Comparing rect.5p0_SCRIP.nc........OK
+Comparing rect.0p50_SCRIP.nc........OK
+Comparing rect.1p00_SCRIP.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
 Comparing tripole.mx025.Bu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx025.Ct.to.rect.0p25.bilinear.nc........OK
 Comparing tripole.mx025.Ct.to.rect.0p25.conserve.nc........OK
-Comparing tripole.mx025.Ct.to.rect.0p5.bilinear.nc........OK
-Comparing tripole.mx025.Ct.to.rect.0p5.conserve.nc........OK
-Comparing tripole.mx025.Ct.to.rect.1p0.bilinear.nc........OK
-Comparing tripole.mx025.Ct.to.rect.1p0.conserve.nc........OK
-Comparing tripole.mx025.Ct.to.rect.5p0.bilinear.nc........OK
-Comparing tripole.mx025.Ct.to.rect.5p0.conserve.nc........OK
+Comparing tripole.mx025.Ct.to.rect.0p50.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.rect.0p50.conserve.nc........OK
+Comparing tripole.mx025.Ct.to.rect.1p00.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.rect.1p00.conserve.nc........OK
+Comparing tripole.mx025.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.rect.5p00.conserve.nc........OK
 Comparing tripole.mx025.Cu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx025.Cv.to.Ct.bilinear.nc........OK
 Comparing tripole.mx025.nc........OK
 
 
-Working dir = /lfs4/HFIP/h-nems/Denise.Worthen/CPLD_GRIDGEN/rt_55026/050
-Baseline dir = /lfs4/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/reg_tests/cpld_gridgen/baseline_data/050.new
+Working dir = /lfs4/HFIP/h-nems/Denise.Worthen/CPLD_GRIDGEN/rt_97163/050
+Baseline dir = /lfs4/HFIP/h-nems/Denise.Worthen/CPLD_GRIDGEN/BASELINE/050
 
 Checking test 050 results ....
 Comparing Bu.mx050_SCRIP.nc........OK
@@ -58,24 +58,24 @@ Comparing Cv.mx050_SCRIP.nc........OK
 Comparing grid_cice_NEMS_mx050.nc........OK
 Comparing kmtu_cice_NEMS_mx050.nc........OK
 Comparing mesh.mx050.nc........OK
-Comparing rect.0p5_SCRIP.nc........OK
-Comparing rect.1p0_SCRIP.nc........OK
-Comparing rect.5p0_SCRIP.nc........OK
+Comparing rect.0p50_SCRIP.nc........OK
+Comparing rect.1p00_SCRIP.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
 Comparing tripole.mx025.Ct.to.mx050.Ct.neareststod.nc........OK
 Comparing tripole.mx050.Bu.to.Ct.bilinear.nc........OK
-Comparing tripole.mx050.Ct.to.rect.0p5.bilinear.nc........OK
-Comparing tripole.mx050.Ct.to.rect.0p5.conserve.nc........OK
-Comparing tripole.mx050.Ct.to.rect.1p0.bilinear.nc........OK
-Comparing tripole.mx050.Ct.to.rect.1p0.conserve.nc........OK
-Comparing tripole.mx050.Ct.to.rect.5p0.bilinear.nc........OK
-Comparing tripole.mx050.Ct.to.rect.5p0.conserve.nc........OK
+Comparing tripole.mx050.Ct.to.rect.0p50.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.rect.0p50.conserve.nc........OK
+Comparing tripole.mx050.Ct.to.rect.1p00.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.rect.1p00.conserve.nc........OK
+Comparing tripole.mx050.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.rect.5p00.conserve.nc........OK
 Comparing tripole.mx050.Cu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx050.Cv.to.Ct.bilinear.nc........OK
 Comparing tripole.mx050.nc........OK
 
 
-Working dir = /lfs4/HFIP/h-nems/Denise.Worthen/CPLD_GRIDGEN/rt_55026/100
-Baseline dir = /lfs4/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/reg_tests/cpld_gridgen/baseline_data/100.new
+Working dir = /lfs4/HFIP/h-nems/Denise.Worthen/CPLD_GRIDGEN/rt_97163/100
+Baseline dir = /lfs4/HFIP/h-nems/Denise.Worthen/CPLD_GRIDGEN/BASELINE/100
 
 Checking test 100 results ....
 Comparing Bu.mx100_SCRIP.nc........OK
@@ -94,22 +94,22 @@ Comparing Cv.mx100_SCRIP.nc........OK
 Comparing grid_cice_NEMS_mx100.nc........OK
 Comparing kmtu_cice_NEMS_mx100.nc........OK
 Comparing mesh.mx100.nc........OK
-Comparing rect.1p0_SCRIP.nc........OK
-Comparing rect.5p0_SCRIP.nc........OK
+Comparing rect.1p00_SCRIP.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
 Comparing tripole.mx025.Ct.to.mx100.Ct.neareststod.nc........OK
 Comparing tripole.mx100.Bu.to.Ct.bilinear.nc........OK
-Comparing tripole.mx100.Ct.to.rect.1p0.bilinear.nc........OK
-Comparing tripole.mx100.Ct.to.rect.1p0.conserve.nc........OK
-Comparing tripole.mx100.Ct.to.rect.5p0.bilinear.nc........OK
-Comparing tripole.mx100.Ct.to.rect.5p0.conserve.nc........OK
+Comparing tripole.mx100.Ct.to.rect.1p00.bilinear.nc........OK
+Comparing tripole.mx100.Ct.to.rect.1p00.conserve.nc........OK
+Comparing tripole.mx100.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx100.Ct.to.rect.5p00.conserve.nc........OK
 Comparing tripole.mx100.Cu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx100.Cv.to.Ct.bilinear.nc........OK
 Comparing tripole.mx100.nc........OK
 Comparing ufs.topo_edits_011818.nc........OK
 
 
-Working dir = /lfs4/HFIP/h-nems/Denise.Worthen/CPLD_GRIDGEN/rt_55026/500
-Baseline dir = /lfs4/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/reg_tests/cpld_gridgen/baseline_data/500.new
+Working dir = /lfs4/HFIP/h-nems/Denise.Worthen/CPLD_GRIDGEN/rt_97163/500
+Baseline dir = /lfs4/HFIP/h-nems/Denise.Worthen/CPLD_GRIDGEN/BASELINE/500
 
 Checking test 500 results ....
 Comparing Bu.mx500_SCRIP.nc........OK
@@ -128,16 +128,16 @@ Comparing Cv.mx500_SCRIP.nc........OK
 Comparing grid_cice_NEMS_mx500.nc........OK
 Comparing kmtu_cice_NEMS_mx500.nc........OK
 Comparing mesh.mx500.nc........OK
-Comparing rect.5p0_SCRIP.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
 Comparing tripole.mx025.Ct.to.mx500.Ct.neareststod.nc........OK
 Comparing tripole.mx500.Bu.to.Ct.bilinear.nc........OK
-Comparing tripole.mx500.Ct.to.rect.5p0.bilinear.nc........OK
-Comparing tripole.mx500.Ct.to.rect.5p0.conserve.nc........OK
+Comparing tripole.mx500.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx500.Ct.to.rect.5p00.conserve.nc........OK
 Comparing tripole.mx500.Cu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx500.Cv.to.Ct.bilinear.nc........OK
 Comparing tripole.mx500.nc........OK
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Oct 26 18:50:56 UTC 2023
-Elapsed time: 00h:32m:10s. Have a nice day!
+Sat Dec 16 19:13:08 UTC 2023
+Elapsed time: 00h:31m:44s. Have a nice day!

--- a/reg_tests/cpld_gridgen/RegressionTests_orion.intel.log
+++ b/reg_tests/cpld_gridgen/RegressionTests_orion.intel.log
@@ -1,8 +1,8 @@
-Thu Oct 26 13:21:30 CDT 2023
+Fri Dec 15 11:10:53 CST 2023
 Start Regression test
 
-Working dir = /work/noaa/stmp/dworthen/CPLD_GRIDGEN/rt_121164/025
-Baseline dir = /work/noaa/nems/role-nems/ufs_utils/reg_tests/cpld_gridgen/baseline_data/025.new
+Working dir = /work/noaa/stmp/dworthen/CPLD_GRIDGEN/rt_408740/025
+Baseline dir = /work/noaa/stmp/dworthen/CPLD_GRIDGEN/BASELINE/025
 
 Checking test 025 results ....
 Comparing Bu.mx025_SCRIP.nc........OK
@@ -21,25 +21,25 @@ Comparing grid_cice_NEMS_mx025.nc........OK
 Comparing kmtu_cice_NEMS_mx025.nc........OK
 Comparing mesh.mx025.nc........OK
 Comparing rect.0p25_SCRIP.nc........OK
-Comparing rect.0p5_SCRIP.nc........OK
-Comparing rect.1p0_SCRIP.nc........OK
-Comparing rect.5p0_SCRIP.nc........OK
+Comparing rect.0p50_SCRIP.nc........OK
+Comparing rect.1p00_SCRIP.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
 Comparing tripole.mx025.Bu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx025.Ct.to.rect.0p25.bilinear.nc........OK
 Comparing tripole.mx025.Ct.to.rect.0p25.conserve.nc........OK
-Comparing tripole.mx025.Ct.to.rect.0p5.bilinear.nc........OK
-Comparing tripole.mx025.Ct.to.rect.0p5.conserve.nc........OK
-Comparing tripole.mx025.Ct.to.rect.1p0.bilinear.nc........OK
-Comparing tripole.mx025.Ct.to.rect.1p0.conserve.nc........OK
-Comparing tripole.mx025.Ct.to.rect.5p0.bilinear.nc........OK
-Comparing tripole.mx025.Ct.to.rect.5p0.conserve.nc........OK
+Comparing tripole.mx025.Ct.to.rect.0p50.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.rect.0p50.conserve.nc........OK
+Comparing tripole.mx025.Ct.to.rect.1p00.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.rect.1p00.conserve.nc........OK
+Comparing tripole.mx025.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.rect.5p00.conserve.nc........OK
 Comparing tripole.mx025.Cu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx025.Cv.to.Ct.bilinear.nc........OK
 Comparing tripole.mx025.nc........OK
 
 
-Working dir = /work/noaa/stmp/dworthen/CPLD_GRIDGEN/rt_121164/050
-Baseline dir = /work/noaa/nems/role-nems/ufs_utils/reg_tests/cpld_gridgen/baseline_data/050.new
+Working dir = /work/noaa/stmp/dworthen/CPLD_GRIDGEN/rt_408740/050
+Baseline dir = /work/noaa/stmp/dworthen/CPLD_GRIDGEN/BASELINE/050
 
 Checking test 050 results ....
 Comparing Bu.mx050_SCRIP.nc........OK
@@ -58,24 +58,24 @@ Comparing Cv.mx050_SCRIP.nc........OK
 Comparing grid_cice_NEMS_mx050.nc........OK
 Comparing kmtu_cice_NEMS_mx050.nc........OK
 Comparing mesh.mx050.nc........OK
-Comparing rect.0p5_SCRIP.nc........OK
-Comparing rect.1p0_SCRIP.nc........OK
-Comparing rect.5p0_SCRIP.nc........OK
+Comparing rect.0p50_SCRIP.nc........OK
+Comparing rect.1p00_SCRIP.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
 Comparing tripole.mx025.Ct.to.mx050.Ct.neareststod.nc........OK
 Comparing tripole.mx050.Bu.to.Ct.bilinear.nc........OK
-Comparing tripole.mx050.Ct.to.rect.0p5.bilinear.nc........OK
-Comparing tripole.mx050.Ct.to.rect.0p5.conserve.nc........OK
-Comparing tripole.mx050.Ct.to.rect.1p0.bilinear.nc........OK
-Comparing tripole.mx050.Ct.to.rect.1p0.conserve.nc........OK
-Comparing tripole.mx050.Ct.to.rect.5p0.bilinear.nc........OK
-Comparing tripole.mx050.Ct.to.rect.5p0.conserve.nc........OK
+Comparing tripole.mx050.Ct.to.rect.0p50.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.rect.0p50.conserve.nc........OK
+Comparing tripole.mx050.Ct.to.rect.1p00.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.rect.1p00.conserve.nc........OK
+Comparing tripole.mx050.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.rect.5p00.conserve.nc........OK
 Comparing tripole.mx050.Cu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx050.Cv.to.Ct.bilinear.nc........OK
 Comparing tripole.mx050.nc........OK
 
 
-Working dir = /work/noaa/stmp/dworthen/CPLD_GRIDGEN/rt_121164/100
-Baseline dir = /work/noaa/nems/role-nems/ufs_utils/reg_tests/cpld_gridgen/baseline_data/100.new
+Working dir = /work/noaa/stmp/dworthen/CPLD_GRIDGEN/rt_408740/100
+Baseline dir = /work/noaa/stmp/dworthen/CPLD_GRIDGEN/BASELINE/100
 
 Checking test 100 results ....
 Comparing Bu.mx100_SCRIP.nc........OK
@@ -94,22 +94,22 @@ Comparing Cv.mx100_SCRIP.nc........OK
 Comparing grid_cice_NEMS_mx100.nc........OK
 Comparing kmtu_cice_NEMS_mx100.nc........OK
 Comparing mesh.mx100.nc........OK
-Comparing rect.1p0_SCRIP.nc........OK
-Comparing rect.5p0_SCRIP.nc........OK
+Comparing rect.1p00_SCRIP.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
 Comparing tripole.mx025.Ct.to.mx100.Ct.neareststod.nc........OK
 Comparing tripole.mx100.Bu.to.Ct.bilinear.nc........OK
-Comparing tripole.mx100.Ct.to.rect.1p0.bilinear.nc........OK
-Comparing tripole.mx100.Ct.to.rect.1p0.conserve.nc........OK
-Comparing tripole.mx100.Ct.to.rect.5p0.bilinear.nc........OK
-Comparing tripole.mx100.Ct.to.rect.5p0.conserve.nc........OK
+Comparing tripole.mx100.Ct.to.rect.1p00.bilinear.nc........OK
+Comparing tripole.mx100.Ct.to.rect.1p00.conserve.nc........OK
+Comparing tripole.mx100.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx100.Ct.to.rect.5p00.conserve.nc........OK
 Comparing tripole.mx100.Cu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx100.Cv.to.Ct.bilinear.nc........OK
 Comparing tripole.mx100.nc........OK
 Comparing ufs.topo_edits_011818.nc........OK
 
 
-Working dir = /work/noaa/stmp/dworthen/CPLD_GRIDGEN/rt_121164/500
-Baseline dir = /work/noaa/nems/role-nems/ufs_utils/reg_tests/cpld_gridgen/baseline_data/500.new
+Working dir = /work/noaa/stmp/dworthen/CPLD_GRIDGEN/rt_408740/500
+Baseline dir = /work/noaa/stmp/dworthen/CPLD_GRIDGEN/BASELINE/500
 
 Checking test 500 results ....
 Comparing Bu.mx500_SCRIP.nc........OK
@@ -128,16 +128,16 @@ Comparing Cv.mx500_SCRIP.nc........OK
 Comparing grid_cice_NEMS_mx500.nc........OK
 Comparing kmtu_cice_NEMS_mx500.nc........OK
 Comparing mesh.mx500.nc........OK
-Comparing rect.5p0_SCRIP.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
 Comparing tripole.mx025.Ct.to.mx500.Ct.neareststod.nc........OK
 Comparing tripole.mx500.Bu.to.Ct.bilinear.nc........OK
-Comparing tripole.mx500.Ct.to.rect.5p0.bilinear.nc........OK
-Comparing tripole.mx500.Ct.to.rect.5p0.conserve.nc........OK
+Comparing tripole.mx500.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx500.Ct.to.rect.5p00.conserve.nc........OK
 Comparing tripole.mx500.Cu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx500.Cv.to.Ct.bilinear.nc........OK
 Comparing tripole.mx500.nc........OK
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Oct 26 13:41:16 CDT 2023
-Elapsed time: 00h:21m:06s. Have a nice day!
+Fri Dec 15 11:33:32 CST 2023
+Elapsed time: 00h:22m:41s. Have a nice day!

--- a/reg_tests/cpld_gridgen/RegressionTests_wcoss2.intel.log
+++ b/reg_tests/cpld_gridgen/RegressionTests_wcoss2.intel.log
@@ -1,8 +1,8 @@
-Thu Oct 26 18:28:37 UTC 2023
+Sat Dec 16 15:19:48 UTC 2023
 Start Regression test
 
-Working dir = /lfs/h2/emc/stmp/denise.worthen/CPLD_GRIDGEN/rt_155737/025
-Baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/UFS_UTILS/reg_tests/cpld_gridgen/baseline_data/025.new
+Working dir = /lfs/h2/emc/stmp/denise.worthen/CPLD_GRIDGEN/rt_194650/025
+Baseline dir = /lfs/h2/emc/stmp/denise.worthen/CPLD_GRIDGEN/BASELINE/025
 
 Checking test 025 results ....
 Comparing Bu.mx025_SCRIP.nc........OK
@@ -21,25 +21,25 @@ Comparing grid_cice_NEMS_mx025.nc........OK
 Comparing kmtu_cice_NEMS_mx025.nc........OK
 Comparing mesh.mx025.nc........OK
 Comparing rect.0p25_SCRIP.nc........OK
-Comparing rect.0p5_SCRIP.nc........OK
-Comparing rect.1p0_SCRIP.nc........OK
-Comparing rect.5p0_SCRIP.nc........OK
+Comparing rect.0p50_SCRIP.nc........OK
+Comparing rect.1p00_SCRIP.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
 Comparing tripole.mx025.Bu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx025.Ct.to.rect.0p25.bilinear.nc........OK
 Comparing tripole.mx025.Ct.to.rect.0p25.conserve.nc........OK
-Comparing tripole.mx025.Ct.to.rect.0p5.bilinear.nc........OK
-Comparing tripole.mx025.Ct.to.rect.0p5.conserve.nc........OK
-Comparing tripole.mx025.Ct.to.rect.1p0.bilinear.nc........OK
-Comparing tripole.mx025.Ct.to.rect.1p0.conserve.nc........OK
-Comparing tripole.mx025.Ct.to.rect.5p0.bilinear.nc........OK
-Comparing tripole.mx025.Ct.to.rect.5p0.conserve.nc........OK
+Comparing tripole.mx025.Ct.to.rect.0p50.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.rect.0p50.conserve.nc........OK
+Comparing tripole.mx025.Ct.to.rect.1p00.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.rect.1p00.conserve.nc........OK
+Comparing tripole.mx025.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.rect.5p00.conserve.nc........OK
 Comparing tripole.mx025.Cu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx025.Cv.to.Ct.bilinear.nc........OK
 Comparing tripole.mx025.nc........OK
 
 
-Working dir = /lfs/h2/emc/stmp/denise.worthen/CPLD_GRIDGEN/rt_155737/050
-Baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/UFS_UTILS/reg_tests/cpld_gridgen/baseline_data/050.new
+Working dir = /lfs/h2/emc/stmp/denise.worthen/CPLD_GRIDGEN/rt_194650/050
+Baseline dir = /lfs/h2/emc/stmp/denise.worthen/CPLD_GRIDGEN/BASELINE/050
 
 Checking test 050 results ....
 Comparing Bu.mx050_SCRIP.nc........OK
@@ -58,24 +58,24 @@ Comparing Cv.mx050_SCRIP.nc........OK
 Comparing grid_cice_NEMS_mx050.nc........OK
 Comparing kmtu_cice_NEMS_mx050.nc........OK
 Comparing mesh.mx050.nc........OK
-Comparing rect.0p5_SCRIP.nc........OK
-Comparing rect.1p0_SCRIP.nc........OK
-Comparing rect.5p0_SCRIP.nc........OK
+Comparing rect.0p50_SCRIP.nc........OK
+Comparing rect.1p00_SCRIP.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
 Comparing tripole.mx025.Ct.to.mx050.Ct.neareststod.nc........OK
 Comparing tripole.mx050.Bu.to.Ct.bilinear.nc........OK
-Comparing tripole.mx050.Ct.to.rect.0p5.bilinear.nc........OK
-Comparing tripole.mx050.Ct.to.rect.0p5.conserve.nc........OK
-Comparing tripole.mx050.Ct.to.rect.1p0.bilinear.nc........OK
-Comparing tripole.mx050.Ct.to.rect.1p0.conserve.nc........OK
-Comparing tripole.mx050.Ct.to.rect.5p0.bilinear.nc........OK
-Comparing tripole.mx050.Ct.to.rect.5p0.conserve.nc........OK
+Comparing tripole.mx050.Ct.to.rect.0p50.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.rect.0p50.conserve.nc........OK
+Comparing tripole.mx050.Ct.to.rect.1p00.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.rect.1p00.conserve.nc........OK
+Comparing tripole.mx050.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.rect.5p00.conserve.nc........OK
 Comparing tripole.mx050.Cu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx050.Cv.to.Ct.bilinear.nc........OK
 Comparing tripole.mx050.nc........OK
 
 
-Working dir = /lfs/h2/emc/stmp/denise.worthen/CPLD_GRIDGEN/rt_155737/100
-Baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/UFS_UTILS/reg_tests/cpld_gridgen/baseline_data/100.new
+Working dir = /lfs/h2/emc/stmp/denise.worthen/CPLD_GRIDGEN/rt_194650/100
+Baseline dir = /lfs/h2/emc/stmp/denise.worthen/CPLD_GRIDGEN/BASELINE/100
 
 Checking test 100 results ....
 Comparing Bu.mx100_SCRIP.nc........OK
@@ -94,22 +94,22 @@ Comparing Cv.mx100_SCRIP.nc........OK
 Comparing grid_cice_NEMS_mx100.nc........OK
 Comparing kmtu_cice_NEMS_mx100.nc........OK
 Comparing mesh.mx100.nc........OK
-Comparing rect.1p0_SCRIP.nc........OK
-Comparing rect.5p0_SCRIP.nc........OK
+Comparing rect.1p00_SCRIP.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
 Comparing tripole.mx025.Ct.to.mx100.Ct.neareststod.nc........OK
 Comparing tripole.mx100.Bu.to.Ct.bilinear.nc........OK
-Comparing tripole.mx100.Ct.to.rect.1p0.bilinear.nc........OK
-Comparing tripole.mx100.Ct.to.rect.1p0.conserve.nc........OK
-Comparing tripole.mx100.Ct.to.rect.5p0.bilinear.nc........OK
-Comparing tripole.mx100.Ct.to.rect.5p0.conserve.nc........OK
+Comparing tripole.mx100.Ct.to.rect.1p00.bilinear.nc........OK
+Comparing tripole.mx100.Ct.to.rect.1p00.conserve.nc........OK
+Comparing tripole.mx100.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx100.Ct.to.rect.5p00.conserve.nc........OK
 Comparing tripole.mx100.Cu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx100.Cv.to.Ct.bilinear.nc........OK
 Comparing tripole.mx100.nc........OK
 Comparing ufs.topo_edits_011818.nc........OK
 
 
-Working dir = /lfs/h2/emc/stmp/denise.worthen/CPLD_GRIDGEN/rt_155737/500
-Baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/UFS_UTILS/reg_tests/cpld_gridgen/baseline_data/500.new
+Working dir = /lfs/h2/emc/stmp/denise.worthen/CPLD_GRIDGEN/rt_194650/500
+Baseline dir = /lfs/h2/emc/stmp/denise.worthen/CPLD_GRIDGEN/BASELINE/500
 
 Checking test 500 results ....
 Comparing Bu.mx500_SCRIP.nc........OK
@@ -128,16 +128,16 @@ Comparing Cv.mx500_SCRIP.nc........OK
 Comparing grid_cice_NEMS_mx500.nc........OK
 Comparing kmtu_cice_NEMS_mx500.nc........OK
 Comparing mesh.mx500.nc........OK
-Comparing rect.5p0_SCRIP.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
 Comparing tripole.mx025.Ct.to.mx500.Ct.neareststod.nc........OK
 Comparing tripole.mx500.Bu.to.Ct.bilinear.nc........OK
-Comparing tripole.mx500.Ct.to.rect.5p0.bilinear.nc........OK
-Comparing tripole.mx500.Ct.to.rect.5p0.conserve.nc........OK
+Comparing tripole.mx500.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx500.Ct.to.rect.5p00.conserve.nc........OK
 Comparing tripole.mx500.Cu.to.Ct.bilinear.nc........OK
 Comparing tripole.mx500.Cv.to.Ct.bilinear.nc........OK
 Comparing tripole.mx500.nc........OK
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Oct 26 18:48:08 UTC 2023
-Elapsed time: 00h:20m:34s. Have a nice day!
+Sat Dec 16 15:39:10 UTC 2023
+Elapsed time: 00h:19m:23s. Have a nice day!

--- a/sorc/cpld_gridgen.fd/postwgts.F90
+++ b/sorc/cpld_gridgen.fd/postwgts.F90
@@ -42,22 +42,22 @@ contains
     if(trim(res) .eq. '500')then
        ndest = 1
        allocate(destgrds(ndest))
-       destgrds = (/'5p0 '/)
+       destgrds = (/'5p00'/)
     end if
     if(trim(res) .eq. '100')then
        ndest = 2
        allocate(destgrds(ndest))
-       destgrds = (/'5p0 ', '1p0 '/)
+       destgrds = (/'5p00', '1p00'/)
     end if
     if(trim(res) .eq. '050')then
        ndest = 3
        allocate(destgrds(ndest))
-       destgrds = (/'5p0 ', '1p0 ', '0p5 '/)
+       destgrds = (/'5p00', '1p00', '0p50'/)
     end if
     if(trim(res) .eq. '025')then
        ndest = 4
        allocate(destgrds(ndest))
-       destgrds = (/'5p0 ', '1p0 ', '0p5 ', '0p25'/)
+       destgrds = (/'5p00', '1p00', '0p50', '0p25'/)
     end if
 
     !---------------------------------------------------------------------

--- a/ush/cpld_gridgen.sh
+++ b/ush/cpld_gridgen.sh
@@ -52,7 +52,7 @@ if [ $RESNAME = 500 ]; then
     export EDITSFILE='none'
     if [ $DO_POSTWGTS == .true. ]; then
 	#pre-generate SCRIP files for dst rectilinear grids using NCO
-	$APRUN -n 1 ncremap -g ${OUTDIR_PATH}/rect.5p0_SCRIP.nc -G latlon=36,72#lon_typ=grn_ctr#lat_typ=cap
+	$APRUN -n 1 ncremap -g ${OUTDIR_PATH}/rect.5p00_SCRIP.nc -G latlon=36,72#lon_typ=grn_ctr#lat_typ=cap
     fi
 fi
 
@@ -64,8 +64,8 @@ if [ $RESNAME = 100 ]; then
     export EDITSFILE=topo_edits_011818.nc
     if [ $DO_POSTWGTS == .true. ]; then
 	#pre-generate SCRIP files for dst rectilinear grids using NCO
-	$APRUN -n 1 ncremap -g ${OUTDIR_PATH}/rect.5p0_SCRIP.nc -G latlon=36,72#lon_typ=grn_ctr#lat_typ=cap
-	$APRUN -n 1 ncremap -g ${OUTDIR_PATH}/rect.1p0_SCRIP.nc -G latlon=181,360#lon_typ=grn_ctr#lat_typ=cap
+	$APRUN -n 1 ncremap -g ${OUTDIR_PATH}/rect.5p00_SCRIP.nc -G latlon=36,72#lon_typ=grn_ctr#lat_typ=cap
+	$APRUN -n 1 ncremap -g ${OUTDIR_PATH}/rect.1p00_SCRIP.nc -G latlon=181,360#lon_typ=grn_ctr#lat_typ=cap
     fi
 fi
 
@@ -76,9 +76,9 @@ if [ $RESNAME = 050 ]; then
     export EDITSFILE='none'
     if [ $DO_POSTWGTS == .true. ]; then
 	#pre-generate SCRIP files for dst rectilinear grids using NCO
-	$APRUN -n 1 ncremap -g ${OUTDIR_PATH}/rect.5p0_SCRIP.nc -G latlon=36,72#lon_typ=grn_ctr#lat_typ=cap
-	$APRUN -n 1 ncremap -g ${OUTDIR_PATH}/rect.1p0_SCRIP.nc -G latlon=181,360#lon_typ=grn_ctr#lat_typ=cap
-	$APRUN -n 1 ncremap -g ${OUTDIR_PATH}/rect.0p5_SCRIP.nc -G latlon=361,720#lon_typ=grn_ctr#lat_typ=cap
+	$APRUN -n 1 ncremap -g ${OUTDIR_PATH}/rect.5p00_SCRIP.nc -G latlon=36,72#lon_typ=grn_ctr#lat_typ=cap
+	$APRUN -n 1 ncremap -g ${OUTDIR_PATH}/rect.1p00_SCRIP.nc -G latlon=181,360#lon_typ=grn_ctr#lat_typ=cap
+	$APRUN -n 1 ncremap -g ${OUTDIR_PATH}/rect.0p50_SCRIP.nc -G latlon=361,720#lon_typ=grn_ctr#lat_typ=cap
     fi
 fi
 
@@ -89,9 +89,9 @@ if [ $RESNAME = 025 ]; then
     export EDITSFILE=All_edits.nc
     if [ $DO_POSTWGTS == .true. ]; then
 	#pre-generate SCRIP files for dst rectilinear grids using NCO
-	$APRUN -n 1 ncremap -g ${OUTDIR_PATH}/rect.5p0_SCRIP.nc -G latlon=36,72#lon_typ=grn_ctr#lat_typ=cap
-	$APRUN -n 1 ncremap -g ${OUTDIR_PATH}/rect.1p0_SCRIP.nc -G latlon=181,360#lon_typ=grn_ctr#lat_typ=cap
-	$APRUN -n 1 ncremap -g ${OUTDIR_PATH}/rect.0p5_SCRIP.nc -G latlon=361,720#lon_typ=grn_ctr#lat_typ=cap
+	$APRUN -n 1 ncremap -g ${OUTDIR_PATH}/rect.5p00_SCRIP.nc -G latlon=36,72#lon_typ=grn_ctr#lat_typ=cap
+	$APRUN -n 1 ncremap -g ${OUTDIR_PATH}/rect.1p00_SCRIP.nc -G latlon=181,360#lon_typ=grn_ctr#lat_typ=cap
+	$APRUN -n 1 ncremap -g ${OUTDIR_PATH}/rect.0p50_SCRIP.nc -G latlon=361,720#lon_typ=grn_ctr#lat_typ=cap
 	$APRUN -n 1 ncremap -g ${OUTDIR_PATH}/rect.0p25_SCRIP.nc -G latlon=721,1440#lon_typ=grn_ctr#lat_typ=cap
     fi
 fi


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 

Change 3-character descriptions of destination grids for post weight generation to be 4-character by adding a trailing 0 where needed

## TESTS CONDUCTED: 
If there are changes to the build or source code, the tests below must be conducted. Contact a repository manager if you need assistance.

- [x] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera and WCOSS2).
- [x] Compile branch on Hera using GNU. Done using 7839434.
- [x] Compile branch in 'Debug' mode on WCOSS2. Done on Dogwood using 7839434.
- [x] Run unit tests locally on any Tier 1 machine. Done on Hera using 7839434
- [x] Run relevant consistency tests locally on all Tier 1 machine.

Baselines will need to be regenerated because of the change in file names compared, e.g. ``rect.1p0_SCRIP.nc`` and ``tripole.mx025.Ct.to.rect.0p5.bilinear.nc`` will now have names containing ``1p00`` and ``0p50`` , respectively and the regression tests will flag these as missing files. Spot checking of the files confirms that they are in fact identical.


- fixes #882 

