### PR TITLE
Update Intel CI to use ubuntu 24.04

### DIFF
--- a/.github/workflows/ubuntu_intel.yaml
+++ b/.github/workflows/ubuntu_intel.yaml
@@ -58,6 +58,7 @@ jobs:
       - name: install-dependencies-with-spack
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
+          sudo mv /usr/local /usr/local_mv
           git clone -c feature.manyFiles=true https://github.com/JCSDA/spack.git
           source spack/share/spack/setup-env.sh
           sed "s/\[oneapi, gcc@10:10, apple-clang@14\]/\[oneapi\]/g" ufs_utils/ci/spack.yaml > spack_ci.yaml

--- a/.github/workflows/ubuntu_intel.yaml
+++ b/.github/workflows/ubuntu_intel.yaml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: checkout  # this is to get the ci/spack.yaml file
@@ -79,7 +79,7 @@ jobs:
 
   ufs_utils:
     needs: setup
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: install-intel

--- a/.github/workflows/ubuntu_intel.yaml
+++ b/.github/workflows/ubuntu_intel.yaml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: checkout  # this is to get the ci/spack.yaml file
@@ -78,7 +78,7 @@ jobs:
 
   ufs_utils:
     needs: setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: install-intel


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Currently, the Intel CI uses ubuntu 20.04, which is being deprecated on 04/15/2025. Update to 24.04, which
is the latest version.

## TESTS CONDUCTED: 

Cleaned out the cache on my branch, then ran the Intel based CI. Everything worked.

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #1047

## CONTRIBUTORS: 
@AlexanderRichert-NOAA 