### PR TITLE
Handle netcdf with large size

### DIFF
--- a/sorc/grid_tools.fd/regional_esg_grid.fd/regional_esg_grid.f90
+++ b/sorc/grid_tools.fd/regional_esg_grid.fd/regional_esg_grid.f90
@@ -108,7 +108,7 @@ program regional_grid
   glat = glat*rtod
   where (glon < 0.0) glon = glon + 360.0
 
-  call check( nf90_create("regional_grid.nc", NF90_64BIT_OFFSET, ncid) )
+  call check( nf90_create("regional_grid.nc", IOR(NF90_NETCDF4,NF90_CLASSIC_MODEL), ncid) )
   call check( nf90_def_dim(ncid, "string", 255, string_dimid) )
   call check( nf90_def_dim(ncid, "nx", nx, nx_dimid) )
   call check( nf90_def_dim(ncid, "ny", ny, ny_dimid) )

--- a/sorc/orog_mask_tools.fd/orog_gsl.fd/module_gsl_oro_data_lg_scale.f90
+++ b/sorc/orog_mask_tools.fd/orog_gsl.fd/module_gsl_oro_data_lg_scale.f90
@@ -808,7 +808,7 @@ else   ! stand-alone regional tile
 end if
 
 ! Open netCDF file for output
-err = nf90_create(oro_data_output_file_name, NF90_CLOBBER, ncid_out)
+err = nf90_create(oro_data_output_file_name, IOR(NF90_NETCDF4,NF90_CLASSIC_MODEL), ncid_out)
 call netcdf_err(err, 'creating: '//oro_data_output_file_name)
 
 err = nf90_redef(ncid_out)

--- a/sorc/orog_mask_tools.fd/orog_gsl.fd/module_gsl_oro_data_sm_scale.f90
+++ b/sorc/orog_mask_tools.fd/orog_gsl.fd/module_gsl_oro_data_sm_scale.f90
@@ -752,7 +752,7 @@ else   ! stand-alone regional tile
 end if
 
 ! Open netCDF file for output
-err = nf90_create(oro_data_output_file_name, NF90_CLOBBER, ncid_out)
+err = nf90_create(oro_data_output_file_name, IOR(NF90_NETCDF4,NF90_CLASSIC_MODEL), ncid_out)
 call netcdf_err(err, 'creating: '//oro_data_output_file_name)
 
 err = nf90_redef(ncid_out)
@@ -925,7 +925,7 @@ if ( min_DX.le.7.5 ) then
    end if
 
    ! Open netCDF file for output
-   err = nf90_create(oro_data_output_file_name, NF90_CLOBBER, ncid_out)
+   err = nf90_create(oro_data_output_file_name, IOR(NF90_NETCDF4,NF90_CLASSIC_MODEL), ncid_out)
    call netcdf_err(err, 'creating: '//oro_data_output_file_name)
 
    err = nf90_redef(ncid_out)


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Update the NetCDF writes in the `regional_esg` and the `orog_gsl` programs to output large grids. Here, large is about 5000x5000 or greater.

## TESTS CONDUCTED: 
If there are changes to the build or source code, the tests below must be conducted. Contact a repository manager if you need assistance.

- [x] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera, Hercules and WCOSS2). Done using ecabb29.
- [x] Compile branch on Hera using GNU. Done using ecabb29. 
- [x] Compile branch in 'Debug' mode on WCOSS2. Done using ecabb29.
- [x] Compile with Doxygen on any machine with no errors. Done using ecabb29 on Hera.
- [x] Run unit tests locally on any Tier 1 machine. Done using ecabb29 on Hera.
- [x] Run `grid_gen` consistency tests locally on all Tier 1 machines. Done using ecabb29. Tests 6 and 7 failed. All other tests passed. The tests that failed run the `orog_gsl` step. The files output from that step differed from the baseline only in the file type. The output from the `nccmp` step is: `DIFFER : FILE FORMATS : NC_FORMAT_NETCDF4_CLASSIC <> NC_FORMAT_CLASSIC.`. The data records were identical. This result is expected.

Describe any additional tests performed.

The `regional_esg` and `orog_gsl` programs were tested with 12000x12000 grids and the file writes were successful: See [here](https://github.com/ufs-community/UFS_UTILS/pull/1044#issuecomment-2845207952) and [here](https://github.com/ufs-community/UFS_UTILS/pull/1044#issuecomment-2845222863).

## DEPENDENCIES:
None.

## ISSUE: 
Fixes #1043.