### PR TITLE
ocean_merge - Increase directory path variable length

### DIFF
--- a/sorc/ocean_merge.fd/merge_lake_ocnmsk.F90
+++ b/sorc/ocean_merge.fd/merge_lake_ocnmsk.F90
@@ -18,8 +18,8 @@ program merge_lake_ocnmsk
 
   implicit none
 
-  character(len=120) :: pth1
-  character(len=120) :: pth2,pth3
+  character(len=200) :: pth1
+  character(len=200) :: pth2,pth3
   character(len=10)  :: atmres,ocnres
 
   integer :: binary_lake

--- a/sorc/ocean_merge.fd/namelist.F90
+++ b/sorc/ocean_merge.fd/namelist.F90
@@ -16,9 +16,9 @@ subroutine read_nml(ocean_mask_dir, lake_mask_dir, atmres,ocnres,out_dir,binary_
 
   integer :: unit=7, io_status
 
-  character(len=120), intent(out) :: ocean_mask_dir
-  character(len=120), intent(out) :: lake_mask_dir
-  character(len=120), intent(out) :: out_dir
+  character(len=200), intent(out) :: ocean_mask_dir
+  character(len=200), intent(out) :: lake_mask_dir
+  character(len=200), intent(out) :: out_dir
   character(len=10),  intent(out) :: atmres,ocnres
   integer, intent(out):: binary_lake
 

--- a/tests/ocean_merge/ftst_read_nml.F90
+++ b/tests/ocean_merge/ftst_read_nml.F90
@@ -7,9 +7,9 @@
 
  implicit none
 
- character(len=120) :: ocean_mask_dir
- character(len=120) :: lake_mask_dir
- character(len=120) :: out_dir
+ character(len=200) :: ocean_mask_dir
+ character(len=200) :: lake_mask_dir
+ character(len=200) :: out_dir
  character(len=10)  :: atmres,ocnres
  
  integer            :: binary_lake


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Some of the path variables do not have enough characters. 

## TESTS CONDUCTED: 

- [x] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera, Hercules and WCOSS2). Done using c1a84df.
- [x] Compile branch on Hera using GNU. Done using c1a84df.
- [x] Compile branch in 'Debug' mode on WCOSS2. Done on Dogwood using c1a84df.
- [x] Run unit tests locally on any Tier 1 machine. Done on Hera (with Gnu) using c1a84df.
- [x] Run `grid_gen` consistency tests locally on all Tier 1 machines. Done using c1a84df. All tests passed as expected.

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #1002.