### PR TITLE
Add QC checks for ICE source files 

### DIFF
--- a/sorc/ocnice_prep.fd/docs/ocnice_prep.md
+++ b/sorc/ocnice_prep.fd/docs/ocnice_prep.md
@@ -117,6 +117,12 @@ from their orientation along model dimensions (IJ) to eastward-northward (EN) di
 4. Vector fields are re-rotated back to model index direction (EN->IJ) and remapped back to their native stagger locations.
 5. Fields are written into a warm-start file.
 
+For CICE6, an additional 2-step QC is performed on the source restart files. This procedure accounts for possible inconsistent fields
+that may have been generated as part of the marine DA process. The QC process affects 4 fields only: ``aicen``, ``vicen``,
+``vsnon`` and ``Tsfcn``. The first step of the QC is to remove any values of the 4 fields which are located where the CICE grid has
+land. The second step is to remove any ice or snow volume where there is no associated ice coverage. The QC process does not impact
+source files which do not contain these physical inconsistencies.
+
 ## Note on rotation angles
 
 The rotation angle retrieved from the master grid file is ``anglet``, which is defined in the same sense as used MOM6. This

--- a/sorc/ocnice_prep.fd/ocniceprep.F90
+++ b/sorc/ocnice_prep.fd/ocniceprep.F90
@@ -26,6 +26,7 @@ program ocniceprep
   use arrays_mod ,     only : nbilin2d, nbilin3d, nconsd2d, bilin2d, bilin3d, consd2d
   use arrays_mod ,     only : mask3d, hmin, maskspval, eta
   use utils_mod  ,     only : getfield, packarrays, remap, dumpnc, nf90_err
+  use utils_mod  ,     only : zero_out_land_ice, zero_out_phantom_ice
   use utils_esmf_mod , only : createRH, remapRH, ChkErr, rotremap
   use restarts_mod ,   only : setup_icerestart, setup_ocnrestart
   use ocncalc_mod ,    only : calc_eta, vfill
@@ -47,13 +48,16 @@ program ocniceprep
   real(kind=8), allocatable, dimension(:,:)   :: out2d !< 2D destination grid output array
   real(kind=8), allocatable, dimension(:,:,:) :: out3d !< 3D destination grid output array
 
+  ! ice mask array for QC of ice files
+  integer(kind=4), allocatable, dimension(:,:) :: a2d  !< 2D land mask for ice
+  integer(kind=4), allocatable, dimension(:)   :: kmt  !< 1D land mask for ice
+  integer :: idx1, idx2, idx3, idx4
+
   character(len=120) :: errmsg
   character(len=120) :: meshfsrc, meshfdst
-  integer            :: nvalid
+  integer            :: nvalid, icnt
   integer            :: k,n,nn,rc,ncid,varid
   character(len=20)  :: vname
-  ! debug
-  integer :: i,j
 
   character(len=*), parameter :: u_FILE_u = __FILE__
 
@@ -120,6 +124,25 @@ program ocniceprep
   call getfield(trim(gridfile), 'anglet', dims=(/nxr,nyr/), field=angdst)
   call getfield(trim(gridfile),  'depth', dims=(/nxr,nyr/), field=bathydst)
   call nf90_err(nf90_close(ncid), 'close: '//trim(gridfile))
+
+  if (.not. do_ocnprep) then
+  ! -----------------------------------------------------------------------------
+  ! obtain the land mask for the ice model on the source grid to QC the ice fields
+  ! -----------------------------------------------------------------------------
+
+     allocate(a2d(nxt,nyt)); a2d = 0
+     allocate(kmt(nxt*nyt)); kmt = 0
+
+     ! obtain the land mask for the source grid
+     vname = 'wet'
+     gridfile = trim(griddir)//fsrc(3:5)//'/'//'tripole.'//trim(fsrc)//'.nc'
+     call nf90_err(nf90_open(trim(gridfile), nf90_nowrite, ncid), &
+          'open: '//trim(gridfile))
+     call nf90_err(nf90_inq_varid(ncid, trim(vname), varid), 'get variable ID: '//trim(vname))
+     call nf90_err(nf90_get_var(ncid, varid, a2d), 'get variable: '//trim(vname))
+     call nf90_err(nf90_close(ncid), 'close: '//trim(gridfile))
+     kmt(:) = reshape(a2d, (/nxt*nyt/))
+  end if
 
   ! -----------------------------------------------------------------------------
   ! get the 3rd (vertical or ncat) dimension and variable attributes for the
@@ -248,6 +271,40 @@ program ocniceprep
   if (allocated(bilin3d))then
      call packarrays(trim(input_file), trim(wgtsdir)//fsrc(3:5)//'/',           &
           cos(angsrc), sin(angsrc), b3d, dims=(/nxt,nyt,nlevs/), nflds=nbilin3d, fields=bilin3d)
+
+     if (.not. do_ocnprep) then
+        ! -----------------------------------------------------------------------------
+        ! QC the source ice files after packing. Not every possible inconsistency is
+        ! checked but these are those known to create issues in the coupled model
+        ! -----------------------------------------------------------------------------
+
+        do n = 1,nbilin3d
+           if (trim(b3d(n)%var_name) == 'aicen')idx1 = n
+           if (trim(b3d(n)%var_name) == 'vicen')idx2 = n
+           if (trim(b3d(n)%var_name) == 'vsnon')idx3 = n
+           if (trim(b3d(n)%var_name) == 'Tsfcn')idx4 = n
+        end do
+
+        ! remove land values, if they exist
+        call zero_out_land_ice(kmt, bilin3d(idx1,:,:), icnt)
+        write(logunit, '(a,i8,a)')'removed ',icnt,' locations of '//trim(b3d(idx1)%var_name)//' from land'
+        call zero_out_land_ice(kmt, bilin3d(idx2,:,:), icnt)
+        write(logunit, '(a,i8,a)')'removed ',icnt,' locations of '//trim(b3d(idx2)%var_name)//' from land'
+        call zero_out_land_ice(kmt, bilin3d(idx3,:,:), icnt)
+        write(logunit, '(a,i8,a)')'removed ',icnt,' locations of '//trim(b3d(idx3)%var_name)//' from land'
+        call zero_out_land_ice(kmt, bilin3d(idx4,:,:), icnt)
+        write(logunit, '(a,i8,a)')'removed ',icnt,' locations of '//trim(b3d(idx4)%var_name)//' from land'
+
+        ! remove phantom-ice (aice=0, vice or vsno /= 0)
+        call zero_out_phantom_ice(bilin3d(idx1,:,:), bilin3d(idx2,:,:), icnt)
+        write(logunit, '(a,i8,a)')'removed ',icnt,' locations of phantom '//trim(b3d(idx2)%var_name)
+        call zero_out_phantom_ice(bilin3d(idx1,:,:), bilin3d(idx3,:,:), icnt)
+        write(logunit, '(a,i8,a)')'removed ',icnt,' locations of phantom '//trim(b3d(idx3)%var_name)
+        ! remove phantom-ice (vicen=0, aicen /=0);  do not QC vsnon=0, aicen /=0)
+        call zero_out_phantom_ice(bilin3d(idx2,:,:), bilin3d(idx1,:,:), icnt)
+        write(logunit, '(a,i8,a)')'removed ',icnt,' locations of phantom '//trim(b3d(idx1)%var_name)
+     end if
+
      rgb3d = 0.0
      do k = 1,nlevs
         if (do_ocnprep) then

--- a/sorc/ocnice_prep.fd/ocniceprep.F90
+++ b/sorc/ocnice_prep.fd/ocniceprep.F90
@@ -142,6 +142,7 @@ program ocniceprep
      call nf90_err(nf90_get_var(ncid, varid, a2d), 'get variable: '//trim(vname))
      call nf90_err(nf90_close(ncid), 'close: '//trim(gridfile))
      kmt(:) = reshape(a2d, (/nxt*nyt/))
+     deallocate(a2d)
   end if
 
   ! -----------------------------------------------------------------------------
@@ -303,6 +304,7 @@ program ocniceprep
         ! remove phantom-ice (vicen=0, aicen /=0);  do not QC vsnon=0, aicen /=0)
         call zero_out_phantom_ice(bilin3d(idx2,:,:), bilin3d(idx1,:,:), icnt)
         write(logunit, '(a,i8,a)')'removed ',icnt,' locations of phantom '//trim(b3d(idx1)%var_name)
+        deallocate(kmt)
      end if
 
      rgb3d = 0.0

--- a/sorc/ocnice_prep.fd/restarts_mod.F90
+++ b/sorc/ocnice_prep.fd/restarts_mod.F90
@@ -66,11 +66,11 @@ contains
        enddo
     end if
     if (allocated(c2d)) then
-      do n = 1,nconsd2d
-         vname = trim(c2d(n)%var_name)
-         call nf90_err(nf90_def_var(ncid, vname, nf90_double, (/idimid,jdimid/), varid),         &
-              'define variable: '// vname)
-      enddo
+       do n = 1,nconsd2d
+          vname = trim(c2d(n)%var_name)
+          call nf90_err(nf90_def_var(ncid, vname, nf90_double, (/idimid,jdimid/), varid),         &
+               'define variable: '// vname)
+       enddo
     end if
     if (allocated(b3d)) then
        do n = 1,nbilin3d
@@ -174,7 +174,7 @@ contains
                'put variable attribute: long_name')
        enddo
     end if
-     if (allocated(c2d)) then
+    if (allocated(c2d)) then
        do n = 1,nconsd2d
           vname = trim(c2d(n)%var_name)
           vunit = trim(c2d(n)%units)

--- a/sorc/ocnice_prep.fd/utils_mod.F90
+++ b/sorc/ocnice_prep.fd/utils_mod.F90
@@ -47,6 +47,8 @@ module utils_mod
   public :: remap
   public :: dumpnc
   public :: nf90_err
+  public :: zero_out_land_ice
+  public :: zero_out_phantom_ice
 
 contains
   !> Pack 2D fields into arrays by mapping type
@@ -699,6 +701,59 @@ contains
 
   end subroutine dumpnc1d
 
+  !> Reset field values to zero on land
+  !!
+  !! @param[in]     fin    the land mask
+  !! @param[inout]  fout   the field value
+  !! @param[out]    icnt   the number spatial points reset
+  !!
+  !! @author Denise.Worthen@noaa.gov
+  subroutine zero_out_land_ice(mask, fout, icnt)
+
+    integer(kind=4), intent(in)    :: mask(:)
+    real(kind=8),    intent(inout) :: fout(:,:)
+    integer,         intent(out)   :: icnt
+
+    !local variables
+    integer :: ij
+    !----------------------------------------------------------------------------
+
+    icnt = 0
+    do ij = 1,size(fout,2)
+       if ( mask(ij) .eq. 0 .and. sum(fout(:,ij)) .ne. 0.0)  then
+          icnt = icnt + 1
+          fout(:,ij) = 0.0
+       end if
+    end do
+  end subroutine zero_out_land_ice
+
+  !> Ensure that when fin contains zeros for all ncat, fout will also contain zeros
+  !! for all ncat
+  !!
+  !! @param[in]     fin    the field to test against
+  !! @param[inout]  fout   the field tested
+  !! @param[out]    icnt   the number spatial points reset
+  !!
+  !! @author Denise.Worthen@noaa.gov
+  subroutine zero_out_phantom_ice(fin, fout, icnt)
+
+    real(kind=8), intent(in)    :: fin(:,:)
+    real(kind=8), intent(inout) :: fout(:,:)
+    integer,      intent(out)   :: icnt
+
+    !local variables
+    integer :: ij
+    !----------------------------------------------------------------------------
+
+    icnt = 0
+    do ij = 1,size(fout,2)
+       if (sum(fin(:,ij)) .eq. 0.0 .and. sum(fout(:,ij)) .ne. 0.0 ) then
+          icnt = icnt + 1
+          fout(:,ij) = 0.0
+       end if
+    end do
+  end subroutine zero_out_phantom_ice
+
   !> Handle netcdf errors
   !!
   !! @param[in]  ierr        the error code
@@ -712,12 +767,13 @@ contains
     !----------------------------------------------------------------------------
 
     if (ierr /= nf90_noerr) then
-      write(0, '(a)') 'FATAL ERROR: ' // trim(string)// ' : ' // trim(nf90_strerror(ierr))
-      ! This fails on WCOSS2 with Intel 19 compiler. See
-      ! https://community.intel.com/t5/Intel-Fortran-Compiler/STOP-and-ERROR-STOP-with-variable-stop-codes/m-p/1182521#M149254
-      ! When WCOSS2 moves to Intel 2020+, uncomment the next line and remove stop 99
-      !stop ierr
-      stop 99
+       write(0, '(a)') 'FATAL ERROR: ' // trim(string)// ' : ' // trim(nf90_strerror(ierr))
+       ! This fails on WCOSS2 with Intel 19 compiler. See
+       ! https://community.intel.com/t5/Intel-Fortran-Compiler/STOP-and-ERROR-STOP-with-variable-stop-codes/m-p/1182521#M149254
+       ! When WCOSS2 moves to Intel 2020+, uncomment the next line and remove stop 99
+       !stop ierr
+       stop 99
     end if
   end subroutine nf90_err
+
 end module utils_mod

--- a/sorc/ocnice_prep.fd/utils_mod.F90
+++ b/sorc/ocnice_prep.fd/utils_mod.F90
@@ -703,7 +703,7 @@ contains
 
   !> Reset field values to zero on land
   !!
-  !! @param[in]     fin    the land mask
+  !! @param[in]     mask   the land mask
   !! @param[inout]  fout   the field value
   !! @param[out]    icnt   the number spatial points reset
   !!

--- a/tests/ocnice_prep/CMakeLists.txt
+++ b/tests/ocnice_prep/CMakeLists.txt
@@ -36,5 +36,9 @@ execute_process( COMMAND ${CMAKE_COMMAND} -E copy
   ${CMAKE_CURRENT_SOURCE_DIR}/data/ocean.badvecgrid.csv ${CMAKE_CURRENT_BINARY_DIR}/data/ocean.badvecgrid.csv)
 
 add_executable(ocnice_ftst_program_setup ftst_program_setup.F90)
-add_test(NAME ocnice-ftst_program_setup COMMAND ocnice_ftst_program_setup)
+add_test(NAME ocnice_ftst_program_setup COMMAND ocnice_ftst_program_setup)
 target_link_libraries(ocnice_ftst_program_setup ocnice_prep_lib)
+
+add_executable(ocnice_ftst_qcice ftst_qcice.F90)
+add_test(NAME ocnice_ftst_qcice COMMAND ocnice_ftst_qcice)
+target_link_libraries(ocnice_ftst_qcice ocnice_prep_lib)

--- a/tests/ocnice_prep/ftst_qcice.F90
+++ b/tests/ocnice_prep/ftst_qcice.F90
@@ -1,0 +1,192 @@
+!> @file
+!! @brief unit test for QC of source CICE restarts
+!! @author Denise.Worthen@noaa.gov
+!!
+!! Test that land values and non-physical values will be found and
+!! removed and that good values are not removed
+!! @author Denise.Worthen@noaa.gov
+program ftst_qcice
+
+  use utils_mod , only : zero_out_land_ice, zero_out_phantom_ice
+
+  implicit none
+
+  integer, parameter :: ncat=3, nxy = 5
+
+  integer      :: kmt(nxy)
+  real(kind=8) :: field1(ncat,nxy), field2(ncat,nxy)
+
+  integer :: passed, ntests_land_ice, ntests_phantom_ice
+  integer :: expected_cnt, icnt
+
+  ntests_phantom_ice = 0
+  ntests_land_ice = 0
+  passed = 0
+
+  ! ------------------------------------
+  ! Tests for zero_out_land_ice
+  ! ------------------------------------
+
+  ! test 1: land only, values everywhere
+  ntests_land_ice = ntests_land_ice + 1
+  kmt = 0
+  field1(:,:) = 1.0e-3
+  expected_cnt = nxy
+  call zero_out_land_ice(kmt, field1, icnt)
+  if (icnt == expected_cnt) passed = passed + 1
+  !print *,expected_cnt,icnt,passed
+
+  ! test2: ocean only, values everywhere
+  ntests_land_ice = ntests_land_ice + 1
+  kmt = 1
+  field1(:,:) = 1.0e-3
+  expected_cnt = 0
+  call zero_out_land_ice(kmt, field1, icnt)
+  if (icnt == expected_cnt) passed = passed + 1
+  !print *,expected_cnt,icnt,passed
+
+  ! test3: mix land and ocean, values everywhere
+  ntests_land_ice = ntests_land_ice + 1
+  kmt = (/0,1,1,0,0/)
+  field1(:,:) = 1.0e-3
+  expected_cnt = 3
+  call zero_out_land_ice(kmt, field1, icnt)
+  if (icnt == expected_cnt) passed = passed + 1
+  !print *,expected_cnt,icnt,passed
+
+  ! test4: mix land and ocean, values nowhere
+  ntests_land_ice = ntests_land_ice + 1
+  kmt = (/0,1,1,0,0/)
+  field1(:,:) = 0.0
+  expected_cnt = 0
+  call zero_out_land_ice(kmt, field1, icnt)
+  if (icnt == expected_cnt) passed = passed + 1
+  !print *,expected_cnt,icnt,passed
+
+  ! test5: mix land and ocean, values at one category/location only at land
+  ntests_land_ice = ntests_land_ice + 1
+  kmt = (/0,1,1,0,0/)
+  field1(:,:) = 0.0
+  field1(ncat,5) = 1.0e-3
+  expected_cnt = 1
+  call zero_out_land_ice(kmt, field1, icnt)
+  if (icnt == expected_cnt) passed = passed + 1
+  !print *,expected_cnt,icnt,passed
+
+  ! test6: mix land and ocean, values at all categories/single location only at land
+  ntests_land_ice = ntests_land_ice + 1
+  kmt = (/0,1,1,0,0/)
+  field1(:,:) = 0.0
+  field1(:,1) = 1.0e-3
+  expected_cnt = 1
+  call zero_out_land_ice(kmt, field1, icnt)
+  if (icnt == expected_cnt) passed = passed + 1
+  !print *,expected_cnt,icnt,passed
+
+  ! test7: mix land and ocean, values at one category/location only at ocean
+  ntests_land_ice = ntests_land_ice + 1
+  kmt = (/0,1,1,0,0/)
+  field1(:,:) = 0.0
+  field1(ncat,3) = 1.0e-3
+  expected_cnt = 0
+  call zero_out_land_ice(kmt, field1, icnt)
+  if (icnt == expected_cnt) passed = passed + 1
+  !print *,expected_cnt,icnt,passed
+
+  ! test8: mix land and ocean, values at all categories/single location only at ocean
+  ntests_land_ice = ntests_land_ice + 1
+  kmt = (/0,1,1,0,0/)
+  field1(:,:) = 0.0
+  field1(:,3) = 1.0e-3
+  expected_cnt = 0
+  call zero_out_land_ice(kmt, field1, icnt)
+  if (icnt == expected_cnt) passed = passed + 1
+  !print *,expected_cnt,icnt,passed
+
+  if (passed .eq. ntests_land_ice) then
+     print '(2(a36,i6),a20)','land-ice QC test: SUCCESS! ',passed ,' tests out of ',ntests_land_ice
+  else
+     print '(2(a36,i6),a20)','land-ice QC test: FAIL! only ',passed,' out of ',ntests_land_ice
+     print '(a)',' Phantom ice QC tests will not run '
+     stop 1
+  endif
+
+  passed = 0
+  ! ------------------------------------
+  ! Tests for zero_out_phantom_ice
+  ! ------------------------------------
+
+  ! test1: all zeros, field1 and 2
+  ntests_phantom_ice = ntests_phantom_ice + 1
+  field1(:,:) = 0.0
+  field2(:,:) = 0.0
+  expected_cnt = 0
+  call zero_out_phantom_ice(field1, field2, icnt)
+  if (icnt == expected_cnt) passed = passed + 1
+  !print *,'test1: ',expected_cnt,icnt,passed
+
+  ! test2: all values, field1 and 2
+  ntests_phantom_ice = ntests_phantom_ice + 1
+  field1(:,:) = 2.0e-1
+  field2(:,:) = 1.0e-3
+  expected_cnt = 0
+  call zero_out_phantom_ice(field1, field2, icnt)
+  if (icnt == expected_cnt) passed = passed + 1
+  !print *,'test2: ',expected_cnt,icnt,passed
+
+  ! test3: field1 contains values, field2 all zero
+  ntests_phantom_ice = ntests_phantom_ice + 1
+  field1(:,:) = 1.e-3
+  field2(:,:) = 0.0
+  ! the expected_cnt = 0 because the QC does not check for this case
+  expected_cnt = 0
+  call zero_out_phantom_ice(field1, field2, icnt)
+  if (icnt == expected_cnt) passed = passed + 1
+  !print *,'test3: ',expected_cnt,icnt,passed
+
+  ! test4: field1 is zero, field2 contains values
+  ntests_phantom_ice = ntests_phantom_ice + 1
+  field1(:,:) = 0.0
+  field2(:,:) = 1.e-3
+  expected_cnt = nxy
+  call zero_out_phantom_ice(field1, field2, icnt)
+  if (icnt == expected_cnt) passed = passed + 1
+  !print *,'test4: ',expected_cnt,icnt,passed
+
+  ! test5: field1 has values single cat & location, field2 is zero
+  ntests_phantom_ice = ntests_phantom_ice + 1
+  field1(2,1) = 1.e-3
+  field2(:,:) = 0.0
+  ! the expected_cnt = 0 because the QC does not check for this case
+  expected_cnt = 0
+  call zero_out_phantom_ice(field1, field2, icnt)
+  if (icnt == expected_cnt) passed = passed + 1
+  !print *,'test5: ',expected_cnt,icnt,passed
+
+  ! test6: field2 has values single cat & location, field1 is zero
+  ntests_phantom_ice = ntests_phantom_ice + 1
+  field1(:,:) = 0.0
+  field2(ncat,3) = 1.e-3
+  expected_cnt = 1
+  call zero_out_phantom_ice(field1, field2, icnt)
+  if (icnt == expected_cnt) passed = passed + 1
+  !print *,'test6: ',expected_cnt,icnt,passed
+
+  ! test7: field1 has values all cat & 1 location, field2 is zero
+  ntests_phantom_ice = ntests_phantom_ice + 1
+  field1(:,3) = 1.e-3
+  field2(:,:) = 0.0
+  ! the expected_cnt = 0 because the QC does not check for this case
+  expected_cnt = 0
+  call zero_out_phantom_ice(field1, field2, icnt)
+  if (icnt == expected_cnt) passed = passed + 1
+  !print *,'test7: ',expected_cnt,icnt,passed
+
+  if (passed .eq. ntests_phantom_ice) then
+     print '(2(a36,i6),a20)','phantom-ice QC test: SUCCESS! ',passed ,' tests out of ',ntests_phantom_ice
+  else
+     print '(2(a36,i6),a20)','phantom-ice QC test: FAIL! only ',passed,' out of ',ntests_phantom_ice
+     stop 1
+  endif
+
+end program ftst_qcice


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Implements some QC checks on the source CICE6 restart files to fix possible issues known to cause run-time failures in the coupled model. A unit test is added for the QC test functionality.

## TESTS CONDUCTED: 
If there are changes to the build or source code, the tests below must be conducted. Contact a repository manager if you need assistance.

- [x] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera, Hercules and WCOSS2). Done using fed6cd9.
- [x] Compile branch on Hera using GNU. Done using fed6cd9.
- [x] Compile branch in 'Debug' mode on WCOSS2. Done using fed6cd9.
- [x] Run unit tests locally on any Tier 1 machine. Done on Hera using fed6cd9. All tests, including the new `ftst_qcice` test passed.
- [x] Run `ocnice_prep` consistency tests locally on all Tier 1 machines using new baseline data [here.](https://github.com/ufs-community/UFS_UTILS/pull/1024#issuecomment-2648548684) Done using fed6cd9.
- [x] Check doxygen. Done on Hera using fed6cd9. No warnings associated with the ocnice_prep code.

Describe any additional tests performed.

1. Baselines were run on Hera. The downscaled ocean warmstarts are B4B, as expected. The 1/2 deg and 1 deg ice files fail comparison. The only differences were seen in fields which are QC'd (category ice coverage, volume and snow volume and surface temperature). 

2. The initial, unfixed IC restart file used during the investigation of the negative dvice issue was QC'd using the ocnice-prep utility. Using the ``debug=.true.`` setting for the ocnice-prep, the QC'd fields were dumped to a netCDF file. The four fields QC'd (aicen, vicen, vsnon, Tsfcn) were identical to those generated via ncap2 commands previously identified as fixing the negative dvice issue. For completeness, the script using ncap2 is 

```
#!/bin/bash

set -x

maskfile=/scratch1/NCEPDEV/global/glopara/fix/cice/20240416/025/kmtu_cice_NEMS_mx025.nc
src=cice_model.res.nc
dst=ncap2.fixes.nc

cp ${src} ${dst}
ncks -A ${maskfile} ${dst}
ncap2 -O -s 'where(kmt==0) aicen=0.0' ${dst} ${dst}
ncap2 -O -s 'where(kmt==0) vicen=0.0' ${dst} ${dst}
ncap2 -O -s 'where(kmt==0) vsnon=0.0' ${dst} ${dst}
ncap2 -O -s 'where(kmt==0) Tsfcn=0.0' ${dst} ${dst}
ncap2 -O -s 'where(aicen.total($ncat) == 0.0) vicen=0.0' ${dst} ${dst}
ncap2 -O -s 'where(aicen.total($ncat) == 0.0) vsnon=0.0' ${dst} ${dst}
ncks -O -x -v kmt ${dst} ${dst}
```

3. A similar test was done for the down-scaled product of the ocnice-prep utility. The generated file via QC was identical to using the ncap2 on a file generated w/o the use of QC.

## ISSUE: 

- fixes #1019 
- related to https://github.com/ufs-community/ufs-weather-model/issues/2562