### PR TITLE
Fix Doxygen in global_cycle

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -19,6 +19,7 @@ If there are changes to the build or source code, the tests below must be conduc
 - [ ] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera, Hercules and WCOSS2).
 - [ ] Compile branch on Hera using GNU.
 - [ ] Compile branch in 'Debug' mode on WCOSS2.
+- [ ] Compile with Doxygen on any machine with no errors.
 - [ ] Run unit tests locally on any Tier 1 machine.
 - [ ] Run relevant consistency tests locally on all Tier 1 machines.
 

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -35,6 +35,10 @@ Add any links to pending PRs that are required prior to merging this PR. For exa
 ufs-community/UFS_UTILS/pull/<pr_number>
 
 ## DOCUMENTATION:
+All new and updated source code must be documented with Doxygen.
+
+- [ ] Doxygen is updated.
+
 If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files in the docs/source directory as supporting material.
 
 ## ISSUE: 

--- a/sorc/global_cycle.fd/read_write_data.f90
+++ b/sorc/global_cycle.fd/read_write_data.f90
@@ -1036,6 +1036,7 @@ MODULE READ_WRITE_DATA
  !! @param[in] LENSFC Total number of points on a tile.
  !! @param[in] DO_NSST When true, nsst fields are read.
  !! @param[out] IS_NOAHMP When true, process for the Noah-MP LSM.
+ !! @param[in] FNAME_INC Name of the increment file.
  !! @param[out] TSFFCS Skin Temperature.
  !! @param[out] SMCFCS Total volumetric soil moisture.
  !! @param[out] SWEFCS Snow water equivalent.
@@ -1076,6 +1077,7 @@ MODULE READ_WRITE_DATA
  !! @param[out] NSST Data structure containing nsst fields.
  !! @param[in] SLCINC Liquid soil moisture increments on the cubed-sphere tiles
  !! @param[in] STCINC Soil temperature increments on the cubed-sphere tiles
+ !! @param[in] LSOIL_INCR -  Number of soil layers (from top) to apply soil increments to
  !! @author George Gayno NOAA/EMC
  !! @author Yuan Xue: add capability to read soil related increments on the
  !! cubed-sphere tiles directly

--- a/sorc/global_cycle.fd/read_write_data.f90
+++ b/sorc/global_cycle.fd/read_write_data.f90
@@ -1619,7 +1619,11 @@ MODULE READ_WRITE_DATA
  ELSE
      ! THIS IS A REGRIDDED GSI FILE
      IF (PRESENT(STCINC)) THEN
-     DO K = 1, LSOIL_INCR
+       IF (.NOT.PRESENT(LSOIL_INCR)) THEN
+         write(6,*)'FATAL ERROR variable lsoil_incr not declared.'
+         CALL MPI_ABORT(MPI_COMM_WORLD, 134, ERROR)
+       END IF
+       DO K = 1, LSOIL_INCR
          WRITE(K_CH, '(I1)') K
 
          INCVAR = "soilt"//K_CH//"_inc"
@@ -1630,10 +1634,14 @@ MODULE READ_WRITE_DATA
          CALL NETCDF_ERR(ERROR, 'READING soilt*_inc increments') 
 
          STCINC(:,K) = RESHAPE(dummy, (/LENSFC/))
-     ENDDO
+       ENDDO
      ENDIF
      IF (PRESENT(SLCINC)) THEN
-     DO K = 1, LSOIL_INCR
+       IF (.NOT.PRESENT(LSOIL_INCR)) THEN
+         write(6,*)'FATAL ERROR variable lsoil_incr not declared.'
+         CALL MPI_ABORT(MPI_COMM_WORLD, 136, ERROR)
+       END IF
+       DO K = 1, LSOIL_INCR
          WRITE(K_CH, '(I1)') K
 
          INCVAR = "slc"//K_CH//"_inc"
@@ -1644,7 +1652,7 @@ MODULE READ_WRITE_DATA
          CALL NETCDF_ERR(ERROR, 'READING slc*_inc increments') 
 
          SLCINC(:,K) = RESHAPE(dummy, (/LENSFC/))
-     ENDDO
+       ENDDO
      ENDIF
  ENDIF 
 

--- a/sorc/global_cycle.fd/read_write_data.f90
+++ b/sorc/global_cycle.fd/read_write_data.f90
@@ -1077,7 +1077,7 @@ MODULE READ_WRITE_DATA
  !! @param[out] NSST Data structure containing nsst fields.
  !! @param[in] SLCINC Liquid soil moisture increments on the cubed-sphere tiles
  !! @param[in] STCINC Soil temperature increments on the cubed-sphere tiles
- !! @param[in] LSOIL_INCR -  Number of soil layers (from top) to apply soil increments to
+ !! @param[in] LSOIL_INCR Number of soil layers (from top) to apply soil increments to
  !! @author George Gayno NOAA/EMC
  !! @author Yuan Xue: add capability to read soil related increments on the
  !! cubed-sphere tiles directly


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Add definitions for two arguments in the `read_data` routine.
- Add checks for missing optional argument `LSOIL_INCR` in `read_data`.
- Update the pull request template to always require a branch be compiled with
Doxygen before merging.

## TESTS CONDUCTED: 
If there are changes to the build or source code, the tests below must be conducted. Contact a repository manager if you need assistance.

- [x] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera, Hercules and WCOSS2). Done using 88b38a8.
- [x] Compile branch on Hera using GNU. Done using 88b38a8.
- [x] Compile branch in 'Debug' mode on WCOSS2. Done on Cactus using 88b38a8.
- [x] Run unit tests locally on any Tier 1 machine. Done on Cactus using 88b38a8. All tests passed.
- [x] Run `global_cycle` consistency tests locally on all Tier 1 machines. Done using 88b38a8. All tests passed as expected.

Describe any additional tests performed.

- On Hera, the repository (at 88b38a8) was built with Doxygen with no errors. There were no warnings associated with the `global_cycle` code.

## DEPENDENCIES:
None.

## DOCUMENTATION:
Minor fixes to the Doxygen.

## ISSUE: 
Fixes #1025.