### PR TITLE
chgres_cube - Add a consistency mask check for restart vs. orog file

### DIFF
--- a/sorc/chgres_cube.fd/sfc_input_data.F90
+++ b/sorc/chgres_cube.fd/sfc_input_data.F90
@@ -1105,7 +1105,7 @@ module sfc_input_data
 
  real(esmf_kind_r8), allocatable :: data_one_tile(:,:) 
  real(esmf_kind_r8), allocatable :: land_frac_one_tile(:,:), vtype_one_tile(:,:)
- real(esmf_kind_i4), allocatable :: slmsk_orog_one_tile(:,:)
+ real(esmf_kind_r4), allocatable :: slmsk_orog_one_tile(:,:)
  real(esmf_kind_r8), allocatable :: data_one_tile_3d(:,:,:)
 
  type(esmf_vm)                   :: vm
@@ -1193,7 +1193,7 @@ module sfc_input_data
      call read_fv3_grid_data_netcdf('vtype', tile, idim_input, jdim_input, &
                                    lsoil_input, sfcdata=vtype_one_tile)
      
-     condition1_met = all(((NINT(vtype_one_tile) > 0) .and. (slmsk_orog_one_tile == 1)) .or. ((NINT(vtype_one_tile) <= 0) .and. (slmsk_orog_one_tile == 0)))
+     condition1_met = all(((NINT(vtype_one_tile) > 0) .and. (NINT(slmsk_orog_one_tile) == 1)) .or. ((NINT(vtype_one_tile) <= 0) .and. (NINT(slmsk_orog_one_tile) == 0)))
      condition2_met = all(((land_frac_one_tile > 0.) .and. (NINT(vtype_one_tile) > 0)) .or. ((land_frac_one_tile == 0.) .and. (NINT(vtype_one_tile)<= 0)))
 
      if (condition1_met) then

--- a/sorc/chgres_cube.fd/sfc_input_data.F90
+++ b/sorc/chgres_cube.fd/sfc_input_data.F90
@@ -1184,7 +1184,7 @@ module sfc_input_data
      ! If this condition not satisfies, restart and orog files are inconsistent
      call read_fv3_grid_data_netcdf('vtype', tile, idim_input, jdim_input, &
                                    lsoil_input, sfcdata=vtype_one_tile)
-     if (any((land_frac_one_tile > 0.) .and. (vtype_one_tile <= 0))) then
+     if (any((land_frac_one_tile > 0.) .and. (vtype_one_tile <= 0)) .or. any((land_frac_one_tile == 0.) .and. (vtype_one_tile > 0))) then
        call error_handler("INCONSISTENT LAND/SEA MASK BETWEEN RESTART AND OROG FILES.", 10)
      else
        print*,'mask check ',tile,': consistent!'

--- a/sorc/chgres_cube.fd/sfc_input_data.F90
+++ b/sorc/chgres_cube.fd/sfc_input_data.F90
@@ -1188,23 +1188,22 @@ module sfc_input_data
      print*,'terrain check ',tile, maxval(data_one_tile)
      error=nf90_close(ncid)
 
-     ! Since the dimensional mismatch case will be captured above
-     ! A consistent fractional grid, will meet both condition1 and condition2
-     ! A consistent non-fractional grid, only can meet condition1 
-     ! An inconsistent fractional(or non-fractional) grid, will not meet condition1
+     ! A consistent non-fractional grid, will meet condition1
+     ! A consistent fractional grid, will meet condition2
      call read_fv3_grid_data_netcdf('vtype', tile, idim_input, jdim_input, &
                                    lsoil_input, sfcdata=vtype_one_tile)
      
-     condition1_met = all((vtype_one_tile > 0) .or. (slmsk_orog_one_tile /= 1))
+     condition1_met = all(((vtype_one_tile > 0) .and. (slmsk_orog_one_tile == 1)) .or. ((vtype_one_tile <= 0) .and. (slmsk_orog_one_tile == 0)))
      condition2_met = all(((land_frac_one_tile > 0.) .and. (vtype_one_tile > 0)) .or. ((land_frac_one_tile == 0.) .and. (vtype_one_tile <= 0)))
 
      if (condition1_met) then
-       if (condition2_met) then
+          print*,'[Non-fractional grid]: mask check ',tile,': consistent!'
+     endif
+     if (condition2_met) then
           print*,'[Fractional grid]: mask check ',tile,': consistent!'
-       else
-          print*, '[Non-fractional grid]: mask check ',tile,': consistent!'
-       endif
-     else
+     endif
+
+     if ((.not. condition1_met) .and. (.not. condition2_met)) then
        call error_handler("INCONSISTENT LAND/SEA MASK BETWEEN RESTART AND OROG FILES.", 10)
      endif
 

--- a/sorc/chgres_cube.fd/sfc_input_data.F90
+++ b/sorc/chgres_cube.fd/sfc_input_data.F90
@@ -1193,8 +1193,8 @@ module sfc_input_data
      call read_fv3_grid_data_netcdf('vtype', tile, idim_input, jdim_input, &
                                    lsoil_input, sfcdata=vtype_one_tile)
      
-     condition1_met = all(((vtype_one_tile > 0) .and. (slmsk_orog_one_tile == 1)) .or. ((vtype_one_tile <= 0) .and. (slmsk_orog_one_tile == 0)))
-     condition2_met = all(((land_frac_one_tile > 0.) .and. (vtype_one_tile > 0)) .or. ((land_frac_one_tile == 0.) .and. (vtype_one_tile <= 0)))
+     condition1_met = all(((NINT(vtype_one_tile) > 0) .and. (slmsk_orog_one_tile == 1)) .or. ((NINT(vtype_one_tile) <= 0) .and. (slmsk_orog_one_tile == 0)))
+     condition2_met = all(((land_frac_one_tile > 0.) .and. (NINT(vtype_one_tile) > 0)) .or. ((land_frac_one_tile == 0.) .and. (NINT(vtype_one_tile)<= 0)))
 
      if (condition1_met) then
           print*,'[Non-fractional grid]: mask check ',tile,': consistent!'

--- a/sorc/chgres_cube.fd/sfc_input_data.F90
+++ b/sorc/chgres_cube.fd/sfc_input_data.F90
@@ -1437,6 +1437,7 @@ module sfc_input_data
  enddo TILE_LOOP
 
  deallocate(data_one_tile, data_one_tile_3d)
+ deallocate(vtype_one_tile, land_frac_one_tile)
 
  end subroutine read_input_sfc_restart_file
 

--- a/sorc/chgres_cube.fd/sfc_input_data.F90
+++ b/sorc/chgres_cube.fd/sfc_input_data.F90
@@ -1101,17 +1101,18 @@ module sfc_input_data
 
  integer                         :: error, rc
  integer                         :: id_dim, idim_input, jdim_input
- integer                         :: ncid, tile, id_var, idum(2)
+ integer                         :: ncid, tile, id_var, id_var1, idum(2)
 
- real(esmf_kind_r8), allocatable :: data_one_tile(:,:)
+ real(esmf_kind_r8), allocatable :: data_one_tile(:,:), land_frac_one_tile(:,:), vtype_one_tile(:,:)
  real(esmf_kind_r8), allocatable :: data_one_tile_3d(:,:,:)
 
  type(esmf_vm)                   :: vm
 
-!---------------------------------------------------------------------------
+!------------------------------------------------------------------------------------------
 ! Get i/j dimensions and number of soil layers from first surface file.
 ! Do dimensions match those from the orography file?
-!---------------------------------------------------------------------------
+! Do land/sea masks (i.e., ocean res. and orog version) match that from the orography file?
+!------------------------------------------------------------------------------------------
 
  print*,"- CALL VMGetGlobal"
  call ESMF_VMGetGlobal(vm, rc=rc)
@@ -1151,9 +1152,13 @@ module sfc_input_data
 
  if (localpet == 0) then
    allocate(data_one_tile(idim_input,jdim_input))
+   allocate(land_frac_one_tile(idim_input,jdim_input))
+   allocate(vtype_one_tile(idim_input,jdim_input))
    allocate(data_one_tile_3d(idim_input,jdim_input,lsoil_input))
  else
    allocate(data_one_tile(0,0))
+   allocate(land_frac_one_tile(0,0))
+   allocate(vtype_one_tile(0,0))
    allocate(data_one_tile_3d(0,0,0))
  endif
 
@@ -1166,10 +1171,25 @@ module sfc_input_data
      call netcdf_err(error, 'OPENING OROGRAPHY FILE' )
      error=nf90_inq_varid(ncid, 'orog_raw', id_var)
      call netcdf_err(error, 'READING OROG RECORD ID' )
+     error=nf90_inq_varid(ncid, 'land_frac', id_var1)
+     call netcdf_err(error, 'READING OROG LAND_FRAC ID' )
      error=nf90_get_var(ncid, id_var, data_one_tile)
      call netcdf_err(error, 'READING OROG RECORD' )
+     error=nf90_get_var(ncid, id_var1, land_frac_one_tile)
+     call netcdf_err(error, 'READING OROG LAND_FRAC' )
      print*,'terrain check ',tile, maxval(data_one_tile)
      error=nf90_close(ncid)
+
+     ! Check if land_frac > 0, vtype > 0
+     ! If this condition not satisfies, restart and orog files are inconsistent
+     call read_fv3_grid_data_netcdf('vtype', tile, idim_input, jdim_input, &
+                                   lsoil_input, sfcdata=vtype_one_tile)
+     if (any((land_frac_one_tile > 0.) .and. (vtype_one_tile <= 0))) then
+       call error_handler("INCONSISTENT LAND/SEA MASK BETWEEN RESTART AND OROG FILES.", 10)
+     else
+       print*,'mask check ',tile,': consistent!'
+     endif
+
    endif
 
    print*,"- CALL FieldScatter FOR INPUT TERRAIN."

--- a/sorc/chgres_cube.fd/sfc_input_data.F90
+++ b/sorc/chgres_cube.fd/sfc_input_data.F90
@@ -1101,17 +1101,19 @@ module sfc_input_data
 
  integer                         :: error, rc
  integer                         :: id_dim, idim_input, jdim_input
- integer                         :: ncid, tile, id_var, id_var1, idum(2)
+ integer                         :: ncid, tile, id_var, id_var1, id_var2, idum(2)
 
- real(esmf_kind_r8), allocatable :: data_one_tile(:,:), land_frac_one_tile(:,:), vtype_one_tile(:,:)
+ real(esmf_kind_r8), allocatable :: data_one_tile(:,:) 
+ real(esmf_kind_r8), allocatable :: land_frac_one_tile(:,:), vtype_one_tile(:,:)
+ real(esmf_kind_i4), allocatable :: slmsk_orog_one_tile(:,:)
  real(esmf_kind_r8), allocatable :: data_one_tile_3d(:,:,:)
 
  type(esmf_vm)                   :: vm
-
+ logical                         :: condition1_met, condition2_met
 !------------------------------------------------------------------------------------------
 ! Get i/j dimensions and number of soil layers from first surface file.
 ! Do dimensions match those from the orography file?
-! Do land/sea masks (i.e., ocean res. and orog version) match that from the orography file?
+! Do land/sea masks (i.e., ocean res. and orog version) match those from the orography file?
 !------------------------------------------------------------------------------------------
 
  print*,"- CALL VMGetGlobal"
@@ -1153,11 +1155,13 @@ module sfc_input_data
  if (localpet == 0) then
    allocate(data_one_tile(idim_input,jdim_input))
    allocate(land_frac_one_tile(idim_input,jdim_input))
+   allocate(slmsk_orog_one_tile(idim_input,jdim_input))
    allocate(vtype_one_tile(idim_input,jdim_input))
    allocate(data_one_tile_3d(idim_input,jdim_input,lsoil_input))
  else
    allocate(data_one_tile(0,0))
    allocate(land_frac_one_tile(0,0))
+   allocate(slmsk_orog_one_tile(0,0))
    allocate(vtype_one_tile(0,0))
    allocate(data_one_tile_3d(0,0,0))
  endif
@@ -1173,21 +1177,35 @@ module sfc_input_data
      call netcdf_err(error, 'READING OROG RECORD ID' )
      error=nf90_inq_varid(ncid, 'land_frac', id_var1)
      call netcdf_err(error, 'READING OROG LAND_FRAC ID' )
+     error=nf90_inq_varid(ncid, 'slmsk', id_var2)
+     call netcdf_err(error, 'READING OROG SLMSK ID' )
      error=nf90_get_var(ncid, id_var, data_one_tile)
      call netcdf_err(error, 'READING OROG RECORD' )
      error=nf90_get_var(ncid, id_var1, land_frac_one_tile)
      call netcdf_err(error, 'READING OROG LAND_FRAC' )
+     error=nf90_get_var(ncid, id_var2, slmsk_orog_one_tile)
+     call netcdf_err(error, 'READING OROG SLMSK' )
      print*,'terrain check ',tile, maxval(data_one_tile)
      error=nf90_close(ncid)
 
-     ! Check if land_frac > 0, vtype > 0
-     ! If this condition not satisfies, restart and orog files are inconsistent
+     ! Since the dimensional mismatch case will be captured above
+     ! A consistent fractional grid, will meet both condition1 and condition2
+     ! A consistent non-fractional grid, only can meet condition1 
+     ! An inconsistent fractional(or non-fractional) grid, will not meet condition1
      call read_fv3_grid_data_netcdf('vtype', tile, idim_input, jdim_input, &
                                    lsoil_input, sfcdata=vtype_one_tile)
-     if (any((land_frac_one_tile > 0.) .and. (vtype_one_tile <= 0)) .or. any((land_frac_one_tile == 0.) .and. (vtype_one_tile > 0))) then
-       call error_handler("INCONSISTENT LAND/SEA MASK BETWEEN RESTART AND OROG FILES.", 10)
+     
+     condition1_met = all((vtype_one_tile > 0) .or. (slmsk_orog_one_tile /= 1))
+     condition2_met = all(((land_frac_one_tile > 0.) .and. (vtype_one_tile > 0)) .or. ((land_frac_one_tile == 0.) .and. (vtype_one_tile <= 0)))
+
+     if (condition1_met) then
+       if (condition2_met) then
+          print*,'[Fractional grid]: mask check ',tile,': consistent!'
+       else
+          print*, '[Non-fractional grid]: mask check ',tile,': consistent!'
+       endif
      else
-       print*,'mask check ',tile,': consistent!'
+       call error_handler("INCONSISTENT LAND/SEA MASK BETWEEN RESTART AND OROG FILES.", 10)
      endif
 
    endif
@@ -1437,7 +1455,7 @@ module sfc_input_data
  enddo TILE_LOOP
 
  deallocate(data_one_tile, data_one_tile_3d)
- deallocate(vtype_one_tile, land_frac_one_tile)
+ deallocate(vtype_one_tile, land_frac_one_tile, slmsk_orog_one_tile)
 
  end subroutine read_input_sfc_restart_file
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
1. Add a consistency check to check the land/sea mask consistency between restart file and orog file
2. Worked with reviewers to better deal with both fractional vs. non-fractional grids for their mask checks

## TESTS CONDUCTED: 
If there are changes to the build or source code, the tests below must be conducted. Contact a repository manager if you need assistance.

- [x] Compile branch on all Tier 1 machines using Intel. Done using a8d2ad7.
- [x] Compile branch on Ursa using GNU. Done using a8d2ad7.
- [x] Compile branch in 'Debug' mode on WCOSS2. Done using a8d2ad7.
- [x] Compile with Doxygen on any machine with no errors. Done on WCOSS2 using a8d2ad7.
- [x] Run unit tests locally on any Tier 1 machine. Done on WCOSS2 using a8d2ad7. All tests passed.
- [x] Run `chgres_cube` consistency tests locally on all Tier 1 machines. Done using a8d2ad7. All tests passed.

## DEPENDENCIES:
N/A

## DOCUMENTATION:
All new and updated source code must be documented with Doxygen.

- [x] Doxygen is updated.

## ISSUE: 
Fixes issue mentioned in #1078
