### PR TITLE
Unload cray-libsci that is breaking ufs-utils build on g6

### DIFF
--- a/modulefiles/build.gaeac6.intel.lua
+++ b/modulefiles/build.gaeac6.intel.lua
@@ -62,5 +62,7 @@ load(pathJoin("esmf", esmf_ver))
 nco_ver=os.getenv("nco_ver") or "5.0.6"
 load(pathJoin("nco", nco_ver))
 
+unload("cray-libsci")
+
 whatis("Description: UFS_UTILS build environment")
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Gaea C6 came back from "preventative" maintainence yesterday. 
This AM, it was noticed in the global-workflow nightly run, that the ufs-utils was failing to build on Gaea C6.

This PR:
- unloads the cray-libsci module for GaeaC6 (similar to the ufs-weather-model)

## TESTS CONDUCTED: 

Tested the build of ufs-utils on Gaea C6 with Intel.

- [ ] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Hera, Hercules and WCOSS2).
- [ ] Compile branch on Hera using GNU.
- [ ] Compile branch in 'Debug' mode on WCOSS2.
- [ ] Compile with Doxygen on any machine with no errors.
- [ ] Run unit tests locally on any Tier 1 machine.
- [ ] Run relevant consistency tests locally on all Tier 1 machines.

Optional test.

- [ ] Run full set of chgres_cube consistency tests on Hera.


## DEPENDENCIES:
None

## DOCUMENTATION:
All new and updated source code must be documented with Doxygen.

- [ ] Doxygen is updated.

## ISSUE: 


## CONTRIBUTORS (optional): 

