### PR TITLE
Port to Orion Rocky 9

### DIFF
--- a/modulefiles/build.orion.intel.lua
+++ b/modulefiles/build.orion.intel.lua
@@ -2,12 +2,12 @@ help([[
 Load environment to compile UFS_UTILS on Orion using Intel
 ]])
 
-prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/unified-env-rocky9/install/modulefiles/Core")
 
-stack_intel_ver=os.getenv("stack_intel_ver") or "2022.0.2"
+stack_intel_ver=os.getenv("stack_intel_ver") or "2021.9.0"
 load(pathJoin("stack-intel", stack_intel_ver))
 
-stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"
+stack_impi_ver=os.getenv("stack_impi_ver") or "2021.9.0"
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
 
 cmake_ver=os.getenv("cmake_ver") or "3.23.1"

--- a/reg_tests/ice_blend/driver.orion.sh
+++ b/reg_tests/ice_blend/driver.orion.sh
@@ -32,6 +32,8 @@ set -x
 source ../../sorc/machine-setup.sh > /dev/null 2>&1
 module use ../../modulefiles
 module load build.$target.intel
+module load grib-util/1.3.0
+module load wgrib2/2.0.8
 module list
 
 ulimit -s unlimited
@@ -49,12 +51,6 @@ export UPDATE_BASELINE="FALSE"
 if [ "$UPDATE_BASELINE" = "TRUE" ]; then
   source ../get_hash.sh
 fi
-
-export WGRIB=/apps/contrib/NCEPLIBS/orion/utils/grib_util.v1.2.0/exec/wgrib
-export WGRIB2=/apps/contrib/NCEPLIBS/orion/utils/grib_util.v1.2.0/exec/wgrib2
-export COPYGB=/apps/contrib/NCEPLIBS/lib/NCEPLIBS-grib_util/v1.1.1/exec/copygb
-export COPYGB2=/apps/contrib/NCEPLIBS/orion/utils/grib_util.v1.2.0/exec/copygb2
-export CNVGRIB=/apps/contrib/NCEPLIBS/orion/utils/grib_util.v1.2.0/exec/cnvgrib
 
 export HOMEreg=/work/noaa/nems/role-nems/ufs_utils/reg_tests/ice_blend
 export HOMEgfs=$PWD/../..

--- a/reg_tests/snow2mdl/driver.orion.sh
+++ b/reg_tests/snow2mdl/driver.orion.sh
@@ -23,6 +23,8 @@ set -x
 source ../../sorc/machine-setup.sh > /dev/null 2>&1
 module use ../../modulefiles
 module load build.$target.intel
+module load grib-util/1.3.0
+module load wgrib2/2.0.8
 module list
 
 ulimit -s unlimited
@@ -48,8 +50,6 @@ rm -fr $DATA_ROOT
 
 export HOMEreg=/work/noaa/nems/role-nems/ufs_utils/reg_tests/snow2mdl
 export HOMEgfs=$PWD/../..
-export WGRIB=/apps/contrib/NCEPLIBS/orion/utils/grib_util.v1.2.0/exec/wgrib
-export WGRIB2=/apps/contrib/NCEPLIBS/orion/utils/grib_util.v1.2.0/exec/wgrib2
 
 # The first test mimics GFS OPS.
 

--- a/sorc/machine-setup.sh
+++ b/sorc/machine-setup.sh
@@ -50,7 +50,7 @@ elif [[ -d /gpfs && -d /ncrc ]] ; then
     fi
     module reset
     target=gaea
-elif [[ "$(hostname)" =~ "Orion" ]]; then
+elif [[ "$(hostname)" =~ "Orion" || "$(hostname)" =~ "orion" ]]; then
     target="orion"
     module purge
 elif [[ "$(hostname)" =~ "hercules" || "$(hostname)" =~ "Hercules" ]]; then


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Orion was recently upgraded to Rocky 9. 
- Update the build module to use Rocky 9 spack-stack.
- Replace hardcoding of grib utility programs in the regression test driver scripts with module loads.
- Update the `machine_setup.sh` script, which did not recognize Orion after the upgrade.

## TESTS CONDUCTED: 

- [x] Compile branch on all Tier 1 machines using Intel. Done using 9199f4a.
- [x] Run unit tests on Orion. All passed using 3923373.
- [x] Run relevant consistency tests on Orion. Done using 3923373. Some passed. Some failed, but the differences are small and consistent with a change in OS. See comments below for more details:

- https://github.com/ufs-community/UFS_UTILS/pull/966#issuecomment-2187099282
- https://github.com/ufs-community/UFS_UTILS/pull/966#issuecomment-2187121462
- https://github.com/ufs-community/UFS_UTILS/pull/966#issuecomment-2186677382

## DEPENDENCIES:
https://github.com/NOAA-EMC/global-workflow/issues/2694

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #963.