### PR TITLE
change from allLand_to_allLand to land_to_land interpolation for cano…

### DIFF
--- a/sorc/chgres_cube.fd/surface.F90
+++ b/sorc/chgres_cube.fd/surface.F90
@@ -1086,8 +1086,8 @@
  allocate(search_nums(num_fields))
  allocate(dozero(num_fields))
 
- search_nums = (/223,66,65/)
- dozero=(/.True.,.False.,.False./)
+ search_nums = (/66,65/)
+ dozero=(/.False.,.False./)
  
  call regrid_many(bundle_allland_input,bundle_allland_target,num_fields,regrid_all_land,dozero, &
                   unmapped_ptr=unmapped_ptr)
@@ -1392,8 +1392,8 @@
  allocate(search_nums(num_fields))
  allocate(dozero(num_fields))
  
- search_nums(1:5) = (/85,7,224,85,86/)
- dozero(1:5) = (/.False.,.False.,.True.,.True.,.False./)
+ search_nums(1:6) = (/85,7,224,85,86,223/)
+ dozero(1:6) = (/.False.,.False.,.True.,.True.,.False.,.True./)
  
  if (.not. vgfrc_from_climo) then
    search_nums(vgfrc_ind) = 224
@@ -2458,6 +2458,7 @@
  enddo
 
  print*,"- ZERO OUT TARGET GRID CANOPY MOISTURE CONTENT WHERE NO PLANTS."
+ print*,"- CAP TARGET GRID CANOPY MOISTURE CONTENT TO 2.0MM."
  call ESMF_FieldGet(canopy_mc_target_grid, &
                     farrayPtr=data_ptr, rc=rc)
  if(ESMF_logFoundError(rcToCheck=rc,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
@@ -2467,6 +2468,7 @@
 
  do j = clb(2), cub(2)
  do i = clb(1), cub(1)
+   data_ptr(i,j) = AMIN1(data_ptr(i,j), 2.0)
    if (veg_greenness_ptr(i,j) <= 0.01) data_ptr(i,j) = 0.0
  enddo
  enddo

--- a/sorc/chgres_cube.fd/surface.F90
+++ b/sorc/chgres_cube.fd/surface.F90
@@ -1071,11 +1071,11 @@
  bundle_allland_input = ESMF_FieldBundleCreate(name="all land input", rc=rc)
    if(ESMF_logFoundError(rcToCheck=rc,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
       call error_handler("IN FieldBundleCreate", rc)
- call ESMF_FieldBundleAdd(bundle_allland_target, (/canopy_mc_target_grid, snow_depth_target_grid, &
+ call ESMF_FieldBundleAdd(bundle_allland_target, (/snow_depth_target_grid, &
                           snow_liq_equiv_target_grid/), rc=rc)
   if(ESMF_logFoundError(rcToCheck=rc,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
       call error_handler("IN FieldBundleAdd", rc)
- call ESMF_FieldBundleAdd(bundle_allland_input, (/canopy_mc_input_grid, snow_depth_input_grid, &
+ call ESMF_FieldBundleAdd(bundle_allland_input, (/snow_depth_input_grid, &
                           snow_liq_equiv_input_grid/), rc=rc)                          
   if(ESMF_logFoundError(rcToCheck=rc,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
       call error_handler("IN FieldBundleAdd", rc)
@@ -1301,12 +1301,14 @@
       call error_handler("IN FieldBundleCreate", rc)
       
  call ESMF_FieldBundleAdd(bundle_nolandice_target, (/skin_temp_target_grid, terrain_from_input_grid,& 
-                          soil_type_from_input_grid,soilm_tot_target_grid,soil_temp_target_grid/), rc=rc)
+                          soil_type_from_input_grid,soilm_tot_target_grid,soil_temp_target_grid,&
+                          canopy_mc_target_grid/), rc=rc)
   if(ESMF_logFoundError(rcToCheck=rc,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
       call error_handler("IN FieldBundleAdd", rc)
       
  call ESMF_FieldBundleAdd(bundle_nolandice_input, (/skin_temp_input_grid, terrain_input_grid,&
-                          soil_type_input_grid,soilm_tot_input_grid,soil_temp_input_grid/), rc=rc)
+                          soil_type_input_grid,soilm_tot_input_grid,soil_temp_input_grid,&
+                          canopy_mc_input_grid/), rc=rc)
   if(ESMF_logFoundError(rcToCheck=rc,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
       call error_handler("IN FieldBundleAdd", rc)
  

--- a/sorc/chgres_cube.fd/surface.F90
+++ b/sorc/chgres_cube.fd/surface.F90
@@ -2457,8 +2457,7 @@
  enddo
  enddo
 
- print*,"- ZERO OUT TARGET GRID CANOPY MOISTURE CONTENT WHERE NO PLANTS."
- print*,"- CAP TARGET GRID CANOPY MOISTURE CONTENT TO 2.0MM."
+ print*,"- QC TARGET GRID CANOPY MOISTURE CONTENT."
  call ESMF_FieldGet(canopy_mc_target_grid, &
                     farrayPtr=data_ptr, rc=rc)
  if(ESMF_logFoundError(rcToCheck=rc,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
@@ -2468,8 +2467,12 @@
 
  do j = clb(2), cub(2)
  do i = clb(1), cub(1)
-   data_ptr(i,j) = AMIN1(data_ptr(i,j), 2.0)
    if (veg_greenness_ptr(i,j) <= 0.01) data_ptr(i,j) = 0.0
+   if (data_ptr(i,j) > 2.0) data_ptr(i,j) = 2.0 ! Input data that used noah-mp can have
+                                                ! canopy moisture values above 10 mm, which
+                                                ! includes a snow portion. The coldstart file
+                                                ! assumes it is all liquid. Capping it to 2 mm
+                                                ! is a hack to remove the snow portion.
  enddo
  enddo
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
As there is no canopy over glacial grids, the canopy variables including canopy moisture content might be fake values at the initial or forecast time over land ice grids. The current chgres interpolates the variable "canopy moisture content" from all land (land ice and non-land ice) to all land grids. This creates potential issues when this variable contains unreasonable values over land ice grids. In order to have this fixed, this variable will be moved from the "all land (land ice and non-land ice)  to all land" interpolation section to the "land (non-land ice) to land" interpolation section in the "surface" module. That's the only required changes. This OR is being issued to the branch "develop"

## TESTS CONDUCTED: 
- [x] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera, Hercules and WCOSS2).
- [x] Compile branch on Hera using GNU. Done using e2bb2e4.
- [x] Compile branch in 'Debug' mode on WCOSS2. Done using e2bb2e4.
- [x] Compile with Doxygen on any machine with no errors. Done on WCOSS2 using e2bb2e4. 
- [x] Run unit tests locally on any Tier 1 machine. Done on Hera using e2bb2e4 and GNU compiler.
- [x] Run `chgres_cube` consistency tests locally on all Tier 1 machines. Run on WCOSS2, Orion, Jet and Hera using e2bb2e4. Tests 4,5,10 and 11 passed. All other tests failed. In all failures, only the canopy moisture content record differed from the baseline. Some of the differences were due to the interpolation method used. The 'all land' to 'all land' fields use 'conservative' regridding. The 'land' to 'land' interpolation uses 'neighbor'. Test 11 does not process surface data - that is why it passed. Tests 4, 5, and 10 use GFS grib2 data as input, which does not have canopy water. In that case, it is set to zero.

Describe any additional tests performed:
- A test case using GFS v17 parallel data (that had the bad canopy moisture values at land ice) was setup on Hera: `/scratch1/NCEPDEV/da/George.Gayno/ufs_utils.git/chgres_cube.bad.cmc`. Using the branch at e2bb2e4 resulted in coldstart files with canopy moisture content that did not exceed 2 mm.

## ISSUE
Fixes #1052