### PR TITLE
Fix broken links in chgres_cube section of ReadTheDocs

### DIFF
--- a/docs/source/chgres_cube.rst
+++ b/docs/source/chgres_cube.rst
@@ -55,7 +55,7 @@ Program inputs and outputs for global applications
 
 **Inputs**
 
-Users may create their own global grids, or use the pre-defined files are located `here <https://ftp.emc.ncep.noaa.gov/EIB/UFS/global/fix/fix_fv3_gmted2010.v20191213/>`_.
+Users may create their own global grids, or use the pre-defined files are located `here <https://ftp.emc.ncep.noaa.gov/static_files/public/UFS/GFS/fix/fix_fv3_gmted2010/>`_.
 
       * FV3 mosaic file - (NetCDF format)
 	      * CRES_mosaic.nc
@@ -76,7 +76,7 @@ Users may create their own global grids, or use the pre-defined files are locate
 	      * CRES_oro_data.tile5.nc
 	      * CRES_oro_data.tile6.nc
 
-      * FV3 surface climatological files - Located under the `./fix_sfc <https://ftp.emc.ncep.noaa.gov/EIB/UFS/global/fix/fix_fv3_gmted2010.v20191213/C48/fix_sfc>`_ sub-directory.  One file for each tile.  NetCDF format.
+      * FV3 surface climatological files - Located under the `./fix_sfc <https://ftp.emc.ncep.noaa.gov/static_files/public/UFS/GFS/fix/fix_fv3_gmted2010/C48/fix_sfc>`_ sub-directory.  One file for each tile.  NetCDF format.
 	      * CRES.facsf.tileX.nc (fractional coverage for strong/weak zenith angle dependent albedo)
 	      * CRES.maximum_snow_albedo.tileX.nc (maximum snow albedo)
 	      * CRES.slope_type.tileX.nc (slope type)

--- a/docs/source/chgres_cube.rst
+++ b/docs/source/chgres_cube.rst
@@ -55,7 +55,7 @@ Program inputs and outputs for global applications
 
 **Inputs**
 
-Users may create their own global grids, or use the pre-defined files are located `here <https://ftp.emc.ncep.noaa.gov/static_files/public/UFS/GFS/fix/fix_fv3_gmted2010/>`_.
+Users may create their own global grids, or use the pre-defined files located `here <https://ftp.emc.ncep.noaa.gov/static_files/public/UFS/GFS/fix/fix_fv3_gmted2010/>`_.
 
       * FV3 mosaic file - (NetCDF format)
 	      * CRES_mosaic.nc


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Two links in the ReadTheDocs file for chgres_cube were updated.

## TESTS CONDUCTED: 
ReadTheDocs was run and the links were checked for correctness.

## DEPENDENCIES:
N/A

## DOCUMENTATION:
Updated ReadTheDocs is here: https://georgegayno-noaaufs-utils.readthedocs.io/en/update_rtd/ufs_utils.html#program-inputs-and-outputs-for-global-applications

## ISSUE: 
Fixes #905.

## CONTRIBUTORS: 
@spencerkclark

