### PR TITLE
Include fre-nctools.fd in GFS builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,6 @@ option(GFS "Enable building GFS-only utilities" OFF)
 # When building the GFS, the following need not be built
 if(GFS)
   message(STATUS "Building utilities specific to the GFS")
-  set(FRENCTOOLS OFF CACHE BOOL "Disable building fre-nctools.fd" FORCE)
   set(GRIDTOOLS OFF CACHE BOOL "Disable building grid_tools.fd" FORCE)
   set(OROG_MASK_TOOLS OFF CACHE BOOL "Disable building orog_mask_tools.fd" FORCE)
   set(SFC_CLIMO_GEN OFF CACHE BOOL "Disable building sfc_climo_gen.fd" FORCE)


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
GFSv17 plans to use `fregrid` to regrid cube sphere restarts from the deterministic to the ensemble resolution to support snow DA. Currently, when built in the global-workflow, UFS_UTILS does not build `fre-nctools.fd`. This PR updates the CMakeLists.txt to not exclude `fre-nctools.fd` when building with the GFS option.

## TESTS CONDUCTED: 
- [x] Compile branch (normal compilation) on all Tier 1 machines using Intel (Orion, Jet, Hera, Hercules and WCOSS2). Ensure all executables are built.
- [x] Compile branch with 'GFS' build switch ON (any machine). Ensure `fregrid` and other programs used by GFS are created.

Describe any additional tests performed.

## DEPENDENCIES:
None

## DOCUMENTATION:
N/A

## ISSUE: 
No issue was created

## CONTRIBUTORS: 
@jiaruidong2017 helped test and verify that fregrid will work for our needs
