### PR TITLE
Update FIX_DIR path for orion and hercules.

### DIFF
--- a/fix/link_fixdirs.sh
+++ b/fix/link_fixdirs.sh
@@ -49,7 +49,7 @@ if [ $machine = "hera" ]; then
 elif [ $machine = "jet" ]; then
     FIX_DIR="/lfs5/HFIP/hfv3gfs/glopara/FIX/fix"
 elif [ $machine = "orion" -o $machine = "hercules" ]; then
-    FIX_DIR="/work/noaa/global/glopara/fix"
+    FIX_DIR="/work2/noaa/global/role-global/fix"
 elif [ $machine = "wcoss2" ]; then
     FIX_DIR="/lfs/h2/emc/global/noscrub/emc.global/FIX/fix"
 elif [ $machine = "s4" ]; then


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Update `./fix/link_fixdirs.sh` to point to the new location of the 'fixed' data on Orion and Hercules: `/work2/noaa/global/role-global/fix/`

## TESTS CONDUCTED: 

The `chgres_cube` consistency tests use data from the `/work2/noaa/global/role-global/fix/am/` directory. The `grid_gen` tests use data from `/work2/.../fix/orog` and `/work2/.../fix/sfc_climo`. These tests were run on Orion and Hercules and finished normally.

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #1040.