### PR TITLE
Cleaned up land-increment namelist and script variable names.

### DIFF
--- a/reg_tests/global_cycle/C192.gsi_lndincsoilnoahmp.sh
+++ b/reg_tests/global_cycle/C192.gsi_lndincsoilnoahmp.sh
@@ -37,9 +37,8 @@ export DONST="NO"
 export use_ufo=.true.
 
 export DO_SFCCYCLE=".FALSE." 
-export DO_LNDINC=".TRUE." 
-export DO_SOI_INC=".true."
-export GCYCLE_INTERP_LNDINC=".true."
+export GCYCLE_DO_SOILINCR=".true."
+export GCYCLE_INTERP_LANDINCR=".true."
 export LSOIL_INCR=3
 
 export VERBOSE=YES

--- a/reg_tests/global_cycle/C192.gsitile_lndincsoilnoahmp.sh
+++ b/reg_tests/global_cycle/C192.gsitile_lndincsoilnoahmp.sh
@@ -37,9 +37,8 @@ export DONST="NO"
 export use_ufo=.true.
 
 export DO_SFCCYCLE=".FALSE." 
-export DO_LNDINC=".TRUE." 
-export DO_SOI_INC=".true."
-export GCYCLE_INTERP_LNDINC=".false."
+export GCYCLE_DO_SOILINCR=".true."
+export GCYCLE_INTERP_LANDINCR=".false."
 export LSOIL_INCR=3
 
 export VERBOSE=YES

--- a/reg_tests/global_cycle/C192.jedi_lndincsoilnoahmp.sh
+++ b/reg_tests/global_cycle/C192.jedi_lndincsoilnoahmp.sh
@@ -39,10 +39,9 @@ export DONST="NO"
 export use_ufo=.true.
 
 export DO_SFCCYCLE=".FALSE." 
-export DO_LNDINC=".TRUE." 
-export DO_SOI_INC=".true."
-export GCYCLE_INTERP_LNDINC=".false."
-export SOI_INC_FNAME="soil_sfcincr_jedi"
+export GCYCLE_DO_SOILINCR=".true."
+export GCYCLE_INTERP_LANDINCR=".false."
+export SOILINCR_FNAME="soil_sfcincr_jedi"
 export LSOIL_INCR=3
 
 export VERBOSE=YES

--- a/reg_tests/global_cycle/C768.lndincsnow.sh
+++ b/reg_tests/global_cycle/C768.lndincsnow.sh
@@ -31,9 +31,8 @@ export FNSNOA=$COMIN/gdas.t00z.snogrb_t1534.3072.1536
 export FNACNA=$COMIN/gdas.t00z.seaice.5min.blend.grb
 export NST_FILE=$COMIN/gdas.t00z.dtfanl.nc
 
-export DO_SNO_INC=.true. # must be lower-case.
-export DO_SOI_INC=.false.
-export GCYCLE_INTERP_LNDINC=.false.
+export GCYCLE_DO_SNOWINCR=.true. # must be lower-case.
+export GCYCLE_INTERP_LANDINCR=.false.
 export JCAP=1534
 export LONB=3072
 export LATB=1536
@@ -42,7 +41,6 @@ export DONST="NO"
 export use_ufo=.true.
 
 export DO_SFCCYCLE=".FALSE." 
-export DO_LNDINC=".TRUE." 
 
 export VERBOSE=YES
 export CYCLVARS=FSNOL=99999.,FSNOS=99999.,

--- a/ush/global_cycle.sh
+++ b/ush/global_cycle.sh
@@ -268,11 +268,12 @@ CYCLVARS=${CYCLVARS:-""}
 use_ufo=${use_ufo:-.true.}
 DONST=${DONST:-"NO"}
 DO_SFCCYCLE=${DO_SFCCYCLE:-.true.}
-DO_LANDINCR=${DO_LANDINCR:-.false.}
 GCYCLE_DO_SOILINCR=${GCYCLE_DO_SOILINCR:-.false.}
 GCYCLE_DO_SNOWINCR=${GCYCLE_DO_SNOWINCR:-.false.}
 if [ "$GCYCLE_DO_SOILINCR" == ".true." ] || [ "$GCYCLE_DO_SNOWINCR" == ".true." ] ; then
         DO_LANDINCR=".true."
+else
+        DO_LANDINCR=".false."
 fi
 GCYCLE_INTERP_LANDINCR=${GCYCLE_INTERP_LANDINCR:-.false.}
 zsea1=${zsea1:-0}

--- a/ush/global_cycle.sh
+++ b/ush/global_cycle.sh
@@ -140,10 +140,9 @@
 #                   between the filtered and unfiltered terrain.  Default is true.
 #     DONST         Process NST records when using NST model.  Default is 'no'.
 #     DO_SFCCYCLE   Call sfcsub routine 
-#     DO_LNDINC     Call routines to add snow and /or soil increments
-#     DO_SOI_INC    Call routine to add soil increments
-#     DO_SNO_INC    Call routine to add snow inrcements
-#     GCYCLE_INTERP_LNDIC  Flag to regrid input land increment from Gaus to native model 
+#     GCYCLE_DO_SOILINCR   Call routine to add soil increments
+#     GCYCLE_DO_SNOWINCR   Call routine to add snow inrcements
+#     GCYCLE_INTERP_LANDINCR  Flag to regrid input land increment from Gaus to native model 
 #                   grid inside gcycle
 #                   
 #     zsea1/zsea2   When running with NST model, this is the lower/upper bound
@@ -269,13 +268,13 @@ CYCLVARS=${CYCLVARS:-""}
 use_ufo=${use_ufo:-.true.}
 DONST=${DONST:-"NO"}
 DO_SFCCYCLE=${DO_SFCCYCLE:-.true.}
-DO_LNDINC=${DO_LNDINC:-.false.}
-DO_SOI_INC=${DO_SOI_INC:-.false.}
-DO_SNO_INC=${DO_SNO_INC:-.false.}
-if [ "$DO_SOI_INC" == ".true." ] || [ "$DO_SNO_INC" == ".true." ] ; then
-        DO_LNDINC=".true."
+DO_LANDINCR=${DO_LANDINCR:-.false.}
+GCYCLE_DO_SOILINCR=${GCYCLE_DO_SOILINCR:-.false.}
+GCYCLE_DO_SNOWINCR=${GCYCLE_DO_SNOWINCR:-.false.}
+if [ "$GCYCLE_DO_SOILINCR" == ".true." ] || [ "$GCYCLE_DO_SNOWINCR" == ".true." ] ; then
+        DO_LANDINCR=".true."
 fi
-GCYCLE_INTERP_LNDINC=${GCYCLE_INTERP_LNDINC:-.false.}
+GCYCLE_INTERP_LANDINCR=${GCYCLE_INTERP_LANDINCR:-.false.}
 zsea1=${zsea1:-0}
 zsea2=${zsea2:-0}
 MAX_TASKS_CY=${MAX_TASKS_CY:-99999}
@@ -386,7 +385,7 @@ cat << EOF > fort.36
   idim=$CRES, jdim=$CRES, lsoil=$LSOIL,
   iy=$iy, im=$im, id=$id, ih=$ih, fh=$FHOUR,
   deltsfc=$DELTSFC,ialb=$IALB,use_ufo=$use_ufo,donst="$DONST",
-  do_sfccycle=$DO_SFCCYCLE,do_lndinc=$DO_LNDINC,isot=$ISOT,ivegsrc=$IVEGSRC,
+  do_sfccycle=$DO_SFCCYCLE,do_landincr=$DO_LANDINCR,isot=$ISOT,ivegsrc=$IVEGSRC,
   zsea1_mm=$zsea1,zsea2_mm=$zsea2,MAX_TASKS=$MAX_TASKS_CY,
   frac_grid=$FRAC_GRID
  /
@@ -396,9 +395,9 @@ EOF
 cat << EOF > fort.37
  &NAMSFCD
   NST_FILE="$NST_FILE",
-  DO_SOI_INC=$DO_SOI_INC,
-  DO_SNO_INC=$DO_SNO_INC,
-  INTERP_LNDINC=$GCYCLE_INTERP_LNDINC,
+  DO_SOILINCR=$GCYCLE_DO_SOILINCR,
+  DO_SNOWINCR=$GCYCLE_DO_SNOWINCR,
+  INTERP_LANDINCR=$GCYCLE_INTERP_LANDINCR,
   lsoil_incr=$LSOIL_INCR, 
  /
 EOF

--- a/ush/global_cycle_driver.sh
+++ b/ush/global_cycle_driver.sh
@@ -52,11 +52,10 @@ else
 fi
 
 export DO_SFCCYLE=${DO_SFCCYCLE:-".true."}
-export DO_LNDINC=${DO_LNDINC:-".false."}
-export DO_SOI_INC=${DO_SOI_INC:-".false."}
-export DO_SNO_INC=${DO_SNO_INC:-".false."}
-export GCYCLE_INTERP_LNDINC=${GCYCLE_INTERP_LNDINC:-".false."}
-SOI_INC_FNAME=${SOI_INC_FNAME:-"soil_xainc"}
+export GCYCLE_DO_SOILINCR=${GCYCLE_DO_SOILINCR:-".false."}
+export GCYCLE_DO_SNOWINCR=${GCYCLE_DO_SNOWINCR:-".false."}
+export GCYCLE_INTERP_LANDINCR=${GCYCLE_INTERP_LANDINCR:-".false."}
+SOILINCR_FNAME=${SOILINCR_FNAME:-"soil_xainc"}
 export FRAC_GRID=${FRAC_GRID:-".false."}
 
 CRES=$(echo $CASE | cut -c 2-)
@@ -96,15 +95,15 @@ for n in $(seq 1 $ntiles); do
     ln -fs $FIXorog/${CASE}/C${CRES}.mx${OCNRES}_oro_data.tile${n}.nc   $DATA/fnorog.00$n
   fi
 
-  if [[ "$DO_SNO_INC" == ".true." ]] ; then  
+  if [[ "$GCYCLE_DO_SNOWINCR" == ".true." ]] ; then  
         ln -fs $COMIN/$PDY.${cyc}0000.xainc.tile${n}.nc      $DATA/snow_xainc.00$n
   fi
 
-  if [ "$DO_SOI_INC" == ".true." ] && [ "$GCYCLE_INTERP_LNDINC" == ".false." ] ; then
-        ln -fs $COMIN/${SOI_INC_FNAME}.00${n} $DATA/soil_xainc.00$n
+  if [ "$GCYCLE_DO_SOILINCR" == ".true." ] && [ "$GCYCLE_INTERP_LANDINCR" == ".false." ] ; then
+        ln -fs $COMIN/${SOILINCR_FNAME}.00${n} $DATA/soil_xainc.00$n
   fi
 
-  if [ "$DO_SOI_INC" == ".true." ] && [ "$GCYCLE_INTERP_LNDINC" == ".true." ] ; then
+  if [ "$GCYCLE_DO_SOILINCR" == ".true." ] && [ "$GCYCLE_INTERP_LANDINCR" == ".true." ] ; then
         ln -fs $COMIN/sfcincr_gsi.00$n $DATA/sfcincr_gsi.00$n
   fi
 done


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 

Changed variable names for the land increments to be more consistent. Also added "gcycle_" at the start of several variable names, so that in the global_workflow it is clear that these actions are being requested from UFS_UTILS. This is in preparation for a future PR to global_workflow which will move some of this functionality into the model (using IAU).

## TESTS CONDUCTED: 

- [x] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera, Hercules and WCOSS2).  Done using 0d1b2ea.
- [x] Compile branch on Hera using GNU. Done using 0d1b2ea. `global_cycle` compiled with no warnings.
- [x] Compile branch in 'Debug' mode on WCOSS2. Done on Cactus using 0d1b2ea with no warnings.
- [x] Run unit tests locally on any Tier 1 machine. Done on Hera using 0d1b2ea. All tests passed.
- [x] Run `global_cycle` consistency tests locally on all Tier 1 machines. Done using 0d1b2ea. All tests passed as expected.

## DEPENDENCIES:

This PR is required for global_workflow PR [3295](https://github.com/NOAA-EMC/global-workflow/pull/3295#discussion_r1943452507 )

## DOCUMENTATION:

Note, the Doxygen did not compile correctly, but that is not related to this PR. It will be fixed in #1026.

## ISSUE: 

Resolves issue [1021](https://github.com/ufs-community/UFS_UTILS/issues/1021)