### PR TITLE
Point to another version of wgrib2 for the regression tests on Jet.

### DIFF
--- a/reg_tests/ice_blend/driver.jet.sh
+++ b/reg_tests/ice_blend/driver.jet.sh
@@ -31,8 +31,7 @@ set -x
 source ../../sorc/machine-setup.sh > /dev/null 2>&1
 module use ../../modulefiles
 module load build.$target.intel
-module load gnu/9.2.0
-module load wgrib2/3.1.1_ncep
+module load wgrib2/2.0.8
 set +x
 module list
 set -x
@@ -52,7 +51,6 @@ if [ "$UPDATE_BASELINE" = "TRUE" ]; then
 fi
 
 export WGRIB=/apps/wgrib/1.8.1.0b/bin/wgrib
-export WGRIB2=${WGRIB2_ROOT}/bin/wgrib2
 export COPYGB=/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/intel/2021.5.0/grib-util-1.3.0-hrqavdi/bin/copygb
 export COPYGB2=/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/intel/2021.5.0/grib-util-1.3.0-hrqavdi/bin/copygb2
 export CNVGRIB=/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/intel/2021.5.0/grib-util-1.3.0-hrqavdi/bin/cnvgrib

--- a/reg_tests/snow2mdl/driver.jet.sh
+++ b/reg_tests/snow2mdl/driver.jet.sh
@@ -24,8 +24,7 @@ set -x
 source ../../sorc/machine-setup.sh > /dev/null 2>&1
 module use ../../modulefiles
 module load build.$target.intel
-module load gnu/9.2.0
-module load wgrib2/3.1.1_ncep
+module load wgrib2/2.0.8
 set +x
 module list
 set -x
@@ -50,7 +49,6 @@ fi
 export HOMEreg=/lfs4/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/reg_tests/snow2mdl
 export HOMEgfs=$PWD/../..
 export WGRIB=/apps/wgrib/1.8.1.0b/bin/wgrib
-export WGRIB2=${WGRIB2_ROOT}/bin/wgrib2
 
 rm -fr $DATA_ROOT
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The version of wgrib2 used by the `ice_blend` and `snow2mdl` regression tests on Jet no longer exists.
Update the driver scripts for these tests to use `v2.0.8` and remove the patch used to set the WGRIB2
environment variable due to a bug in the `v3.1.1_ncep` modulefile.

## TESTS CONDUCTED: 

Tests done using 952df04.

- [x] Compile branch on Jet using Intel.
- [x] Run unit tests locally on Jet. All passed as expected.
- [x] Run relevant `ice_blend` and `snow2mdl` tests on Jet. Both tests passed as expected.

## DEPENDENCIES:
None.

## DOCUMENTATION:
No updates needed.

## ISSUE: 
Fixes #930.
