### PR TITLE
ubuntu_gcc CI fixes

### DIFF
--- a/.github/workflows/ubuntu_gcc.yaml
+++ b/.github/workflows/ubuntu_gcc.yaml
@@ -10,9 +10,9 @@ defaults:
 
 env:
   cache_key: gcc
-  CC: gcc-10
-  FC: gfortran-10
-  CXX: g++-10
+  CC: gcc-12
+  FC: gfortran-12
+  CXX: g++-12
 
 # The jobs are split into:
 # 1. a dependency build step (setup), and
@@ -47,7 +47,7 @@ jobs:
         run: |
           git clone -c feature.manyFiles=true https://github.com/JCSDA/spack.git
           source spack/share/spack/setup-env.sh
-          sed "s/\[oneapi, gcc@10:10, apple-clang@14\]/\[gcc@10:10\]/g" ufs_utils/ci/spack.yaml > spack_ci.yaml
+          sed "s/\[oneapi, gcc@12:12, apple-clang@14\]/\[gcc@12:12\]/g" ufs_utils/ci/spack.yaml > spack_ci.yaml
           spack env create ufs_utils-env spack_ci.yaml
           spack env activate ufs_utils-env
           sudo apt install cmake

--- a/.github/workflows/ubuntu_gcc.yaml
+++ b/.github/workflows/ubuntu_gcc.yaml
@@ -10,9 +10,9 @@ defaults:
 
 env:
   cache_key: gcc
-  CC: gcc-12
-  FC: gfortran-12
-  CXX: g++-12
+  CC: gcc-13
+  FC: gfortran-13
+  CXX: g++-13
 
 # The jobs are split into:
 # 1. a dependency build step (setup), and
@@ -23,7 +23,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: checkout  # this is to get the ci/spack.yaml file
@@ -47,7 +47,7 @@ jobs:
         run: |
           git clone -c feature.manyFiles=true https://github.com/JCSDA/spack.git
           source spack/share/spack/setup-env.sh
-          sed "s/\[oneapi, gcc@12:12, apple-clang@14\]/\[gcc@12:12\]/g" ufs_utils/ci/spack.yaml > spack_ci.yaml
+          sed "s/\[oneapi, gcc@13:13, apple-clang@14\]/\[gcc@13:13\]/g" ufs_utils/ci/spack.yaml > spack_ci.yaml
           spack env create ufs_utils-env spack_ci.yaml
           spack env activate ufs_utils-env
           sudo apt install cmake
@@ -59,7 +59,7 @@ jobs:
 
   ufs_utils:
     needs: setup
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: checkout

--- a/.github/workflows/ubuntu_gcc.yaml
+++ b/.github/workflows/ubuntu_gcc.yaml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: checkout  # this is to get the ci/spack.yaml file
@@ -59,7 +59,7 @@ jobs:
 
   ufs_utils:
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: checkout

--- a/.github/workflows/ubuntu_intel.yaml
+++ b/.github/workflows/ubuntu_intel.yaml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: checkout  # this is to get the ci/spack.yaml file
@@ -78,7 +78,7 @@ jobs:
 
   ufs_utils:
     needs: setup
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: install-intel

--- a/.github/workflows/ubuntu_intel.yaml
+++ b/.github/workflows/ubuntu_intel.yaml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: checkout  # this is to get the ci/spack.yaml file
@@ -78,7 +78,7 @@ jobs:
 
   ufs_utils:
     needs: setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: install-intel

--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -2,7 +2,7 @@
 spack:
   packages:
     all:
-      compiler: [oneapi, gcc@10:10, apple-clang@14]
+      compiler: [oneapi, gcc@12:12, apple-clang@14]
   specs:
   - netcdf-c@4.9.2
   - netcdf-fortran@4.6.1

--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -2,7 +2,7 @@
 spack:
   packages:
     all:
-      compiler: [oneapi, gcc@12:12, apple-clang@14]
+      compiler: [oneapi, gcc@13:13, apple-clang@14]
   specs:
   - netcdf-c@4.9.2
   - netcdf-fortran@4.6.1


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The GNU CI workflow stopped working in early December. GNU version 10 is no longer available
with the latest ubuntu. Update to GNU version 13.

## TESTS CONDUCTED: 

- [x] Ensure CI workflows run to completion.

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A.

## ISSUE: 
Fixes #1006.

## CONTRIBUTORS: 
@AlexanderRichert-NOAA 
