### PR TITLE
Port to Intel LLVM on Jet

### DIFF
--- a/driver_scripts/driver_grid.jet.sh
+++ b/driver_scripts/driver_grid.jet.sh
@@ -61,12 +61,12 @@
 #
 #-----------------------------------------------------------------------
 
-set -x
-
 source ../sorc/machine-setup.sh > /dev/null 2>&1
 module use ../modulefiles
-module load build.$target.intel
+module load build.$target.intelllvm
+set +x
 module list
+set -x
 
 #-----------------------------------------------------------------------
 # Set grid specs here.

--- a/modulefiles/build.jet.intel.lua
+++ b/modulefiles/build.jet.intel.lua
@@ -1,5 +1,5 @@
 help([[
-Load environment to compile UFS_UTILS on Jet using Intel
+Load environment to compile UFS_UTILS on Jet using Intel Classic
 ]])
 
 hpss_ver=os.getenv("hpss_ver") or ""

--- a/modulefiles/build.jet.intelllvm.lua
+++ b/modulefiles/build.jet.intelllvm.lua
@@ -1,0 +1,71 @@
+help([[
+Load environment to compile UFS_UTILS on Jet using Intel
+]])
+
+hpss_ver=os.getenv("hpss_ver") or ""
+load(pathJoin("hpss", hpss_ver))
+
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core")
+
+stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
+load(pathJoin("stack-intel", stack_intel_ver))
+
+stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"
+load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
+
+cmake_ver=os.getenv("cmake_ver") or "3.23.1"
+load(pathJoin("cmake", cmake_ver))
+
+bacio_ver=os.getenv("bacio_ver") or "2.4.1"
+load(pathJoin("bacio", bacio_ver))
+
+g2_ver=os.getenv("g2_ver") or "3.4.5"
+load(pathJoin("g2", g2_ver))
+
+ip_ver=os.getenv("ip_ver") or "4.3.0"
+load(pathJoin("ip", ip_ver))
+
+nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
+load(pathJoin("nemsio", nemsio_ver))
+
+sp_ver=os.getenv("sp_ver") or "2.5.0"
+load(pathJoin("sp", sp_ver))
+
+w3emc_ver=os.getenv("w3emc_ver") or "2.10.0"
+load(pathJoin("w3emc", w3emc_ver))
+
+-- Uncomment when CHGRES_ALL is ON.
+--sfcio_ver=os.getenv("sfcio_ver") or "1.4.1"
+--load(pathJoin("sfcio", sfcio_ver))
+
+sigio_ver=os.getenv("sigio_ver") or "2.3.2"
+load(pathJoin("sigio", sigio_ver))
+
+zlib_ver=os.getenv("zlib_ver") or "1.2.13"
+load(pathJoin("zlib", zlib_ver))
+
+png_ver=os.getenv("png_ver") or "1.6.37"
+load(pathJoin("libpng", png_ver))
+
+netcdf_c_ver=os.getenv("netcdf_c_ver") or "4.9.2"
+load(pathJoin("netcdf-c", netcdf_c_ver))
+
+netcdf_fortran_ver=os.getenv("netcdf_fortran_ver") or "4.6.1"
+load(pathJoin("netcdf-fortran", netcdf_fortran_ver))
+
+nccmp_ver=os.getenv("nccmp_ver") or "1.9.0.1"
+load(pathJoin("nccmp", nccmp_ver))
+
+esmf_ver=os.getenv("esmf_ver") or "8.6.0"
+load(pathJoin("esmf", esmf_ver))
+
+nco_ver=os.getenv("nco_ver") or "5.0.6"
+load(pathJoin("nco", nco_ver))
+
+setenv("I_MPI_CC", "icx")
+setenv("I_MPI_F90", "ifx")
+
+setenv("CC", "mpiicc")
+setenv("FC", "mpiifort")
+
+whatis("Description: UFS_UTILS build environment")

--- a/modulefiles/build.jet.intelllvm.lua
+++ b/modulefiles/build.jet.intelllvm.lua
@@ -1,5 +1,5 @@
 help([[
-Load environment to compile UFS_UTILS on Jet using Intel
+Load environment to compile UFS_UTILS on Jet using Intel LLVM
 ]])
 
 hpss_ver=os.getenv("hpss_ver") or ""

--- a/reg_tests/chgres_cube/driver.jet.sh
+++ b/reg_tests/chgres_cube/driver.jet.sh
@@ -27,8 +27,10 @@ set -x
 
 source ../../sorc/machine-setup.sh > /dev/null 2>&1
 module use ../../modulefiles
-module load build.$target.intel
+module load build.$target.intelllvm
+set +x
 module list
+set -x
 
 export OUTDIR="${WORK_DIR:-/lfs5/HFIP/emcda/$LOGNAME/stmp}"
 export OUTDIR="${OUTDIR}/reg-tests/chgres-cube"

--- a/reg_tests/cpld_gridgen/rt.sh
+++ b/reg_tests/cpld_gridgen/rt.sh
@@ -227,7 +227,9 @@ if [[ $target = wcoss2 ]]; then
   module load netcdf
   module load nccmp
 fi
+set +x
 module list
+set -x
 
 if [[ $CREATE_BASELINE = true ]]; then
     rm -rf $NEW_BASELINE_ROOT

--- a/reg_tests/cpld_gridgen/rt.sh
+++ b/reg_tests/cpld_gridgen/rt.sh
@@ -108,7 +108,7 @@ TESTS_FILE="$PATHRT/rt.conf"
 export TEST_NAME=
 
 # for C3072 on hera, use WLCLK=60 and MEM="--exclusive"
-WLCLK_dflt=50
+WLCLK_dflt=60
 export WLCLK=$WLCLK_dflt
 MEM_dflt="--mem=16g"
 export MEM=$MEM_dflt

--- a/reg_tests/global_cycle/driver.jet.sh
+++ b/reg_tests/global_cycle/driver.jet.sh
@@ -22,8 +22,10 @@ set -x
 
 source ../../sorc/machine-setup.sh > /dev/null 2>&1
 module use ../../modulefiles
-module load build.$target.intel
+module load build.$target.intelllvm
+set +x
 module list
+set -x
 
 export WORK_DIR="${WORK_DIR:-/lfs5/HFIP/emcda/$LOGNAME/stmp}"
 

--- a/reg_tests/grid_gen/driver.jet.sh
+++ b/reg_tests/grid_gen/driver.jet.sh
@@ -23,7 +23,7 @@
 
 source ../../sorc/machine-setup.sh > /dev/null 2>&1
 module use ../../modulefiles
-module load build.$target.intel
+module load build.$target.intelllvm
 module list
 
 set -x

--- a/reg_tests/ice_blend/driver.jet.sh
+++ b/reg_tests/ice_blend/driver.jet.sh
@@ -30,7 +30,7 @@ set -x
 
 source ../../sorc/machine-setup.sh > /dev/null 2>&1
 module use ../../modulefiles
-module load build.$target.intel
+module load build.$target.intelllvm
 module load wgrib2/2.0.8
 module load grib-util/1.3.0
 set +x

--- a/reg_tests/ocnice_prep/rt.sh
+++ b/reg_tests/ocnice_prep/rt.sh
@@ -232,7 +232,9 @@ if [[ $target = wcoss2 ]]; then
   module load netcdf
   module load nccmp/1.8.9.0
 fi
+set +x
 module list
+set -x
 
 if [[ $CREATE_BASELINE = true ]]; then
     rm -rf $NEW_BASELINE_ROOT

--- a/reg_tests/snow2mdl/driver.jet.sh
+++ b/reg_tests/snow2mdl/driver.jet.sh
@@ -23,7 +23,7 @@ set -x
 
 source ../../sorc/machine-setup.sh > /dev/null 2>&1
 module use ../../modulefiles
-module load build.$target.intel
+module load build.$target.intelllvm
 module load wgrib2/2.0.8
 set +x
 module list

--- a/reg_tests/weight_gen/driver.jet.sh
+++ b/reg_tests/weight_gen/driver.jet.sh
@@ -28,12 +28,12 @@
 
 set -x
 
-compiler=${compiler:-"intel"}
-
 source ../../sorc/machine-setup.sh > /dev/null 2>&1
 module use ../../modulefiles
-module load build.$target.$compiler
+module load build.$target.intelllvm
+set +x
 module list
+set -x
 
 export DATA="${WORK_DIR:-/lfs5/HFIP/emcda/$LOGNAME/stmp}"
 export DATA="${DATA}/reg-tests/weight_gen"

--- a/util/gdas_init/driver.jet.sh
+++ b/util/gdas_init/driver.jet.sh
@@ -10,11 +10,13 @@
 
 set -x
 
-compiler=${compiler:-"intel"}
+compiler=${compiler:-"intelllvm"}
 source ../../sorc/machine-setup.sh > /dev/null 2>&1
 module use ../../modulefiles
 module load build.$target.$compiler
+set +x
 module list
+set -x
 
 PROJECT_CODE=hfv3gfs
 QUEUE=batch

--- a/util/weight_gen/run.jet.sh
+++ b/util/weight_gen/run.jet.sh
@@ -33,8 +33,10 @@ set -x
 UFS_DIR=$PWD/../..
 source $UFS_DIR/sorc/machine-setup.sh > /dev/null 2>&1
 module use $UFS_DIR/modulefiles
-module load build.$target.intel
+module load build.$target.intelllvm
+set +x
 module list
+set -x
 
 export CRES="C48"
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Add build module for Intel LLVM. Build using LLVM is the default.
- Retain option to build using Intel Classic.
- Update all scripts to load the Intel LLVM build module.

## TESTS CONDUCTED: 
If there are changes to the build or source code, the tests below must be conducted. Contact a repository manager if you need assistance.

- [x] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera, Hercules and WCOSS2). Done using dbcaeca and Intel LLVM on Jet, Hercules, Hera and Orion. Done using dbcaeca and Intel Classic on Cactus.
- [x] Run unit tests on Jet. Done using dbcaeca. All tests passed using Intel LLVM.
- [x] Run consistency tests on Jet. The [global_cycle]( https://github.com/ufs-community/UFS_UTILS/issues/1009#issuecomment-2545937404), [ocnice_prep](https://github.com/ufs-community/UFS_UTILS/issues/1009#issuecomment-2546096743), [ice_blend, snow2mdl and weight_gen](https://github.com/ufs-community/UFS_UTILS/issues/1009#issuecomment-2546020743) tests passed. The [chgres_cube](https://github.com/ufs-community/UFS_UTILS/issues/1009#issuecomment-2545937404), [grid_gen](https://github.com/ufs-community/UFS_UTILS/issues/1009#issuecomment-2545998704), and [cpld_gridgen](https://github.com/ufs-community/UFS_UTILS/issues/1009#issuecomment-2546608739) tests failed. However, differences from the baseline were not significant.

Other tests on Jet:
- The [weight_gen](https://github.com/ufs-community/UFS_UTILS/issues/1009#issuecomment-2546457857)  and [gdas_init](https://github.com/ufs-community/UFS_UTILS/issues/1009#issuecomment-2546571899) utilities were successfully tested on Jet.
- A global [C96](https://github.com/ufs-community/UFS_UTILS/issues/1009#issuecomment-2546708279) uniform grid was successfuly created on Jet.
- Compiled the branch on Jet using Intel Classic (860203e).

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #1009.