### PR TITLE
Bug fix for update_baseline.sh script

### DIFF
--- a/reg_tests/grid_gen/c96.uniform.sh
+++ b/reg_tests/grid_gen/c96.uniform.sh
@@ -49,7 +49,7 @@ for files in *tile*.nc ./sfc/*tile*.nc
 do
   if [ -f $files ]; then
     echo CHECK $files
-    $NCCMP -dmfqS $files $HOMEreg/c96.uniform/$files
+    $NCCMP -dmfqS $files $HOMEreg/baseline_data/c96.uniform/$files
     iret=$?
     if [ $iret -ne 0 ]; then
       test_failed=1
@@ -61,7 +61,7 @@ set +x
 if [ $test_failed -ne 0 ]; then
   echo "<<< C96 UNIFORM TEST FAILED. >>>"
   if [ "$UPDATE_BASELINE" = "TRUE" ]; then
-    $home_dir/reg_tests/update_baseline.sh "${HOMEreg}/.." "c96.uniform" $commit_num
+    $home_dir/reg_tests/update_baseline.sh "${HOMEreg}" "c96.uniform" $commit_num
   fi
 else
   echo "<<< C96 UNIFORM TEST PASSED. >>>"

--- a/reg_tests/grid_gen/c96.viirs.bnu.sh
+++ b/reg_tests/grid_gen/c96.viirs.bnu.sh
@@ -47,7 +47,7 @@ for files in *tile*.nc ./sfc/*tile*.nc
 do
   if [ -f $files ]; then
     echo CHECK $files
-    $NCCMP -dmfqS $files $HOMEreg/c96.viirs.bnu/$files
+    $NCCMP -dmfqS $files $HOMEreg/baseline_data/c96.viirs.bnu/$files
     iret=$?
     if [ $iret -ne 0 ]; then
       test_failed=1
@@ -59,7 +59,7 @@ set +x
 if [ $test_failed -ne 0 ]; then
   echo "<<< C96 VIIRS BNU TEST FAILED. >>>"
   if [ "$UPDATE_BASELINE" = "TRUE" ]; then
-    $home_dir/reg_tests/update_baseline.sh "${HOMEreg}/.." "c96.viirs.bnu" $commit_num
+    $home_dir/reg_tests/update_baseline.sh "${HOMEreg}" "c96.viirs.bnu" $commit_num
   fi
 else
   echo "<<< C96 VIIRS BNU TEST PASSED. >>>"

--- a/reg_tests/grid_gen/driver.hercules.sh
+++ b/reg_tests/grid_gen/driver.hercules.sh
@@ -54,7 +54,7 @@ if [ "$UPDATE_BASELINE" = "TRUE" ]; then
   source ../get_hash.sh
 fi
 
-export HOMEreg=/work/noaa/nems/role-nems/ufs_utils.hercules/reg_tests/grid_gen/baseline_data
+export HOMEreg=/work/noaa/nems/role-nems/ufs_utils.hercules/reg_tests/grid_gen
 
 rm -fr $WORK_DIR
 

--- a/reg_tests/grid_gen/driver.jet.sh
+++ b/reg_tests/grid_gen/driver.jet.sh
@@ -50,7 +50,7 @@ export home_dir=$PWD/../..
 export APRUN=time
 export APRUN_SFC=srun
 export OMP_STACKSIZE=2048m
-export HOMEreg=/lfs5/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/reg_tests/grid_gen/baseline_data
+export HOMEreg=/lfs5/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/reg_tests/grid_gen
 
 ulimit -a
 ulimit -s unlimited

--- a/reg_tests/grid_gen/driver.orion.sh
+++ b/reg_tests/grid_gen/driver.orion.sh
@@ -53,7 +53,7 @@ if [ "$UPDATE_BASELINE" = "TRUE" ]; then
   source ../get_hash.sh
 fi
 
-export HOMEreg=/work/noaa/nems/role-nems/ufs_utils/reg_tests/grid_gen/baseline_data
+export HOMEreg=/work/noaa/nems/role-nems/ufs_utils/reg_tests/grid_gen
 
 rm -fr $WORK_DIR
 

--- a/reg_tests/grid_gen/driver.ursa.sh
+++ b/reg_tests/grid_gen/driver.ursa.sh
@@ -52,7 +52,7 @@ export home_dir=$PWD/../..
 export APRUN=time
 export APRUN_SFC=srun
 export OMP_STACKSIZE=2048m
-export HOMEreg=/scratch3/NCEPDEV/nems/role.ufsutils/ufs_utils/reg_tests/grid_gen/baseline_data
+export HOMEreg=/scratch3/NCEPDEV/nems/role.ufsutils/ufs_utils/reg_tests/grid_gen
 
 ulimit -a
 

--- a/reg_tests/grid_gen/driver.wcoss2.sh
+++ b/reg_tests/grid_gen/driver.wcoss2.sh
@@ -55,7 +55,7 @@ export APRUN_SFC="mpiexec -n 30 -ppn 30 -cpu-bind core"
 export OMP_STACKSIZE=2048m
 export OMP_NUM_THREADS=30 # orog code uses threads
 export OMP_PLACES=cores
-export HOMEreg=/lfs/h2/emc/nems/noscrub/emc.nems/UFS_UTILS/reg_tests/grid_gen/baseline_data
+export HOMEreg=/lfs/h2/emc/nems/noscrub/emc.nems/UFS_UTILS/reg_tests/grid_gen
 this_dir=$PWD
 
 ulimit -a

--- a/reg_tests/grid_gen/esg.regional.pct.cat.sh
+++ b/reg_tests/grid_gen/esg.regional.pct.cat.sh
@@ -54,7 +54,7 @@ for files in *tile*.nc ./sfc/*tile*.nc
 do
   if [ -f $files ]; then
     echo CHECK $files
-    $NCCMP -dmfqS $files $HOMEreg/${TEST_NAME}/$files
+    $NCCMP -dmfqS $files $HOMEreg/baseline_data/${TEST_NAME}/$files
     iret=$?
     if [ $iret -ne 0 ]; then
       test_failed=1
@@ -66,7 +66,7 @@ set +x
 if [ $test_failed -ne 0 ]; then
   echo "<<< ESG REGIONAL PERCENT CATEGORY TEST FAILED. >>>"
   if [ "$UPDATE_BASELINE" = "TRUE" ]; then
-    $home_dir/reg_tests/update_baseline.sh "${HOMEreg}/.." "${TEST_NAME}" $commit_num
+    $home_dir/reg_tests/update_baseline.sh "${HOMEreg}" "${TEST_NAME}" $commit_num
   fi
 else
   echo "<<< ESG REGIONAL PERCENT CATEGORY TEST PASSED. >>>"

--- a/reg_tests/grid_gen/esg.regional.sh
+++ b/reg_tests/grid_gen/esg.regional.sh
@@ -50,7 +50,7 @@ for files in *tile*.nc ./sfc/*tile*.nc
 do
   if [ -f $files ]; then
     echo CHECK $files
-    $NCCMP -dmfqS $files $HOMEreg/esg.regional/$files
+    $NCCMP -dmfqS $files $HOMEreg/baseline_data/esg.regional/$files
     iret=$?
     if [ $iret -ne 0 ]; then
       test_failed=1
@@ -62,7 +62,7 @@ set +x
 if [ $test_failed -ne 0 ]; then
   echo "<<< ESG REGIONAL TEST FAILED. >>>"
   if [ "$UPDATE_BASELINE" = "TRUE" ]; then
-    $home_dir/reg_tests/update_baseline.sh "${HOMEreg}/.." "esg.regional" $commit_num
+    $home_dir/reg_tests/update_baseline.sh "${HOMEreg}" "esg.regional" $commit_num
   fi
 else
   echo "<<< ESG REGIONAL TEST PASSED. >>>"

--- a/reg_tests/grid_gen/gfdl.regional.sh
+++ b/reg_tests/grid_gen/gfdl.regional.sh
@@ -53,7 +53,7 @@ for files in *tile*.nc ./sfc/*tile*.nc
 do
   if [ -f $files ]; then
     echo CHECK $files
-    $NCCMP -dmfqS $files $HOMEreg/gfdl.regional/$files
+    $NCCMP -dmfqS $files $HOMEreg/baseline_data/gfdl.regional/$files
     iret=$?
     if [ $iret -ne 0 ]; then
       test_failed=1
@@ -65,7 +65,7 @@ set +x
 if [ $test_failed -ne 0 ]; then
   echo "<<< GFDL REGIONAL TEST FAILED. >>>"
   if [ "$UPDATE_BASELINE" = "TRUE" ]; then
-    $home_dir/reg_tests/update_baseline.sh "${HOMEreg}/.." "gfdl.regional" $commit_num
+    $home_dir/reg_tests/update_baseline.sh "${HOMEreg}" "gfdl.regional" $commit_num
   fi
 else
   echo "<<< GFDL REGIONAL TEST PASSED. >>>"

--- a/reg_tests/grid_gen/regional.gsl.gwd.sh
+++ b/reg_tests/grid_gen/regional.gsl.gwd.sh
@@ -54,7 +54,7 @@ for files in *tile*.nc ./sfc/*tile*.nc
 do
   if [ -f $files ]; then
     echo CHECK $files
-    $NCCMP -dmfqS $files $HOMEreg/regional.gsl.gwd/$files
+    $NCCMP -dmfqS $files $HOMEreg/baseline_data/regional.gsl.gwd/$files
     iret=$?
     if [ $iret -ne 0 ]; then
       test_failed=1
@@ -66,7 +66,7 @@ set +x
 if [ $test_failed -ne 0 ]; then
   echo "<<< REGIONAL ${nthreads} THREAD GSL GWD TEST FAILED. >>>"
   if [ "$UPDATE_BASELINE" = "TRUE" ]; then
-    $home_dir/reg_tests/update_baseline.sh "${HOMEreg}/.." "regional.gsl.gwd" $commit_num
+    $home_dir/reg_tests/update_baseline.sh "${HOMEreg}" "regional.gsl.gwd" $commit_num
   fi
 else
   echo "<<< REGIONAL ${nthreads} THREAD GSL GWD TEST PASSED. >>>"

--- a/reg_tests/ice_blend/driver.hercules.sh
+++ b/reg_tests/ice_blend/driver.hercules.sh
@@ -57,7 +57,6 @@ export COPYGB2=/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.5.0/
 export CNVGRIB=/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.5.0/envs/unified-env/install/intel/2021.9.0/grib-util-1.3.0-wenl3in/bin/cnvgrib
 
 export HOMEreg=/work/noaa/nems/role-nems/ufs_utils.hercules/reg_tests/ice_blend
-export HOMEreg=/work/noaa/global/dhuber/noscrub/ufs_utils/reg_tests/ice_blend
 export HOMEgfs=$PWD/../..
 
 rm -fr $DATA

--- a/reg_tests/update_baseline.sh
+++ b/reg_tests/update_baseline.sh
@@ -45,6 +45,16 @@ if [ -d ./sfc ]; then
   chmod 555 $base_dir_commit/sfc
 fi
 
+if [[ "$test_name" == "c192.gsi_lndincsoilnoahmp" ]]; then
+  for files in gaussian_interp.*
+  do
+    if [ -f $files ]; then
+      cp $files $base_dir_commit
+      chmod 444 $base_dir_commit/$files
+    fi
+  done
+fi
+
 chmod 555 $base_dir_commit
 rm -f $base_dir/$test_name
 cd $base_dir

--- a/reg_tests/update_baseline.sh
+++ b/reg_tests/update_baseline.sh
@@ -1,66 +1,52 @@
 #!/bin/bash
-
 set -x
 
-HOMEreg=$1
-test_name=$2
-commit_num=$3
+HOMEreg="$1"
+test_name="$2"
+commit_num="$3"
 
-base_dir=$HOMEreg/baseline_data
-base_dir_commit=${base_dir}/$test_name.$commit_num
+prog_name="${HOMEreg##*/}"
+base_dir="${HOMEreg}/baseline_data"
+base_dir_commit="${base_dir}/${test_name}.${commit_num}"
 
-chmod 755 $base_dir
+chmod 755 "$base_dir"
 
-if [ -d $base_dir_commit ];then
-  chmod 777 $base_dir_commit
-  if [ -d $base_dir_commit/sfc ]; then
-    chmod 777 $base_dir_commit/sfc
+if [ -d "$base_dir_commit" ];then
+  chmod 777 "$base_dir_commit"
+  if [ -d "$base_dir_commit/sfc" ]; then
+    chmod 777 "$base_dir_commit/sfc"
   fi
-  rm -fr $base_dir_commit
+  rm -fr "$base_dir_commit"
 fi
 
-mkdir -p $base_dir_commit
+mkdir -p "$base_dir_commit"
 
-for files in *.nc snogrb_model seaice.5min.blend
-do
-  if [ -f $files ]; then
-    cp $files $base_dir_commit
-    chmod 444 $base_dir_commit/$files
-  fi
-done
-
-# The grid_gen tests have a subdirectory for
-# the surface climo fields.
-
-if [ -d ./sfc ]; then
-  mkdir -p $base_dir_commit/sfc
-  cd sfc
-  for files in *.nc
-  do 
-    if [ -f $files ]; then
-      cp $files $base_dir_commit/sfc
-      chmod 444 $base_dir_commit/sfc/$files
-    fi
+copy_and_protect() {
+  for file in "$@"; do
+    [ -f "$file" ] && cp "$file" "$base_dir_commit" && chmod 444 "$base_dir_commit/$file"
   done
-  chmod 555 $base_dir_commit/sfc
-fi
+}
 
-if [[ "$test_name" == "c192.gsi_lndincsoilnoahmp" ]]; then
-  for files in gaussian_interp.*
-  do
-    if [ -f $files ]; then
-      cp $files $base_dir_commit
-      chmod 444 $base_dir_commit/$files
+case "$prog_name" in
+  snow2mdl)      copy_and_protect snogrb_model ;;
+  ice_blend)     copy_and_protect seaice.5min.blend ;;
+  global_cycle)
+    if [ "$test_name" == "c192.gsi_lndincsoilnoahmp" ]; then
+      copy_and_protect *.nc gaussian_interp.*
+    else
+      copy_and_protect *.nc
     fi
-  done
-fi
+    ;;
+  grid_gen)
+    copy_and_protect *.nc
+    mkdir -p "$base_dir_commit/sfc"
+    for file in sfc/*.nc; do
+      [ -f "$file" ] && cp "$file" "$base_dir_commit/sfc" && chmod 444 "$base_dir_commit/sfc/$(basename "$file")"
+    done
+    chmod 555 "$base_dir_commit/sfc" ;;
+  *) copy_and_protect *.nc ;;
+esac
 
-chmod 555 $base_dir_commit
-rm -f $base_dir/$test_name
-cd $base_dir
-ln -fs $test_name.$commit_num $test_name
-
-# move this to driver?
-###chmod 555 $base_dir
-
-exit
+chmod 555 "$base_dir_commit"
+rm -f "$base_dir/$test_name"
+cd "$base_dir" && ln -fs "$test_name.$commit_num" "$test_name"


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The `update_baseline.sh` script was bug fixed - it did not copy the correct files for the `global_cycle`  [c192.gsi_lndincsoilnoahmp](https://github.com/ufs-community/UFS_UTILS/blob/develop/reg_tests/global_cycle/C192.gsi_lndincsoilnoahmp.sh) regression test.

Refactored the script to make it easier to specify which files to copy for a specific test.

## TESTS CONDUCTED: 
If there are changes to the build or source code, the tests below must be conducted. Contact a repository manager if you need assistance.

- [x] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Ursa, Hercules and WCOSS2). Done using de743a6.
- [x] Run `grid_gen` consistency tests locally on all Tier 1 machines. Done using de743a6. All tests passed.

Describe any additional tests performed.

- [Tests](https://github.com/ufs-community/UFS_UTILS/issues/1080#issuecomment-3108737165) were done to update baseline directories from the following regression tests: [chgres_cube](https://github.com/ufs-community/UFS_UTILS/issues/1080#issuecomment-3109203418), [global_cycle](https://github.com/ufs-community/UFS_UTILS/issues/1080#issuecomment-3109146213), [grid_gen](https://github.com/ufs-community/UFS_UTILS/issues/1080#issuecomment-3109045107), [ice_blend](https://github.com/ufs-community/UFS_UTILS/issues/1080#issuecomment-3108974715), [regrid_sfc](https://github.com/ufs-community/UFS_UTILS/issues/1080#issuecomment-3108917450), [snow2mdl](https://github.com/ufs-community/UFS_UTILS/issues/1080#issuecomment-3108891724) and [weight_gen](https://github.com/ufs-community/UFS_UTILS/issues/1080#issuecomment-3108851310).  Please see #1080 for details.

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A.

## ISSUE: 
Fixes #1080.

## CONTRIBUTORS: 
Copilot