### PR TITLE
Increase memory for C384 gdas_init utility on WCOSS2

### DIFF
--- a/util/gdas_init/driver.wcoss2.sh
+++ b/util/gdas_init/driver.wcoss2.sh
@@ -124,7 +124,9 @@ if [ $RUN_CHGRES == yes ]; then
   TASKS_PER_NODE=24
   WALLT="0:15:00"
   MEM=75GB
-  if [ $CRES_HIRES == 'C768' ] ; then
+  if [ $CRES_HIRES == 'C384' ] ; then
+    MEM=150GB
+  elif [ $CRES_HIRES == 'C768' ] ; then
     MEM=250GB
   elif [ $CRES_HIRES == 'C1152' ] ; then
     MEM=500GB


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This increases the memory request for C384 chgres when running the gdas_init utility on WCOSS2.  It was found that 75GB would produce out of memory errors on Cactus.

## TESTS CONDUCTED: 
Ran the gdas_init utility at C384/C192 and C768/C384.  Since no code changes were implemented, no other tests were performed.