### PR TITLE
Update hsi path on Gaea clusters

### DIFF
--- a/modulefiles/build.gaeac5.intel.lua
+++ b/modulefiles/build.gaeac5.intel.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to compile UFS_UTILS on Gaea using Intel
 ]])
 
-prepend_path("MODULEPATH", "/sw/rdtn/modulefiles")
+prepend_path("MODULEPATH", "/usw/hpss/modulefiles")
 load("hsi")
 
 prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")

--- a/modulefiles/build.gaeac6.intel.lua
+++ b/modulefiles/build.gaeac6.intel.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to compile UFS_UTILS on Gaea C6 using Intel
 ]])
 
-prepend_path("MODULEPATH", "/sw/rdtn/modulefiles")
+prepend_path("MODULEPATH", "/usw/hpss/modulefiles")
 load("hsi")
 
 prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/c6/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Update the paths to the HSI module on C5 and C6.

## TESTS CONDUCTED: 
Only test builds on both C5 and C6 were conducted.  The change in HSI module paths should have no effect on the science.

## DEPENDENCIES:
None

## ISSUE: 
Resolves https://github.com/ufs-community/UFS_UTILS/issues/1030