### PR TITLE
Add gdas_init support for GaeaC6

### DIFF
--- a/docs/source/ufs_utils.rst
+++ b/docs/source/ufs_utils.rst
@@ -681,6 +681,7 @@ The gdas_init utility is used to create coldstart initial conditions for global 
      * Hera
      * Jet
      * WCOSS2
+     * Gaea C6
      * S4 (Only the chgres_cube step is supported, not the data pull step.)
 
 Location

--- a/fix/link_fixdirs.sh
+++ b/fix/link_fixdirs.sh
@@ -57,7 +57,7 @@ elif [ $machine = "s4" ]; then
 elif [ $machine = "gaeac5" ]; then
     FIX_DIR="/gpfs/f5/ufs-ard/world-shared/global/glopara/data/fix"
 elif [ $machine = "gaeac6" ]; then
-    FIX_DIR="/gpfs/f6/bil-fire8/world-shared/global/glopara/data/fix"
+    FIX_DIR="/gpfs/f6/drsa-precip3/world-shared/role.glopara/fix"
 fi
 
 am_ver=${am_ver:-20220805}

--- a/util/gdas_init/driver.gaeac6.sh
+++ b/util/gdas_init/driver.gaeac6.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #---------------------------------------------------------------------
-# Driver script for running on Hera.
+# Driver script for running on Gaea-C6.
 #
 # Edit the 'config' file before running.
 #---------------------------------------------------------------------

--- a/util/gdas_init/driver.gaeac6.sh
+++ b/util/gdas_init/driver.gaeac6.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+
+#---------------------------------------------------------------------
+# Driver script for running on Hera.
+#
+# Edit the 'config' file before running.
+#---------------------------------------------------------------------
+
+set -x
+
+compiler=${compiler:-"intel"}
+source ../../sorc/machine-setup.sh > /dev/null 2>&1
+module use ../../modulefiles
+module load build.$target.$compiler
+module list
+
+# Needed for NDATE utility
+module load prod_util/2.1.1
+
+PROJECT_CODE=drsa-hurr1
+QUEUE_dtn=hpss
+QUEUE=normal
+
+export machine=gaeac6
+
+source config
+
+if [ $EXTRACT_DATA == yes ]; then
+
+  rm -fr $EXTRACT_DIR
+  mkdir -p $EXTRACT_DIR
+
+  MEM=6000M
+  WALLT="2:00:00"
+
+  case $gfs_ver in
+    v12 | v13)
+      DATAH=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_${CDUMP} \
+       -o log.data.${CDUMP} -e log.data.${CDUMP} ./get_pre-v14.data.sh ${CDUMP})
+      DEPEND="-d afterok:$DATAH"
+      if [ "$CDUMP" = "gdas" ] ; then
+        DATA1=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_enkf \
+         -o log.data.enkf -e log.data.enkf ./get_pre-v14.data.sh enkf)
+        DEPEND="-d afterok:$DATAH:$DATA1"
+      fi
+      ;;
+    v14)
+      DATAH=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_${CDUMP} \
+       -o log.data.${CDUMP} -e log.data.${CDUMP} ./get_v14.data.sh ${CDUMP})
+      DEPEND="-d afterok:$DATAH"
+      if [ "$CDUMP" = "gdas" ] ; then
+        DATA1=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_enkf \
+         -o log.data.enkf -e log.data.enkf ./get_v14.data.sh enkf)
+        DEPEND="-d afterok:$DATAH:$DATA1"
+      fi
+      ;;
+    v15)
+      DATAH=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_${CDUMP} \
+       -o log.data.${CDUMP} -e log.data.${CDUMP} ./get_v15.data.sh ${CDUMP})
+      if [ "$CDUMP" = "gfs" ] ; then
+        DEPEND="-d afterok:$DATAH"
+      else
+        DATA1=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_grp1 \
+         -o log.data.grp1 -e log.data.grp1 ./get_v15.data.sh grp1)
+        DATA2=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_grp2 \
+         -o log.data.grp2 -e log.data.grp2 ./get_v15.data.sh grp2)
+        DATA3=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_grp3 \
+         -o log.data.grp3 -e log.data.grp3 ./get_v15.data.sh grp3)
+        DATA4=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_grp4 \
+         -o log.data.grp4 -e log.data.grp4 ./get_v15.data.sh grp4)
+        DATA5=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_grp5 \
+         -o log.data.grp5 -e log.data.grp5 ./get_v15.data.sh grp5)
+        DATA6=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_grp6 \
+         -o log.data.grp6 -e log.data.grp6 ./get_v15.data.sh grp6)
+        DATA7=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_grp7 \
+         -o log.data.grp7 -e log.data.grp7 ./get_v15.data.sh grp7)
+        DATA8=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_grp8 \
+         -o log.data.grp8 -e log.data.grp8 ./get_v15.data.sh grp8)
+        DEPEND="-d afterok:$DATAH:$DATA1:$DATA2:$DATA3:$DATA4:$DATA5:$DATA6:$DATA7:$DATA8"
+      fi
+      ;;
+    v16retro)
+      DATAH=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_v16retro \
+       -o log.data.v16retro -e log.data.v16retro ./get_v16retro.data.sh ${CDUMP})
+      DEPEND="-d afterok:$DATAH"
+      ;;
+    v16)
+      DATAH=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_${CDUMP} \
+       -o log.data.${CDUMP} -e log.data.${CDUMP} ./get_v16.data.sh ${CDUMP})
+      DEPEND="-d afterok:$DATAH"
+      if [ "$CDUMP" = "gdas" ] ; then
+        DATA1=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_grp1 \
+         -o log.data.grp1 -e log.data.grp1 ./get_v16.data.sh grp1)
+        DATA2=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_grp2 \
+         -o log.data.grp2 -e log.data.grp2 ./get_v16.data.sh grp2)
+        DATA3=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_grp3 \
+         -o log.data.grp3 -e log.data.grp3 ./get_v16.data.sh grp3)
+        DATA4=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_grp4 \
+         -o log.data.grp4 -e log.data.grp4 ./get_v16.data.sh grp4)
+        DATA5=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_grp5 \
+         -o log.data.grp5 -e log.data.grp5 ./get_v16.data.sh grp5)
+        DATA6=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_grp6 \
+         -o log.data.grp6 -e log.data.grp6 ./get_v16.data.sh grp6)
+        DATA7=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_grp7 \
+         -o log.data.grp7 -e log.data.grp7 ./get_v16.data.sh grp7)
+        DATA8=$(sbatch --parsable --clusters=es --partition=dtn_f5_f6 --constraint=f6 --ntasks=1 --mem=$MEM -t $WALLT -A $PROJECT_CODE -q $QUEUE_dtn -J get_grp8 \
+         -o log.data.grp8 -e log.data.grp8 ./get_v16.data.sh grp8)
+        DEPEND="-d afterok:$DATAH:$DATA1:$DATA2:$DATA3:$DATA4:$DATA5:$DATA6:$DATA7:$DATA8"
+      fi
+      ;;
+ esac
+
+else  # do not extract data.
+
+  DEPEND=' '
+
+fi  # extract data?
+
+# Strip ;es from dependencies (this is printed when submitting to the es cluster)
+DEPEND=$(echo ${DEPEND} | sed "s/;es//g")
+
+if [ $RUN_CHGRES == yes ]; then
+
+  export APRUN=srun
+  NODES=3
+  WALLT="0:15:00"
+  export OMP_NUM_THREADS=1
+  if [ $CRES_HIRES == 'C768' ] ; then
+    NODES=5
+  elif [ $CRES_HIRES == 'C1152' ] ; then
+    NODES=8
+    WALLT="0:20:00"
+  fi
+  case $gfs_ver in
+    v12 | v13)
+      export OMP_NUM_THREADS=4
+      export OMP_STACKSIZE=1024M
+      sbatch --parsable --ntasks-per-node=6 --clusters=c6 --partition=batch --nodes=${NODES} --cpus-per-task=$OMP_NUM_THREADS \
+        -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${CDUMP} \
+        -o log.${CDUMP} -e log.${CDUMP} ${DEPEND} run_pre-v14.chgres.sh ${CDUMP}
+      ;;
+    v14)
+      sbatch --parsable --ntasks-per-node=6 --clusters=c6 --partition=batch --nodes=${NODES} -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${CDUMP} \
+      -o log.${CDUMP} -e log.${CDUMP} ${DEPEND} run_v14.chgres.sh ${CDUMP}
+      ;;
+    v15)
+      sbatch --parsable --ntasks-per-node=6 --clusters=c6 --partition=batch --nodes=${NODES} -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${CDUMP} \
+      -o log.${CDUMP} -e log.${CDUMP} ${DEPEND} run_v15.chgres.sh ${CDUMP}
+      ;;
+    v16retro)
+      if [ "$CDUMP" = "gdas" ] ; then
+        sbatch --parsable --ntasks-per-node=6 --clusters=c6 --partition=batch --nodes=${NODES} -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${CDUMP} \
+        -o log.${CDUMP} -e log.${CDUMP} ${DEPEND} run_v16retro.chgres.sh hires
+      else
+        sbatch --parsable --ntasks-per-node=6 --clusters=c6 --partition=batch --nodes=${NODES} -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${CDUMP} \
+        -o log.${CDUMP} -e log.${CDUMP} ${DEPEND} run_v16.chgres.sh ${CDUMP}
+      fi
+      ;;
+    v16)
+      sbatch --parsable --ntasks-per-node=6 --clusters=c6 --partition=batch --nodes=${NODES} -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${CDUMP} \
+      -o log.${CDUMP} -e log.${CDUMP} ${DEPEND} run_v16.chgres.sh ${CDUMP}
+      ;;
+  esac
+
+  if [ "$CDUMP" = "gdas" ]; then
+
+    WALLT="0:15:00"
+
+    if [ "$gfs_ver" = "v16retro" ]; then
+
+      sbatch --parsable --ntasks-per-node=12 --clusters=c6 --partition=batch --nodes=1 -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_enkf \
+      -o log.enkf -e log.enkf ${DEPEND} run_v16retro.chgres.sh enkf
+
+    else
+
+      MEMBER=1
+      while [ $MEMBER -le 80 ]; do
+        if [ $MEMBER -lt 10 ]; then
+          MEMBER_CH="00${MEMBER}"
+        else
+          MEMBER_CH="0${MEMBER}"
+        fi
+        case $gfs_ver in
+          v12 | v13)
+              export OMP_NUM_THREADS=2
+              export OMP_STACKSIZE=1024M
+              sbatch --parsable --ntasks-per-node=12 --clusters=c6 --partition=batch --nodes=1 --cpus-per-task=$OMP_NUM_THREADS \
+               -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${MEMBER_CH} \
+               -o log.${MEMBER_CH} -e log.${MEMBER_CH} ${DEPEND} run_pre-v14.chgres.sh ${MEMBER_CH}
+            ;;
+          v14)
+              sbatch --parsable --ntasks-per-node=12 --clusters=c6 --partition=batch --nodes=1 -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${MEMBER_CH} \
+              -o log.${MEMBER_CH} -e log.${MEMBER_CH} ${DEPEND} run_v14.chgres.sh ${MEMBER_CH}
+            ;;
+          v15)
+              sbatch --parsable --ntasks-per-node=12 --clusters=c6 --partition=batch --nodes=1 -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${MEMBER_CH} \
+              -o log.${MEMBER_CH} -e log.${MEMBER_CH} ${DEPEND} run_v15.chgres.sh ${MEMBER_CH}
+            ;;
+          v16)
+              sbatch --parsable --ntasks-per-node=12 --clusters=c6 --partition=batch --nodes=1 -t $WALLT -A $PROJECT_CODE -q $QUEUE -J chgres_${MEMBER_CH} \
+              -o log.${MEMBER_CH} -e log.${MEMBER_CH} ${DEPEND} run_v16.chgres.sh ${MEMBER_CH}
+            ;;
+        esac
+        MEMBER=$(( $MEMBER + 1 ))
+      done
+
+    fi # v16 retro?
+
+  fi  # which CDUMP?
+
+fi  # run chgres?

--- a/util/gdas_init/set_fixed_files.sh
+++ b/util/gdas_init/set_fixed_files.sh
@@ -45,6 +45,8 @@ elif [ "$machine" = 'jet' ] ; then
   FIX_ORO_INPUT=/lfs5/HFIP/hfv3gfs/glopara/FIX/fix/orog/20230615
 elif [ "$machine" = 's4' ] ; then
   FIX_ORO_INPUT=/data/prod/glopara/fix/orog/20230615
+elif [ "$machine" = 'gaeac6' ] ; then
+  FIX_ORO_INPUT=/gpfs/f6/drsa-precip3/world-shared/role.glopara/fix/orog/20230615
 else
   set +x
   echo ERROR machine $machine not supported.


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This add support for Gaea C6 to be able to run the GDAS_Init utility on that platform.

## TESTS CONDUCTED: 
Ran the utility on C6 and generated C768/C384 initial conditions for 2024092518 on that platform.  There are no source code changes, so no other tests were performed.

## DEPENDENCIES:
None.

## DOCUMENTATION:
Added a note to `ufs_utils.rst` to indicate that Gaea C6 is now supported.

## ISSUE: 
Fixes #1035.