### PR TITLE
Add instructions for the gdas_init utility to readthedocs

### DIFF
--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -691,13 +691,19 @@ Find it here: ./util/gdas_init
 Build UFS_UTILS and set 'fixed' directories
 -------------------------------------------
 
-     * Invoke the build script from the root directory: 
+Invoke the build script from the root directory: 
 
 ::
 
-       ./build_all.sh
+  ./build_all.sh
 
-     * Set the 'fixed' directories using the script in the 'fix' subdirectory: ``./link_fixdirs.sh emc $MACHINE`` (where MACHINE is 'hera', 'jet', 'wcoss2', or 's4')
+Set the 'fixed' directories using the script in the 'fix' subdirectory:
+
+::
+
+  ./link_fixdirs.sh emc $MACHINE
+
+where MACHINE is 'hera', 'jet', 'wcoss2', or 's4'.
 
 Configure for your experiment
 -----------------------------

--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -697,4 +697,31 @@ Build UFS_UTILS and set 'fixed' directories
 Configure for your experiment
 -----------------------------
 
-Edit the 'config' file in ./util/gdas_init
+Edit the variables in the 'config' file (located in ./util/gdas_init) for your experiment:
+
+     * EXTRACT_DIR  - Directory where data extracted from HPSS is stored.
+     * EXTRACT_DATA - Set to 'yes' to extract data from HPSS. If data has been extracted and is located in EXTRACT_DIR, set to 'no'.
+# RUN_CHGRES   - To run chgres, set to 'yes'.  To extract
+#                data only, set to 'no'.
+# yy/mm/dd/hh  - The year/month/day/hour of your desired
+#                experiment.  Currently, does not support
+#                pre-ENKF GFS data, prior to
+#                2012 May 21 00z.  Use two digits.
+# LEVS         - Number of hybrid levels plus 1.  To
+#                run with 64 levels, set LEVS to 65.
+# CRES_HIRES   - Resolution of the hires component of
+#                your experiment.
+# CRES_ENKF    - Resolution of the enkf component of the
+#                your experiment.
+# UFS_DIR      - Location of your checked out UFS_UTILS
+#                repo.
+# OUTDIR       - Directory where the coldstart data output
+#                from chgres is stored.
+# CDUMP        - When 'gdas', will process gdas and enkf
+#                members. When 'gfs', will process gfs
+#                member for running free forecast only.
+# use_v16retro - When 'yes', use v16 retro parallel data.
+#                The retro parallel tarballs can be missing
+#                or incomplete. So this option may not
+#                always work. Contact george.gayno@noaa.gov
+#                if you encounter problems.

--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -697,13 +697,11 @@ Invoke the build script from the root directory:
 
   ./build_all.sh
 
-Set the 'fixed' directories using the script in the 'fix' subdirectory:
+Set the 'fixed' directories using the script in the './fix' subdirectory (where $MACHINE is 'hera', 'jet', 'wcoss2', or 's4'):
 
 ::
 
   ./link_fixdirs.sh emc $MACHINE
-
-where MACHINE is 'hera', 'jet', 'wcoss2', or 's4'.
 
 Configure for your experiment
 -----------------------------

--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -711,6 +711,9 @@ Edit the variables in the 'config' file for your experiment:
      * **CDUMP**        - When 'gdas', will process gdas and enkf members. When 'gfs', will process gfs member for running free forecast only.
      * **use_v16retro** - When 'yes', use v16 retrospective parallel data. The retro parallel tarballs can be missing or incomplete. So this option may not always work. Contact a UFS_UTILS repository manager if you encounter problems.
 
+Note: This utility selects the ocean resolution in the set_fixed_files.sh script using a default based on the user-selected CRES value. For example, for a cycled experiment with a CRES_HIRES/CRES_ENKF of C384/C192, the ocean resolution defaults to 0.25/0.50-degree. To choose another ocean resolution, the user will need to manually modify the set_fixed_files.sh script.
+
+
 Kick off the utility
 --------------------
 

--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -672,3 +672,29 @@ UFS_UTILS utilities
 
 gdas_init
 =========
+
+Introduction
+------------
+
+The gdas_init utility is used to create coldstart initial conditions for global cycled experiments using the chgres_cube program.  It has two components, one that pulls the input data required by chgres_cube from HPSS, and one that runs chgres_cube. The utility is only supported on machines with access to HPSS:
+
+     * Hera
+     * Jet
+     * WCOSS2
+     * S4 (Only the chgres step is supported, not the data pull step.)
+
+Location
+--------
+
+Find it here: ./util/gdas_init
+
+Build UFS_UTILS and set 'fixed' directories
+-------------------------------------------
+
+     * Invoke the build script from the root directory: ./build_all.sh
+     * Set the 'fixed' directories using the script in the 'fix' subdirectory: ./link_fixdirs.sh emc $MACHINE (where MACHINE is 'hera', 'jet', 'wcoss2', or 's4')
+
+Configure for your experiment
+-----------------------------
+
+Edit the 'config' file in ./util/gdas_init

--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -691,7 +691,11 @@ Find it here: ./util/gdas_init
 Build UFS_UTILS and set 'fixed' directories
 -------------------------------------------
 
-     * Invoke the build script from the root directory: ``./build_all.sh``
+     * Invoke the build script from the root directory: 
+
+::
+./build_all.sh
+
      * Set the 'fixed' directories using the script in the 'fix' subdirectory: ``./link_fixdirs.sh emc $MACHINE`` (where MACHINE is 'hera', 'jet', 'wcoss2', or 's4')
 
 Configure for your experiment
@@ -717,13 +721,11 @@ Note: This utility selects the ocean resolution in the set_fixed_files.sh script
 Kick off the utility
 --------------------
 
-Submit the script for your machine: 
+Submit the driver script (where $MACHINE is 'hera', 'jet', 'wcoss2', or 's4')
 
 ::
 
   ./driver.$MACHINE.sh 
-
-where MACHINE IS 'hera', 'jet', 'wcoss2', or 's4'.
 
 The standard output will be placed in log files in the current directory. 
 

--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -665,3 +665,10 @@ Run script
 ----------
 
 To run, use the machine-dependent script under ./util/weight_gen
+
+***************************************************
+UFS_UTILS utilities
+***************************************************
+
+gdas_init
+=========

--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -695,7 +695,7 @@ Build UFS_UTILS and set 'fixed' directories
 
 ::
 
-./build_all.sh
+       ./build_all.sh
 
      * Set the 'fixed' directories using the script in the 'fix' subdirectory: ``./link_fixdirs.sh emc $MACHINE`` (where MACHINE is 'hera', 'jet', 'wcoss2', or 's4')
 

--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -701,27 +701,12 @@ Edit the variables in the 'config' file (located in ./util/gdas_init) for your e
 
      * EXTRACT_DIR  - Directory where data extracted from HPSS is stored.
      * EXTRACT_DATA - Set to 'yes' to extract data from HPSS. If data has been extracted and is located in EXTRACT_DIR, set to 'no'.
-# RUN_CHGRES   - To run chgres, set to 'yes'.  To extract
-#                data only, set to 'no'.
-# yy/mm/dd/hh  - The year/month/day/hour of your desired
-#                experiment.  Currently, does not support
-#                pre-ENKF GFS data, prior to
-#                2012 May 21 00z.  Use two digits.
-# LEVS         - Number of hybrid levels plus 1.  To
-#                run with 64 levels, set LEVS to 65.
-# CRES_HIRES   - Resolution of the hires component of
-#                your experiment.
-# CRES_ENKF    - Resolution of the enkf component of the
-#                your experiment.
-# UFS_DIR      - Location of your checked out UFS_UTILS
-#                repo.
-# OUTDIR       - Directory where the coldstart data output
-#                from chgres is stored.
-# CDUMP        - When 'gdas', will process gdas and enkf
-#                members. When 'gfs', will process gfs
-#                member for running free forecast only.
-# use_v16retro - When 'yes', use v16 retro parallel data.
-#                The retro parallel tarballs can be missing
-#                or incomplete. So this option may not
-#                always work. Contact george.gayno@noaa.gov
-#                if you encounter problems.
+     * RUN_CHGRES   - To run chgres, set to 'yes'.  To extract data only, set to 'no'.
+     * yy/mm/dd/hh  - The year/month/day/hour of your desired experiment.  Currently, does not support pre-ENKF GFS data, prior to 2012 May 21 00z.  Use two digits.
+     * LEVS         - Number of hybrid levels plus 1.  To run with 64 levels, set LEVS to 65.
+     * CRES_HIRES   - Resolution of the hires component of your experiment. Example: C768.
+     * CRES_ENKF    - Resolution of the enkf component of the experiments.
+     * UFS_DIR      - Location of your cloned UFS_UTILS repository.
+     * OUTDIR       - Directory where the coldstart data output from chgres is stored.
+     * CDUMP        - When 'gdas', will process gdas and enkf members. When 'gfs', will process gfs member for running free forecast only.
+     * use_v16retro - When 'yes', use v16 retrospective parallel data. The retro parallel tarballs can be missing or incomplete. So this option may not always work. Contact a UFS_UTILS repository manager if you encounter problems.

--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -694,6 +694,7 @@ Build UFS_UTILS and set 'fixed' directories
      * Invoke the build script from the root directory: 
 
 ::
+
 ./build_all.sh
 
      * Set the 'fixed' directories using the script in the 'fix' subdirectory: ``./link_fixdirs.sh emc $MACHINE`` (where MACHINE is 'hera', 'jet', 'wcoss2', or 's4')

--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -718,7 +718,7 @@ Edit the variables in the 'config' file for your experiment:
      * **UFS_DIR**      - Location of your cloned UFS_UTILS repository.
      * **OUTDIR**       - Directory where the coldstart data output from chgres is stored.
      * **CDUMP**        - When 'gdas', will process gdas and enkf members. When 'gfs', will process gfs member for running free forecast only.
-     * **use_v16retro** - When 'yes', use v16 retrospective parallel data. The retro parallel tarballs can be missing or incomplete. So this option may not always work. Contact a UFS_UTILS repository manager if you encounter problems.
+     * **use_v16retro** - When 'yes', use v16 retrospective parallel data. The retrospective parallel tarballs can be missing or incomplete. So this option may not always work. Contact a UFS_UTILS repository manager if you encounter problems.
 
 Note: This utility selects the ocean resolution in the set_fixed_files.sh script using a default based on the user-selected CRES value. For example, for a cycled experiment with a CRES_HIRES/CRES_ENKF of C384/C192, the ocean resolution defaults to 0.25/0.50-degree. To choose another ocean resolution, the user will need to manually modify the set_fixed_files.sh script.
 

--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -692,21 +692,21 @@ Build UFS_UTILS and set 'fixed' directories
 -------------------------------------------
 
      * Invoke the build script from the root directory: ``./build_all.sh``
-     * Set the 'fixed' directories using the script in the 'fix' subdirectory: ./link_fixdirs.sh emc $MACHINE (where MACHINE is 'hera', 'jet', 'wcoss2', or 's4')
+     * Set the 'fixed' directories using the script in the 'fix' subdirectory: ``./link_fixdirs.sh emc $MACHINE`` (where MACHINE is 'hera', 'jet', 'wcoss2', or 's4')
 
 Configure for your experiment
 -----------------------------
 
-Edit the variables in the 'config' file (located in ./util/gdas_init) for your experiment:
+Edit the variables in the 'config' file (located in ``./util/gdas_init``) for your experiment:
 
-     * EXTRACT_DIR  - Directory where data extracted from HPSS is stored.
+     * **EXTRACT_DIR**  - Directory where data extracted from HPSS is stored.
      * **EXTRACT_DATA** - Set to 'yes' to extract data from HPSS. If data has been extracted and is located in EXTRACT_DIR, set to 'no'.
-     * RUN_CHGRES   - To run chgres, set to 'yes'.  To extract data only, set to 'no'.
-     * yy/mm/dd/hh  - The year/month/day/hour of your desired experiment.  Currently, does not support pre-ENKF GFS data, prior to 2012 May 21 00z.  Use two digits.
-     * LEVS         - Number of hybrid levels plus 1.  To run with 64 levels, set LEVS to 65.
-     * CRES_HIRES   - Resolution of the hires component of your experiment. Example: C768.
-     * CRES_ENKF    - Resolution of the enkf component of the experiments.
-     * UFS_DIR      - Location of your cloned UFS_UTILS repository.
-     * OUTDIR       - Directory where the coldstart data output from chgres is stored.
-     * CDUMP        - When 'gdas', will process gdas and enkf members. When 'gfs', will process gfs member for running free forecast only.
-     * use_v16retro - When 'yes', use v16 retrospective parallel data. The retro parallel tarballs can be missing or incomplete. So this option may not always work. Contact a UFS_UTILS repository manager if you encounter problems.
+     * **RUN_CHGRES**   - To run chgres, set to 'yes'.  To extract data only, set to 'no'.
+     * **yy/mm/dd/hh**  - The year/month/day/hour of your desired experiment.  Currently, does not support pre-ENKF GFS data, prior to 2012 May 21 00z.  Use two digits.
+     * **LEVS**         - Number of hybrid levels plus 1.  To run with 64 levels, set LEVS to 65.
+     * **CRES_HIRES**   - Resolution of the hires component of your experiment. Example: C768.
+     * **CRES_ENKF**    - Resolution of the enkf component of the experiments.
+     * **UFS_DIR**      - Location of your cloned UFS_UTILS repository.
+     * **OUTDIR**       - Directory where the coldstart data output from chgres is stored.
+     * **CDUMP**        - When 'gdas', will process gdas and enkf members. When 'gfs', will process gfs member for running free forecast only.
+     * **use_v16retro** - When 'yes', use v16 retrospective parallel data. The retro parallel tarballs can be missing or incomplete. So this option may not always work. Contact a UFS_UTILS repository manager if you encounter problems.

--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -676,7 +676,7 @@ gdas_init
 Introduction
 ------------
 
-The gdas_init utility is used to create coldstart initial conditions for global cycled experiments using the chgres_cube program.  It has two components: one that pulls the input data required by chgres_cube from HPSS, and one that runs chgres_cube. The utility is only supported on machines with access to HPSS:
+The gdas_init utility is used to create coldstart initial conditions for global cycled and forecast-only experiments using the chgres_cube program.  It has two components: one that pulls the input data required by chgres_cube from HPSS, and one that runs chgres_cube. The utility is only supported on machines with access to HPSS:
 
      * Hera
      * Jet
@@ -703,7 +703,7 @@ Edit the variables in the 'config' file for your experiment:
      * **EXTRACT_DATA** - Set to 'yes' to extract data from HPSS. If data has been extracted and is located in EXTRACT_DIR, set to 'no'. On 's4' this step can't be run. Instead, the data must be pulled from another machine.
      * **RUN_CHGRES**   - To run chgres, set to 'yes'.  To extract data only, set to 'no'.
      * **yy/mm/dd/hh**  - The year/month/day/hour of your desired experiment.  Currently, does not support pre-ENKF GFS data, prior to 2012 May 21 00z.  Use two digits.
-     * **LEVS**         - Number of hybrid levels plus 1.  To run with 64 levels, set LEVS to 65.
+     * **LEVS**         - Number of hybrid levels plus 1.  To run with 127 levels, set LEVS to 128.
      * **CRES_HIRES**   - Resolution of the hires component of your experiment. Example: C768.
      * **CRES_ENKF**    - Resolution of the enkf component of the experiments.
      * **UFS_DIR**      - Location of your cloned UFS_UTILS repository.

--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -676,17 +676,17 @@ gdas_init
 Introduction
 ------------
 
-The gdas_init utility is used to create coldstart initial conditions for global cycled experiments using the chgres_cube program.  It has two components, one that pulls the input data required by chgres_cube from HPSS, and one that runs chgres_cube. The utility is only supported on machines with access to HPSS:
+The gdas_init utility is used to create coldstart initial conditions for global cycled experiments using the chgres_cube program.  It has two components: one that pulls the input data required by chgres_cube from HPSS, and one that runs chgres_cube. The utility is only supported on machines with access to HPSS:
 
      * Hera
      * Jet
      * WCOSS2
-     * S4 (Only the chgres step is supported, not the data pull step.)
+     * S4 (Only the chgres_cube step is supported, not the data pull step.)
 
 Location
 --------
 
-Find it here: ``./util/gdas_init``
+Find it here: ./util/gdas_init
 
 Build UFS_UTILS and set 'fixed' directories
 -------------------------------------------
@@ -697,7 +697,7 @@ Build UFS_UTILS and set 'fixed' directories
 Configure for your experiment
 -----------------------------
 
-Edit the variables in the 'config' file (located in ``./util/gdas_init``) for your experiment:
+Edit the variables in the 'config' file for your experiment:
 
      * **EXTRACT_DIR**  - Directory where data extracted from HPSS is stored.
      * **EXTRACT_DATA** - Set to 'yes' to extract data from HPSS. If data has been extracted and is located in EXTRACT_DIR, set to 'no'. On 's4' this step can't be run. Instead, the data must be pulled from another machine.

--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -700,7 +700,7 @@ Configure for your experiment
 Edit the variables in the 'config' file (located in ``./util/gdas_init``) for your experiment:
 
      * **EXTRACT_DIR**  - Directory where data extracted from HPSS is stored.
-     * **EXTRACT_DATA** - Set to 'yes' to extract data from HPSS. If data has been extracted and is located in EXTRACT_DIR, set to 'no'.
+     * **EXTRACT_DATA** - Set to 'yes' to extract data from HPSS. If data has been extracted and is located in EXTRACT_DIR, set to 'no'. On 's4' this step can't be run. Instead, the data must be pulled from another machine.
      * **RUN_CHGRES**   - To run chgres, set to 'yes'.  To extract data only, set to 'no'.
      * **yy/mm/dd/hh**  - The year/month/day/hour of your desired experiment.  Currently, does not support pre-ENKF GFS data, prior to 2012 May 21 00z.  Use two digits.
      * **LEVS**         - Number of hybrid levels plus 1.  To run with 64 levels, set LEVS to 65.
@@ -710,3 +710,12 @@ Edit the variables in the 'config' file (located in ``./util/gdas_init``) for yo
      * **OUTDIR**       - Directory where the coldstart data output from chgres is stored.
      * **CDUMP**        - When 'gdas', will process gdas and enkf members. When 'gfs', will process gfs member for running free forecast only.
      * **use_v16retro** - When 'yes', use v16 retrospective parallel data. The retro parallel tarballs can be missing or incomplete. So this option may not always work. Contact a UFS_UTILS repository manager if you encounter problems.
+
+Kick off the utility
+--------------------
+
+Submit the script for your machine: ``./driver.$MACHINE.sh`` where MACHINE IS 'hera', 'jet', 'wcoss2', or 's4'.
+
+The standard output will be placed in log files in the current directory. 
+
+The converted output will be found in $OUTDIR, including the needed abias and radstat initial condition files (if CDUMP=gdas). The files will be in the needed directory structure for the global-workflow system, therefore a user can move the contents of their $OUTDIR directly into their $ROTDIR.

--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -717,7 +717,13 @@ Note: This utility selects the ocean resolution in the set_fixed_files.sh script
 Kick off the utility
 --------------------
 
-Submit the script for your machine: ``./driver.$MACHINE.sh`` where MACHINE IS 'hera', 'jet', 'wcoss2', or 's4'.
+Submit the script for your machine: 
+
+::
+
+  ./driver.$MACHINE.sh 
+
+where MACHINE IS 'hera', 'jet', 'wcoss2', or 's4'.
 
 The standard output will be placed in log files in the current directory. 
 

--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -686,12 +686,12 @@ The gdas_init utility is used to create coldstart initial conditions for global 
 Location
 --------
 
-Find it here: ./util/gdas_init
+Find it here: ``./util/gdas_init``
 
 Build UFS_UTILS and set 'fixed' directories
 -------------------------------------------
 
-     * Invoke the build script from the root directory: ./build_all.sh
+     * Invoke the build script from the root directory: ``./build_all.sh``
      * Set the 'fixed' directories using the script in the 'fix' subdirectory: ./link_fixdirs.sh emc $MACHINE (where MACHINE is 'hera', 'jet', 'wcoss2', or 's4')
 
 Configure for your experiment
@@ -700,7 +700,7 @@ Configure for your experiment
 Edit the variables in the 'config' file (located in ./util/gdas_init) for your experiment:
 
      * EXTRACT_DIR  - Directory where data extracted from HPSS is stored.
-     * EXTRACT_DATA - Set to 'yes' to extract data from HPSS. If data has been extracted and is located in EXTRACT_DIR, set to 'no'.
+     * **EXTRACT_DATA** - Set to 'yes' to extract data from HPSS. If data has been extracted and is located in EXTRACT_DIR, set to 'no'.
      * RUN_CHGRES   - To run chgres, set to 'yes'.  To extract data only, set to 'no'.
      * yy/mm/dd/hh  - The year/month/day/hour of your desired experiment.  Currently, does not support pre-ENKF GFS data, prior to 2012 May 21 00z.  Use two digits.
      * LEVS         - Number of hybrid levels plus 1.  To run with 64 levels, set LEVS to 65.

--- a/util/gdas_init/set_fixed_files.sh
+++ b/util/gdas_init/set_fixed_files.sh
@@ -2,6 +2,7 @@
 
 #---------------------------------------------------------------------------
 # Set directory names and file names for the target grid orog data.
+# A default ocean resolution (OCNRES) based on CTAR is used.
 #---------------------------------------------------------------------------
 
 if [ ${CTAR} == 'C48' ] ; then


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Add section to readthedocs for the gdas_init utility.

## TESTS CONDUCTED: 
N/A

## DEPENDENCIES:
https://github.com/NOAA-EMC/global-workflow/pull/2397

## DOCUMENTATION:
https://georgegayno-noaaufs-utils.readthedocs.io/en/gi_doc/ufs_utils.html#gdas-init

## ISSUE: 
Fixes #915.