### PR TITLE
Update the gdas_init utility for the new NCO-specified 'model' directory

### DIFF
--- a/util/gdas_init/copy_coldstart_files.sh
+++ b/util/gdas_init/copy_coldstart_files.sh
@@ -10,7 +10,7 @@ copy_data()
 
   MEM=$1
 
-  SAVEDIR_MODEL_DATA=$SUBDIR/model_data/atmos/input
+  SAVEDIR_MODEL_DATA=$SUBDIR/model/atmos/input
   mkdir -p $SAVEDIR_MODEL_DATA
   cp gfs_ctrl.nc $SAVEDIR_MODEL_DATA
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Update the `gdas_init` utility for the new NCO-specified 'model' directory in COM 
paths -> `model_data` is now just `model`.

## TESTS CONDUCTED: 
The `gdas_init` utility was tested on Hera. See the comments for details.

## DEPENDENCIES:
N/A

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #967.
Related to: https://github.com/NOAA-EMC/global-workflow/issues/2686