### PR TITLE
Check for gaea compute nodes

### DIFF
--- a/sorc/machine-setup.sh
+++ b/sorc/machine-setup.sh
@@ -46,7 +46,7 @@ elif [[ -d /scratch1 ]] ; then
     fi
     target=hera
     module purge
-elif [[ "$(hostname)" == "gaea5"* && -d /gpfs/f5 ]] ; then
+elif [[ "$(hostname)" == "gaea5"* || "$(hostname)" =~ c5n[0-9]+ ]] && [[ -d /gpfs/f5 ]] ; then
     # We are on GAEAC5.
     if ( ! eval module help > /dev/null 2>&1 ) ; then
       # We cannot simply load the module command.  The GAEA
@@ -58,7 +58,7 @@ elif [[ "$(hostname)" == "gaea5"* && -d /gpfs/f5 ]] ; then
     fi
     module reset
     target=gaeac5
-elif [[ "$(hostname)" == "gaea6"* && -d /gpfs/f6 ]] ; then
+elif [[ "$(hostname)" == "gaea6"* || "$(hostname)" =~ c6n[0-9]+ ]] && [[ -d /gpfs/f6 ]] ; then
     target=gaeac6
     source /opt/cray/pe/lmod/8.7.31/init/$__ms_shell
 elif [[ "$(hostname)" =~ "Orion" || "$(hostname)" =~ "orion" ]]; then


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This adds regex checks to machine-setup.sh to check if it is being run on one of the compute nodes when determining the system name.

## TESTS CONDUCTED: 
Test builds on Gaea C5 and C6 compute clusters.  I don't think other tests are required since there are no code changes.

## ISSUE: 
Resolves #1017