### PR TITLE
removed checks preventing land increments for fractional grids.

### DIFF
--- a/sorc/global_cycle.fd/cycle.f90
+++ b/sorc/global_cycle.fd/cycle.f90
@@ -454,10 +454,6 @@
  ENDIF
 
 IF (DO_LNDINC) THEN
-   IF (FRAC_GRID) THEN
-     print *, 'FATAL ERROR: land increment update does not work with fractional grids.'
-     call MPI_ABORT(MPI_COMM_WORLD, 17, IERR)
-   ENDIF
    ! identify variables to be updated, and allocate arrays.
    IF  (TRIM(LND_SOI_FILE) .NE. "NULL") THEN
        DO_SOI_INC = .TRUE.
@@ -503,11 +499,6 @@ ENDIF
  IF (FRAC_GRID .AND. .NOT. IS_NOAHMP) THEN
    print *, 'FATAL ERROR: NOAH lsm update does not work with fractional grids.'
    call MPI_ABORT(MPI_COMM_WORLD, 18, IERR)
- ENDIF
-
- IF (FRAC_GRID .AND. DO_SNO_INC) THEN
-   print *, 'FATAL ERROR: Snow increment update does not work with fractional grids.'
-   call MPI_ABORT(MPI_COMM_WORLD, 19, IERR)
  ENDIF
 
  IF (IS_NOAHMP .AND. DO_SNO_INC) THEN


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Removed two checks that caused global_cycle to report an error and exit in the case that both land increments were being added and fractional grids are used. 

There are no issues adding soil moisture and soil temperature increments in fractional grid mode, so the code can be allowed to proceed. The snow increment code is only for the Noah model at this stage, which is not run the fractional mode anyway.

## TESTS CONDUCTED: 

- [x] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera, Hercules and WCOSS2).
- [x] Compile branch on Hera using GNU.
- [x] Compile branch in 'Debug' mode on WCOSS2.  Done on Dogwood.
- [x] Run unit tests locally on any Tier 1 machine. Done on Hera.
- [x] Run relevant consistency tests locally on all Tier 1 machine.

## DEPENDENCIES:
none. 

This PR is required for the current global_workflow to be used to be used to perform the soil analysis, in global workflow PR [2263](https://github.com/NOAA-EMC/global-workflow/pull/2263) (still in draft)

## DOCUMENTATION:
none. 

## ISSUE: 
Resolves issue [895](https://github.com/ufs-community/UFS_UTILS/issues/895)