### PR TITLE
Add time dimension to sfc regrid based on namelist specification

### DIFF
--- a/parm/regrid_sfc/regrid.nml_tmpl
+++ b/parm/regrid_sfc/regrid.nml_tmpl
@@ -1,0 +1,28 @@
+&config
+  n_vars=@[n_vars],
+  variable_list=@[soil_incr_vars]
+  missing_value=0.,
+  time_list=@[time_list],
+  add_time_dim=@[add_time_dim], 
+/
+&input
+  gridtype="gau_inc",
+  ires=@[ires],
+  jres=@[jres],
+  fname=@[in_fname], 
+  dir="./",
+  fname_coord="gaussian_scrip.nc",
+  dir_coord="./",
+  fname_mask=@[fname_mask_in],
+  dir_mask=@[dir_mask_in]
+/
+&output
+  gridtype="fv3_rst",
+  ires=@[ireso],
+  jres=@[jreso],
+  fname=@[out_fname],
+  dir="./",
+  fname_mask="vegetation_type" 
+  dir_mask="./"
+  dir_coord="./"
+ /

--- a/reg_tests/regrid_sfc/gauss2fv3incr.sh
+++ b/reg_tests/regrid_sfc/gauss2fv3incr.sh
@@ -57,6 +57,7 @@ cat << EOF > regrid.nml
   variable_list="soilt1_inc", "soilt2_inc", "slc1_inc", "slc2_inc",
   missing_value=0.,
   time_list=6,
+  add_time_dim=.true.,
   extrap_levs=2,
  /
  &input

--- a/reg_tests/regrid_sfc/gauss2fv3incr.sh
+++ b/reg_tests/regrid_sfc/gauss2fv3incr.sh
@@ -34,7 +34,7 @@ mkdir -p $DATA
 cd ${DATA}
 
 # input, increment
-/bin/cp -p ${COMIN_REGTEST}/sfcincr_gsi ${DATA}/sfcincr_gsi
+/bin/cp -p ${COMIN_REGTEST}/sfcincr_gsi ${DATA}/sfcincr_gsi006.nc
 
 # input, fixed files
 ln -sf "${FIXorog}/gaussian.${LONB_CASE_IN}.${LATB_CASE_IN}.nc" \
@@ -56,6 +56,7 @@ cat << EOF > regrid.nml
   n_vars=4,
   variable_list="soilt1_inc", "soilt2_inc", "slc1_inc", "slc2_inc",
   missing_value=0.,
+  time_list=6,
   extrap_levs=2,
  /
  &input

--- a/sorc/regrid_sfc.fd/grids_IO.F90
+++ b/sorc/regrid_sfc.fd/grids_IO.F90
@@ -26,6 +26,7 @@
         character(15)  :: mask_variable(1) !< name of variables used for mask
         character(100) :: fname_mask       !< file name for reading in mask
         character(100) :: dir_mask         !< directory name for reading in mask
+        logical        :: mask_from_input  !< read mask from input file
         character(100) :: fname_coord      !< file name with coordinate info
         character(100) :: dir_coord        !< directory name for coordinate info
         integer        :: ires             !< latitudinal dimension
@@ -44,16 +45,18 @@
 !! @param[in] grid_setup        data structure with grid details 
 !! @param[out] mod_grid         output esmf_grid structure 
 
- subroutine setup_grid(localpet, npets, grid_setup, mod_grid )
+ subroutine setup_grid(localpet, npets, grid_setup, mod_grid, timestamp )
 
  implicit none
 
  ! INTENT IN
  type(grid_setup_type), intent(in)    :: grid_setup
  integer, intent(in)            :: localpet, npets
+ integer, intent(in), optional  :: timestamp
 
  ! INTENT OUT
  type(esmf_grid), intent(out)   :: mod_grid
+
 
  ! LOCAL
  type(esmf_field)               :: mask_field(1,1)
@@ -61,6 +64,8 @@
  integer(esmf_kind_i4), pointer :: ptr_mask(:,:)
 
  integer                        :: ierr, ncid, tile
+ character(len=128)             :: fname_mask
+ character(len=3)               :: tstr
 
 !--------------------------
 ! Create grid object, and set up pet distribution
@@ -85,7 +90,14 @@
  if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
     call error_handler("IN FieldCreate, mask_variable", ierr)
 
- call read_into_fields(localpet, grid_setup%ires, grid_setup%jres, trim(grid_setup%fname_mask), &
+ if (present(timestamp)) then 
+    write(tstr,"(I3.3)") timestamp
+    fname_mask = trim(grid_setup%fname_mask)//tstr//".nc"
+ else
+    fname_mask = trim(grid_setup%fname_mask)
+ endif
+
+ call read_into_fields(localpet, grid_setup%ires, grid_setup%jres, trim(fname_mask), &
                          trim(grid_setup%dir_mask), grid_setup, 1, &
                          grid_setup%mask_variable(1), mask_field(1,1))
 

--- a/sorc/regrid_sfc.fd/grids_IO.F90
+++ b/sorc/regrid_sfc.fd/grids_IO.F90
@@ -246,7 +246,7 @@
 !! @param[in] fields         fields to read variables into
 
  subroutine write_from_fields(localpet, i_dim, j_dim , fname_out, dir_out, &
-                                n_vars, n_tims, variable_list, fields)
+                                n_vars, n_tims, variable_list, fields, add_time_dim)
 
  implicit none
 
@@ -256,6 +256,7 @@
  character(*), intent(in)        :: dir_out
  character(15), dimension(n_vars), intent(in)     :: variable_list
  type(esmf_field), dimension(n_tims,n_vars), intent(in)  :: fields
+ logical,      intent(in)        :: add_time_dim
 
  ! LOCAL
  integer                         :: tt, id_var, ncid, ierr, &
@@ -299,7 +300,7 @@
          ierr = nf90_create(trim(fname), NF90_NETCDF4, ncid)
          call netcdf_err(ierr, 'creating file='//trim(fname) )
 
-         if (n_tims>1) then ! UFS_UTILS expects input with no time dim
+         if (add_time_dim) then ! UFS_UTILS expects input with no time dim
                            ! GFS (for IAU) expects a time dimension
                            ! later: update GFS to not expect a time dimension
              ierr = nf90_def_dim(ncid, 'Time', n_tims, id_t)
@@ -315,7 +316,7 @@
 
          do v=1, n_vars
 
-             if (n_tims>1) then
+             if (add_time_dim) then
                  ! UFS model code to read in the increments is expecting
                  ! dimensions: time, y, x (in the ncdump read out - which reverses fortran indexes)
                  ! need dimensions to be x,y,t below.

--- a/sorc/regrid_sfc.fd/grids_IO.F90
+++ b/sorc/regrid_sfc.fd/grids_IO.F90
@@ -44,6 +44,7 @@
 !! @param[in] npets             total number of pets
 !! @param[in] grid_setup        data structure with grid details 
 !! @param[out] mod_grid         output esmf_grid structure 
+!! @param[in, optional] timestamp      timestep of input file
 
  subroutine setup_grid(localpet, npets, grid_setup, mod_grid, timestamp )
 
@@ -256,6 +257,7 @@
 !! @param[in] n_tims            number of times to write out
 !! @param[in] variable_list     variables to read in
 !! @param[in] fields         fields to read variables into
+!! @param[in] add_time_dim      specify whether output file has time dimension
 
  subroutine write_from_fields(localpet, i_dim, j_dim , fname_out, dir_out, &
                                 n_vars, n_tims, variable_list, fields, add_time_dim)

--- a/sorc/regrid_sfc.fd/grids_IO.F90
+++ b/sorc/regrid_sfc.fd/grids_IO.F90
@@ -44,7 +44,7 @@
 !! @param[in] npets             total number of pets
 !! @param[in] grid_setup        data structure with grid details 
 !! @param[out] mod_grid         output esmf_grid structure 
-!! @param[in, optional] timestamp      timestep of input file
+!! @param[in] timestamp      timestep of input file
 
  subroutine setup_grid(localpet, npets, grid_setup, mod_grid, timestamp )
 

--- a/sorc/regrid_sfc.fd/readin_setup.F90
+++ b/sorc/regrid_sfc.fd/readin_setup.F90
@@ -29,18 +29,22 @@
  character(len=4)   :: default_str="NULL"
  integer            :: ires, jres
  integer            :: ierr
+ logical            :: add_time_dim
+ integer            :: fhrs(10) ! forecast hours of increment files
 
  namelist /input/  fname, dir, &
                    gridtype, &
                    fname_mask, dir_mask, &
                    fname_coord, dir_coord, &
-                   ires, jres
+                   ires, jres, &
+                   fhrs         
 
  namelist /output/  fname, dir, &
                     gridtype, &
                     fname_mask, dir_mask, &
                     fname_coord, dir_coord,&
-                    ires, jres
+                    ires, jres, &
+                    add_time_dim
 
  ! set defaults
  fname = default_str
@@ -51,6 +55,8 @@
  dir_coord = default_str
  ires = 0
  jres = 0
+ add_time_dim = .false.
+ fhrs = -1
 
  select case (namel)
  case ("input")

--- a/sorc/regrid_sfc.fd/readin_setup.F90
+++ b/sorc/regrid_sfc.fd/readin_setup.F90
@@ -73,6 +73,7 @@
 
  grid_setup%dir = dir
  grid_setup%fname = fname
+ grid_setup%mask_from_input = .false.
 
  ! set-up mask details, based on file type
  select case (gridtype)
@@ -84,6 +85,7 @@
      if (trim(fname_mask) == default_str) then ! if not specified, use input file
          grid_setup%dir_mask = dir
          grid_setup%fname_mask = fname
+         grid_setup%mask_from_input = .true.
      else
          grid_setup%dir_mask = dir_mask
          grid_setup%fname_mask = fname_mask

--- a/sorc/regrid_sfc.fd/regridStates.F90
+++ b/sorc/regrid_sfc.fd/regridStates.F90
@@ -26,8 +26,8 @@
  ! namelist inputs
  character(len=15)              :: variable_list(max_vars)
  integer                        :: n_vars, n_tims, extrap_levs
- integer                        :: time_list(10)               ! increment forecast hours
- logical                        :: add_time_dim
+ integer                        :: time_list(10)               !< increment forecast hours
+ logical                        :: add_time_dim                !< specify whether the output increment has time dimension 
  real(esmf_kind_r8)             :: missing_value ! value given to unmapped cells in the output grid
 
  type(grid_setup_type)          :: grid_setup_in, grid_setup_out

--- a/sorc/regrid_sfc.fd/regridStates.F90
+++ b/sorc/regrid_sfc.fd/regridStates.F90
@@ -33,12 +33,13 @@
  type(grid_setup_type)          :: grid_setup_in, grid_setup_out
 
  integer                        :: ierr, localpet, npets
- integer                        :: v, t, SRCTERM, k
+ integer                        :: v, t, SRCTERM
 
  character(100)                 :: fname_time
 
  type(esmf_vm)                  :: vm
- type(esmf_grid)                :: grid_in, grid_out
+ type(esmf_grid), allocatable   :: grid_in(:)
+ type(esmf_grid)                :: grid_out
  type(esmf_field), allocatable  :: fields_in(:,:)
  type(esmf_field), allocatable  :: fields_out(:,:)
  type(esmf_routehandle)         :: regrid_route
@@ -101,14 +102,13 @@
 
  
  n_tims = 0
- do k=1,10
-   if (time_list(k) .lt. 0) exit
+ do t=1,10
+   if (time_list(t) .lt. 0) exit
    n_tims = n_tims + 1
  enddo
  if (n_tims < 1) then
    call error_handler("n_tims < 1. must have at least one valid increment hour in time_list", 1)
  endif
-
 
 !------------------------
 ! Create esmf grid objects for input and output grids, and add land masks
@@ -116,8 +116,14 @@
 ! TO DO - can we make the number of tasks more flexible for fv3
 
  if (localpet==0) print*,'** Setting up grids'
- call setup_grid(localpet, npets, grid_setup_in, grid_in )
-
+ allocate(grid_in(n_tims))
+ do t = 1, n_tims
+   if (grid_setup_in%mask_from_input) then
+     call setup_grid(localpet, npets, grid_setup_in, grid_in(t), time_list(t) )
+   else
+     call setup_grid(localpet, npets, grid_setup_in, grid_in(t))
+   endif
+ enddo
  call setup_grid(localpet, npets, grid_setup_out, grid_out )
 
 !------------------------
@@ -131,7 +137,7 @@
  do t = 1, n_tims
      do v = 1, n_vars
 
-        fields_in(t,v)  = ESMF_FieldCreate(grid_in, &
+        fields_in(t,v)  = ESMF_FieldCreate(grid_in(t), &
                             typekind=ESMF_TYPEKIND_R8, &
                             staggerloc=ESMF_STAGGERLOC_CENTER, &
                             name="input for regridding", &
@@ -252,11 +258,11 @@
          if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
             call error_handler("DESTROYING FIELD", ierr)
      enddo
+ 
+     call ESMF_GridDestroy(grid_in(t), rc=ierr)
+     if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
+        call error_handler("DESTROYING GRID", ierr)
  enddo
-
- call ESMF_GridDestroy(grid_in,rc=ierr)
- if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
-    call error_handler("DESTROYING GRID", ierr)
 
  call ESMF_GridDestroy(grid_out,rc=ierr)
  if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &

--- a/sorc/regrid_sfc.fd/regridStates.F90
+++ b/sorc/regrid_sfc.fd/regridStates.F90
@@ -25,14 +25,15 @@
 
  ! namelist inputs
  character(len=15)              :: variable_list(max_vars)
- character(len=2)               :: time_list(9)
  integer                        :: n_vars, n_tims, extrap_levs
+ integer                        :: time_list(10)               ! increment forecast hours
+ logical                        :: add_time_dim
  real(esmf_kind_r8)             :: missing_value ! value given to unmapped cells in the output grid
 
  type(grid_setup_type)          :: grid_setup_in, grid_setup_out
 
  integer                        :: ierr, localpet, npets
- integer                        :: v, t, SRCTERM
+ integer                        :: v, t, SRCTERM, k
 
  character(100)                 :: fname_time
 
@@ -46,9 +47,10 @@
  integer :: ut
 
  real :: t1, t2, t3, t4
+ character(len=3)               :: tstr
 
  ! see README for details of namelist variables.
- namelist /config/ n_vars, n_tims, time_list, variable_list, missing_value, extrap_levs
+ namelist /config/ n_vars, variable_list, missing_value, extrap_levs, time_list, add_time_dim
 
 ! INITIALIZE
 !-------------------------------------------------------------------------
@@ -87,7 +89,7 @@
  ! defaults
  missing_value=-999.
  extrap_levs=2
- n_tims=1
+ time_list=-1
 
  open(newunit=ut, file='regrid.nml', iostat=ierr)
  if (ierr /= 0) call error_handler("OPENING regrid NAMELIST.", ierr)
@@ -96,6 +98,16 @@
  call readin_setup(ut,"input",grid_setup_in)
  call readin_setup(ut,"output",grid_setup_out)
  close (ut)
+
+ 
+ n_tims = 0
+ do k=1,10
+   if (time_list(k) .lt. 0) exit
+   n_tims = n_tims + 1
+ enddo
+ if (n_tims < 1) then
+   call error_handler("n_tims < 1. must have at least one valid increment hour in time_list", 1)
+ endif
 
 
 !------------------------
@@ -161,12 +173,9 @@
 ! read data into input fields
 
  do t = 1, n_tims
-
-        if (n_tims>1) then
-                fname_time = trim(grid_setup_in%fname)//"."//time_list(t)
-        else
-                fname_time = trim(grid_setup_in%fname)
-        endif
+        
+        write(tstr,"(I3.3)")time_list(t)
+        fname_time = trim(grid_setup_in%fname)//tstr//".nc"
         write(6,*) 'reading into ', trim(fname_time)
         call read_into_fields(localpet, grid_setup_in%ires, grid_setup_in%jres, &
                                  trim(fname_time), trim(grid_setup_in%dir), &
@@ -224,7 +233,7 @@
 
  call write_from_fields(localpet, grid_setup_out%ires, grid_setup_out%jres,     &
                           trim(grid_setup_out%fname), trim(grid_setup_out%dir), &
-                          n_vars, n_tims, variable_list(1:n_vars), fields_out)
+                          n_vars, n_tims, variable_list(1:n_vars), fields_out, add_time_dim)
 
 
 ! clean up


### PR DESCRIPTION
- This PR modifies the surface regridding code to add time dimensions in output files based on namelist specification. The previous version added time dimension only to files with more than one timesteps, but the UFS model expects time dim for all files. 
- This PR also adds a surface regridding namelist template (used in Global Workflow)
- For inputs with multiple timesteps, separate land mask specific to each timestamp is applied.

## TESTS CONDUCTED: 
If there are changes to the build or source code, the tests below must be conducted. Contact a repository manager if you need assistance.

- [x] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera, Hercules and WCOSS2). Done using a2629eb.
- [x] Compile branch on Hera using GNU. Done using a2629eb.
- [x] Compile branch in 'Debug' mode on WCOSS2. Successfully done using a2629eb. 
- [x] Compile with Doxygen on any machine with no errors. Done on WCOSS2 using a2629eb.
- [x] Run unit tests locally on any Tier 1 machine. Done on Hera using GNU and a2629eb.
- [x] Run `regrid_sfc` consistency tests locally on all Tier 1 machines. Done using a2629eb. See note below.

Note on the consistency tests. This PR adds a time dimension to the output files. Therefore, new baselines were generated and placed in the official locations. The tests were run against this new baseline (and passed).

## DEPENDENCIES:
None.

## DOCUMENTATION:
The Doxygen was built and visualized. The `regrid_sfc` section looked good.

## ISSUE:
None.