### PR TITLE
add DATM mesh generation utility on Hera

### DIFF
--- a/util/datmmesh_gen/datmmesh.sh
+++ b/util/datmmesh_gen/datmmesh.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eux
+
+APRUN=${APRUN:-"srun"}
+
+FDIMS=${NX}x${NY}
+FDST=${OUTPUT_DIR}/datm.${FDIMS}.SCRIP.nc
+if [ $N2S == .true. ]; then
+    ncremap -g ${FDST} -G ttl='DATM grid '${FDIMS}#latlon=${NY},${NX}#lon_typ=grn_ctr#lat_typ=gss#lat_drc=n2s
+else
+    ncremap -g ${FDST} -G ttl='DATM grid '${FDIMS}#latlon=${NY},${NX}#lon_typ=grn_ctr#lat_typ=gss
+fi
+
+FSRC=${OUTPUT_DIR}/datm.${FDIMS}.SCRIP.nc
+FDST=${OUTPUT_DIR}/mesh.datm.${FDIMS}.nc
+$APRUN -n 1 ESMF_Scrip2Unstruct ${FSRC} ${FDST} 0

--- a/util/datmmesh_gen/readme.md
+++ b/util/datmmesh_gen/readme.md
@@ -1,0 +1,3 @@
+This utility creates meshes required for the DATM component using
+NCO operators to create a SCRIP file and then ESMF_Scrip2Unstruct
+to convert the SCRIP file to an unstructured mesh.

--- a/util/datmmesh_gen/run.hera.sh
+++ b/util/datmmesh_gen/run.hera.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Edit account (-A) setting as required !
+
+#SBATCH -J datmmesh_gen
+#SBATCH -A nems
+#SBATCH --open-mode=truncate
+#SBATCH -o log
+#SBATCH -e log
+#SBATCH --ntasks=1
+#SBATCH -q debug
+#SBATCH -t 00:03:00
+
+#-------------------------------------------------------------------------------
+#
+# Run the datmmesh generation program on Hera.
+#
+# Set NX and NY to your desired resolution. Valid choices are:
+#   NX=3072, NY=1536 => 3072x1536 mesh
+#   NX=1760, NY=880 => 1760x880 mesh
+#   NX=1536, NY=768 => 1536x768 mesh
+#
+# Set N2S=.true. for N->S orientation, 1536x768 mesh only.
+#
+# To run this script, do: 'sbatch $script'
+#
+#-------------------------------------------------------------------------------
+
+set -x
+
+UFS_DIR=$PWD/../..
+source $UFS_DIR/sorc/machine-setup.sh > /dev/null 2>&1
+module use $UFS_DIR/modulefiles
+module load build.$target.intelllvm
+module list
+
+export OUTPUT_DIR=/scratch1/NCEPDEV/stmp4/$USER/datmmesh_gen
+mkdir -p $OUTPUT_DIR
+
+export NX=3072
+export NY=1536
+export N2S=.false.
+${UFS_DIR}/util/datmmesh_gen/datmmesh.sh
+
+export NX=1760
+export NY=880
+export N2S=.false.
+${UFS_DIR}/util/datmmesh_gen/datmmesh.sh
+
+export NX=1536
+export NY=768
+export N2S=.true.
+${UFS_DIR}/util/datmmesh_gen/datmmesh.sh
+
+exit


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 
Currently the meshes used by the DATM component of UWM have no known, documented creation method. These meshes are fixed files and should have a known, reproducible method to create them. This PR adds a utility script to generate the meshes required by the DATM configurations for UWM Regression testing. 

New meshes are required by the UWM RT system because the existing meshes (also in ``/scratch1/NCEPDEV/global/glopara/fix/datm/20220805/``) contain a land mask and this land mask must be removed in order for bilinear mapping to be used in the DATM component.

Eventually, these meshes will be used by G-W for the NG-GODAS application. For now, these meshes are only required only on Hera since all input-data used the RT system is sync'd from Hera to all other platforms.

## TESTS CONDUCTED: 

Describe any additional tests performed.

The DATM meshes produced have been compared to those currently in use by UWM. The differences in centerCoord are all on the order of ~10-17, the differences in the nodeCoords are all on the order of ~10-14 and the differences in the element areas are all ~10-12. The DATM meshes produced also have a uniform elementMask==1, as required by the switch to bilinear mapping.

Validation that the new meshes are working properly is at https://github.com/ufs-community/ufs-weather-model/issues/2686

## ISSUE: 
- fixes #1056 
- required by ufs-community/ufs-weather-model/issues/2686




