### PR TITLE
Update for Rocky8 on Jet

### DIFF
--- a/modulefiles/build.jet.intel.lua
+++ b/modulefiles/build.jet.intel.lua
@@ -5,7 +5,7 @@ Load environment to compile UFS_UTILS on Jet using Intel
 hpss_ver=os.getenv("hpss_ver") or ""
 load(pathJoin("hpss", hpss_ver))
 
-prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core")
 
 stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 load(pathJoin("stack-intel", stack_intel_ver))

--- a/reg_tests/grid_gen/driver.jet.sh
+++ b/reg_tests/grid_gen/driver.jet.sh
@@ -72,7 +72,7 @@ TEST1=$(sbatch --parsable --ntasks-per-node=24 --nodes=1 -t 0:20:00 -A $PROJECT_
 #-----------------------------------------------------------------------------
 
 LOG_FILE2=${LOG_FILE}02
-TEST2=$(sbatch --parsable --ntasks-per-node=10 --nodes=3 -t 0:15:00 -A $PROJECT_CODE -q $QUEUE -J c96.viirs.bnu \
+TEST2=$(sbatch --parsable --ntasks-per-node=12 --nodes=4 -t 0:15:00 -A $PROJECT_CODE -q $QUEUE -J c96.viirs.bnu \
       --partition=xjet -o $LOG_FILE2 -e $LOG_FILE2 ./c96.viirs.bnu.sh)
 
 #-----------------------------------------------------------------------------

--- a/reg_tests/ice_blend/driver.jet.sh
+++ b/reg_tests/ice_blend/driver.jet.sh
@@ -53,9 +53,9 @@ fi
 
 export WGRIB=/apps/wgrib/1.8.1.0b/bin/wgrib
 export WGRIB2=${WGRIB2_ROOT}/bin/wgrib2
-export COPYGB=/lfs4/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/grib_util/NCEPLIBS-grib_util/exec/bin/copygb
-export COPYGB2=/lfs4/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/grib_util/NCEPLIBS-grib_util/exec/bin/copygb2
-export CNVGRIB=/apps/cnvgrib/1.4.0/bin/cnvgrib
+export COPYGB=/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/intel/2021.5.0/grib-util-1.3.0-hrqavdi/bin/copygb
+export COPYGB2=/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/intel/2021.5.0/grib-util-1.3.0-hrqavdi/bin/copygb2
+export CNVGRIB=/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/intel/2021.5.0/grib-util-1.3.0-hrqavdi/bin/cnvgrib
 
 export HOMEreg=/lfs4/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/reg_tests/ice_blend
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Update build module to use the Rocky8 version of spack-stack.
- Update the ice blend regression test script to use Rocky8 versions of `copygb/2` and `cnvgrib`.
- Increase requested memory for one `grid_gen` regression test.

## TESTS CONDUCTED: 
If there are changes to the build or source code, the tests below must be conducted. Contact a repository manager if you need assistance.

- [x] Compile branch on Jet using Intel. Done using 92f5252.
- [x] Run unit tests locally on Jet. Done using 92f5252. All tests passed.
- [x] Run all consistency tests on Jet. Done using 92f5252. All tests passed except one `chgres_cube` test. Details below.

Additional tests using 92f5252:
- Successfully created a C96 grid using .`/driver_scripts/driver_grid.jet.sh`.
- Successfully ran the `weight_gen` utility (`./util/weight_gen`)
- Successfully ran the `gdas_init` utility to produce coldstart files for a GFS 2024/03/06/06z case (`./util/gdas_init`)

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #918.


