### PR TITLE
regrid_sfc - separate non-land and water masks

### DIFF
--- a/sorc/regrid_sfc.fd/grids_IO.F90
+++ b/sorc/regrid_sfc.fd/grids_IO.F90
@@ -14,7 +14,8 @@
 
  integer, public, parameter  :: n_tiles=6 !< number tiles in fv3 grid
  ! mask values for land / ocean mask built from veg type
- integer, public, parameter  :: vtype_water=0, & !< non-land
+ integer, public, parameter  :: vtype_nonland=0, & !< non-land
+                                vtype_water=17, & !< water
                                 vtype_landice=15 !< land ice
  ! mask values for soilsnow_mask calculated in the GSI EnKF
  integer, public, parameter  :: mtype_water=0, & !< water
@@ -127,7 +128,8 @@
 ! calculate the mask
  ptr_mask = 1 ! initialize land everywhere
  select case (trim(grid_setup%mask_variable(1)))
- case("vegetation_type") ! removing non-land and glaciers using veg class
+ case("vegetation_type") ! removing non-land, water, and glaciers using veg class
+     where (nint(ptr_maskvar) == vtype_nonland)   ptr_mask = 0 ! exclude non-land
      where (nint(ptr_maskvar) == vtype_water )   ptr_mask = 0 ! exclude water
      where (nint(ptr_maskvar) == vtype_landice ) ptr_mask = 0 ! exclude glaciers
  case("soilsnow_mask") ! removing snow and non-land using pre-computed mask


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Adds vegetation type 17 (water) in addition to 0 (no data) and 15 (land ice) to be masked out from the surface regridding outputs.

## TESTS CONDUCTED: 
If there are changes to the build or source code, the tests below must be conducted. Contact a repository manager if you need assistance.

- [x] Compile branch on all Tier 1 machines using Intel. Done on Jet, Ursa, Hercules, Orion, GAEAC6 and WCOSS2 using a6e2c1a.
- [x] Compile branch on Ursa using GNU. Done using a6e2c1a.
- [x] Compile branch in 'Debug' mode on WCOSS2. Done using a6e2c1a.
- [x] Compile with Doxygen on any machine with no errors. Done on WCOSS2 using a6e2c1a.
- [x] Run unit tests locally on any Tier 1 machine. Done on WCOSS2 using a6e2c1a. All tests passed.
- [x] Run `regrid_sfc` consistency tests locally on all Tier 1 machines. Done using a6e2c1a.
        `regrid_sfc` test on:
        - WCOSS (log file at /lfs/h2/emc/da/noscrub/tseganeh.gichamo/UFS_UTILS/reg_tests/regrid_sfc) and 
        - Ursa (/scratch3/NCEPDEV/da/Tseganeh.Gichamo/UFS_UTILS/reg_tests/regrid_sfc) finish the regridding task successfully. Also run on Jet, Orion and Hercules. All tests failed as expected because this PR changes the outputs. 

Describe any additional tests performed.

- Ran a soil DA test within the global workflow with land spin-up ICs (C384E192; May,1-3, 2022). 

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes issue #1082