### PR TITLE
Unload cray-libsci on C6

### DIFF
--- a/modulefiles/build.gaeac6.intel.lua
+++ b/modulefiles/build.gaeac6.intel.lua
@@ -62,5 +62,7 @@ load(pathJoin("esmf", esmf_ver))
 nco_ver=os.getenv("nco_ver") or "5.0.6"
 load(pathJoin("nco", nco_ver))
 
+unload("cray-libsci")
+
 whatis("Description: UFS_UTILS build environment")
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This unloads the problematic cray-libsci module on C6 which is causing build failures after system maintenance yesterday.

## TESTS CONDUCTED: 
If there are changes to the build or source code, the tests below must be conducted. Contact a repository manager if you need assistance.

- [x] Compile branch on all C6

I cannot run consistency or unit tests on C6 as they have not been ported there.

## ISSUE: 
Resolves #1070