### PR TITLE
Update default ocean resolution in the gdas_init utility

### DIFF
--- a/util/gdas_init/set_fixed_files.sh
+++ b/util/gdas_init/set_fixed_files.sh
@@ -10,7 +10,7 @@ if [ ${CTAR} == 'C48' ] ; then
 elif [ ${CTAR} == 'C96' ]; then
   OCNRES='500'
 elif [ ${CTAR} == 'C192' ]; then
-  OCNRES='050'
+  OCNRES='025'
 elif [ ${CTAR} == 'C384' ]; then
   OCNRES='025'
 elif [ ${CTAR} == 'C768' ]; then


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The default ocean resolution for C192 was updated to 0.25-degree.

## TESTS CONDUCTED: 
The `gdas_init` utility was run on a 20240806/06z test case on Hera using 05f0120. 

CDUMP was set to 'gdas' and CRES_HIRES was set to C192. 

The log file indicated that the 0.25-degree 'fixed' files were used. The log file (log.gdas) and the coldstart files from the run were placed here: `/scratch2/NCEPDEV/stmp1/George.Gayno/gdas.init/output`

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #979.

## CONTRIBUTORS: 
@CatherineThomas-NOAA
