### PR TITLE
Ensure proper stack size setting on Orion

### DIFF
--- a/reg_tests/chgres_cube/driver.orion.sh
+++ b/reg_tests/chgres_cube/driver.orion.sh
@@ -30,7 +30,7 @@ module use ../../modulefiles
 module load build.$target.intelllvm
 module list
 
-ulimit -s unlimited
+ulimit -a
 
 export OUTDIR="${WORK_DIR:-/work/noaa/stmp/$LOGNAME}"
 export OUTDIR="${OUTDIR}/reg-tests/chgres-cube"

--- a/reg_tests/cpld_gridgen/rt.sh
+++ b/reg_tests/cpld_gridgen/rt.sh
@@ -70,7 +70,7 @@ elif [[ $target = orion ]]; then
   export NCCMP=nccmp
   BASELINE_ROOT=/work/noaa/nems/role-nems/ufs_utils/reg_tests/cpld_gridgen/baseline_data
   PARTITION=''
-  ulimit -s unlimited
+  ulimit -a
 elif [[ $target = hercules ]]; then
   STMP=${STMP:-/work2/noaa/stmp/$USER}
   ACCOUNT=${ACCOUNT:-fv3-cpu}

--- a/reg_tests/global_cycle/driver.orion.sh
+++ b/reg_tests/global_cycle/driver.orion.sh
@@ -25,6 +25,8 @@ module use ../../modulefiles
 module load build.$target.intelllvm
 module list
 
+ulimit -a
+
 export WORK_DIR="${WORK_DIR:-/work/noaa/stmp/$LOGNAME}"
 
 PROJECT_CODE="${PROJECT_CODE:-fv3-cpu}"

--- a/reg_tests/grid_gen/driver.orion.sh
+++ b/reg_tests/grid_gen/driver.orion.sh
@@ -27,7 +27,7 @@ module load build.$target.intelllvm
 module list
 
 set -x
-ulimit -s unlimited
+ulimit -a
 
 export WORK_DIR="${WORK_DIR:-/work/noaa/stmp/$LOGNAME}"
 export WORK_DIR="${WORK_DIR}/reg-tests/grid-gen"

--- a/reg_tests/ice_blend/driver.orion.sh
+++ b/reg_tests/ice_blend/driver.orion.sh
@@ -36,7 +36,7 @@ module load grib-util/1.3.0
 module load wgrib2/2.0.8
 module list
 
-ulimit -s unlimited
+ulimit -a
 
 export DATA="${WORK_DIR:-/work/noaa/stmp/$LOGNAME}"
 export DATA="${DATA}/reg-tests/ice-blend"

--- a/reg_tests/ocnice_prep/rt.sh
+++ b/reg_tests/ocnice_prep/rt.sh
@@ -86,7 +86,7 @@ elif [[ $target = orion ]]; then
     WLCLK=15
     export NCCMP=nccmp
     PARTITION=''
-    ulimit -s unlimited
+    ulimit -a
 elif [[ $target = hercules ]]; then
     STMP=${STMP:-/work2/noaa/stmp/$USER}
     BASELINE_ROOT=/work/noaa/nems/role-nems/ufs_utils.hercules/reg_tests/ocnice_prep/baseline_data

--- a/reg_tests/regrid_sfc/driver.sh
+++ b/reg_tests/regrid_sfc/driver.sh
@@ -68,6 +68,7 @@ elif [[ "$target" == "orion" ]];then
   export HOMEreg=/work/noaa/nems/role-nems/ufs_utils/reg_tests/regrid_sfc
   export APRUN_REGRID=srun
   PARTITION=''
+  ulimit -a
 elif [[ "$target" == "hercules" ]];then
   WORK_DIR="${WORK_DIR:-/work2/noaa/stmp/$LOGNAME}"
   PROJECT_CODE="${PROJECT_CODE:-fv3-cpu}"

--- a/reg_tests/rt.sh
+++ b/reg_tests/rt.sh
@@ -13,7 +13,11 @@ wait_for_fin() {
   done
 }
 
-ulimit -s unlimited
+if [[ "$(hostname)" =~ "Orion" || "$(hostname)" =~ "orion" ]]; then
+  ulimit -a
+else
+  ulimit -s unlimited
+fi
 
 export MAILTO=
 

--- a/reg_tests/snow2mdl/driver.orion.sh
+++ b/reg_tests/snow2mdl/driver.orion.sh
@@ -28,7 +28,7 @@ module load wgrib2/2.0.8
 module load prod_util/2.1.1
 module list
 
-ulimit -s unlimited
+ulimit -a
 
 export DATA_ROOT="${WORK_DIR:-/work/noaa/stmp/$LOGNAME}"
 export DATA_ROOT="${DATA_ROOT}/reg-tests/snow2mdl"

--- a/reg_tests/weight_gen/driver.orion.sh
+++ b/reg_tests/weight_gen/driver.orion.sh
@@ -36,6 +36,8 @@ module use ../../modulefiles
 module load build.$target.$compiler
 module list
 
+ulimit -a
+
 export DATA="${WORK_DIR:-/work/noaa/stmp/$LOGNAME}"
 export DATA="${DATA}/reg-tests/weight_gen"
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Remove any setting of stack size in the Orion regression test scripts, which can 
cause script crashes.  Instead, users (including the role account) will be required to 
set a proper stack size in their environment

## TESTS CONDUCTED: 

- [x] Run all consistency tests on Orion using both the role account and personal account (George). Done using 88cd6c0.
- [x] Run all consistency tests on Orion using both the role account and personal account (Brian)

Describe any additional tests performed.

## DEPENDENCIES:
None.

## DOCUMENTATION:
N/A

## ISSUE: 
Fixes #1079.