### PR TITLE
update fix dir path for Gaea to a shared directory

### DIFF
--- a/fix/link_fixdirs.sh
+++ b/fix/link_fixdirs.sh
@@ -55,7 +55,7 @@ elif [ $machine = "wcoss2" ]; then
 elif [ $machine = "s4" ]; then
     FIX_DIR="/data/prod/glopara/fix"
 elif [ $machine = "gaea" ]; then
-    FIX_DIR="/gpfs/f5/epic/proj-shared/global/glopara/data/fix"
+    FIX_DIR="/gpfs/f5/ufs-ard/world-shared/global/glopara/data/fix"
 fi
 
 am_ver=${am_ver:-20220805}


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
In fix/link_fixdirs.sh for Gaea, FIX_DIR pointed to a directory owned by EPIC, which limited access to other project users.  The link directory has been updated to a world-shared directory structure where permissions include all users.

## TESTS CONDUCTED: 
Cloned, set up links, and built on Gaea.

## ISSUE: 
Fixes issue mentioned in #971 