### PR TITLE
Generate ESMF weights in cpld_gridgen in parallel

### DIFF
--- a/reg_tests/cpld_gridgen/RegressionTests_hercules.intelllvm.log
+++ b/reg_tests/cpld_gridgen/RegressionTests_hercules.intelllvm.log
@@ -1,0 +1,347 @@
+
+Working dir = /work2/noaa/stmp/dworthen/CPLD_GRIDGEN/rt_956360/025
+Baseline dir = /work/noaa/nems/role-nems/ufs_utils.hercules/reg_tests/cpld_gridgen/baseline_data/025
+
+Checking test 025 results ....
+Comparing Bu.mx025_SCRIP.nc........OK
+Comparing C1152.mx025.tile1.nc........OK
+Comparing C1152.mx025.tile2.nc........OK
+Comparing C1152.mx025.tile3.nc........OK
+Comparing C1152.mx025.tile4.nc........OK
+Comparing C1152.mx025.tile5.nc........OK
+Comparing C1152.mx025.tile6.nc........OK
+Comparing C192.mx025.tile1.nc........OK
+Comparing C192.mx025.tile2.nc........OK
+Comparing C192.mx025.tile3.nc........OK
+Comparing C192.mx025.tile4.nc........OK
+Comparing C192.mx025.tile5.nc........OK
+Comparing C192.mx025.tile6.nc........OK
+Comparing C384.mx025.tile1.nc........OK
+Comparing C384.mx025.tile2.nc........OK
+Comparing C384.mx025.tile3.nc........OK
+Comparing C384.mx025.tile4.nc........OK
+Comparing C384.mx025.tile5.nc........OK
+Comparing C384.mx025.tile6.nc........OK
+Comparing C48.mx025.tile1.nc........OK
+Comparing C48.mx025.tile2.nc........OK
+Comparing C48.mx025.tile3.nc........OK
+Comparing C48.mx025.tile4.nc........OK
+Comparing C48.mx025.tile5.nc........OK
+Comparing C48.mx025.tile6.nc........OK
+Comparing C768.mx025.tile1.nc........OK
+Comparing C768.mx025.tile2.nc........OK
+Comparing C768.mx025.tile3.nc........OK
+Comparing C768.mx025.tile4.nc........OK
+Comparing C768.mx025.tile5.nc........OK
+Comparing C768.mx025.tile6.nc........OK
+Comparing C96.mx025.tile1.nc........OK
+Comparing C96.mx025.tile2.nc........OK
+Comparing C96.mx025.tile3.nc........OK
+Comparing C96.mx025.tile4.nc........OK
+Comparing C96.mx025.tile5.nc........OK
+Comparing C96.mx025.tile6.nc........OK
+Comparing Ct.mx025.to.C1152.nc........OK
+Comparing Ct.mx025.to.C192.nc........OK
+Comparing Ct.mx025.to.C384.nc........OK
+Comparing Ct.mx025.to.C48.nc........OK
+Comparing Ct.mx025.to.C768.nc........OK
+Comparing Ct.mx025.to.C96.nc........OK
+Comparing Ct.mx025_SCRIP.nc........OK
+Comparing Ct.mx025_SCRIP_land.nc........OK
+Comparing Cu.mx025_SCRIP.nc........OK
+Comparing Cv.mx025_SCRIP.nc........OK
+Comparing grid_cice_NEMS_mx025.nc........OK
+Comparing kmtu_cice_NEMS_mx025.nc........OK
+Comparing mesh.mx025.nc........OK
+Comparing rect.0p25_SCRIP.nc........OK
+Comparing rect.0p50_SCRIP.nc........OK
+Comparing rect.1p00_SCRIP.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
+Comparing rect.9p00_SCRIP.nc........OK
+Comparing tripole.mx025.Bu.to.Ct.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.Bu.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.Cu.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.Cv.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.rect.0p25.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.rect.0p25.conserve.nc........OK
+Comparing tripole.mx025.Ct.to.rect.0p50.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.rect.0p50.conserve.nc........OK
+Comparing tripole.mx025.Ct.to.rect.1p00.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.rect.1p00.conserve.nc........OK
+Comparing tripole.mx025.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.rect.5p00.conserve.nc........OK
+Comparing tripole.mx025.Ct.to.rect.9p00.bilinear.nc........OK
+Comparing tripole.mx025.Ct.to.rect.9p00.conserve.nc........OK
+Comparing tripole.mx025.Cu.to.Ct.bilinear.nc........OK
+Comparing tripole.mx025.Cv.to.Ct.bilinear.nc........OK
+Comparing tripole.mx025.nc........OK
+
+Elapsed time: 00h:15m:16s. Have a nice day!
+
+Working dir = /work2/noaa/stmp/dworthen/CPLD_GRIDGEN/rt_956360/050
+Baseline dir = /work/noaa/nems/role-nems/ufs_utils.hercules/reg_tests/cpld_gridgen/baseline_data/050
+
+Checking test 050 results ....
+Comparing Bu.mx050_SCRIP.nc........OK
+Comparing C1152.mx050.tile1.nc........OK
+Comparing C1152.mx050.tile2.nc........OK
+Comparing C1152.mx050.tile3.nc........OK
+Comparing C1152.mx050.tile4.nc........OK
+Comparing C1152.mx050.tile5.nc........OK
+Comparing C1152.mx050.tile6.nc........OK
+Comparing C192.mx050.tile1.nc........OK
+Comparing C192.mx050.tile2.nc........OK
+Comparing C192.mx050.tile3.nc........OK
+Comparing C192.mx050.tile4.nc........OK
+Comparing C192.mx050.tile5.nc........OK
+Comparing C192.mx050.tile6.nc........OK
+Comparing C384.mx050.tile1.nc........OK
+Comparing C384.mx050.tile2.nc........OK
+Comparing C384.mx050.tile3.nc........OK
+Comparing C384.mx050.tile4.nc........OK
+Comparing C384.mx050.tile5.nc........OK
+Comparing C384.mx050.tile6.nc........OK
+Comparing C48.mx050.tile1.nc........OK
+Comparing C48.mx050.tile2.nc........OK
+Comparing C48.mx050.tile3.nc........OK
+Comparing C48.mx050.tile4.nc........OK
+Comparing C48.mx050.tile5.nc........OK
+Comparing C48.mx050.tile6.nc........OK
+Comparing C768.mx050.tile1.nc........OK
+Comparing C768.mx050.tile2.nc........OK
+Comparing C768.mx050.tile3.nc........OK
+Comparing C768.mx050.tile4.nc........OK
+Comparing C768.mx050.tile5.nc........OK
+Comparing C768.mx050.tile6.nc........OK
+Comparing C96.mx050.tile1.nc........OK
+Comparing C96.mx050.tile2.nc........OK
+Comparing C96.mx050.tile3.nc........OK
+Comparing C96.mx050.tile4.nc........OK
+Comparing C96.mx050.tile5.nc........OK
+Comparing C96.mx050.tile6.nc........OK
+Comparing Ct.mx050.to.C1152.nc........OK
+Comparing Ct.mx050.to.C192.nc........OK
+Comparing Ct.mx050.to.C384.nc........OK
+Comparing Ct.mx050.to.C48.nc........OK
+Comparing Ct.mx050.to.C768.nc........OK
+Comparing Ct.mx050.to.C96.nc........OK
+Comparing Ct.mx050_SCRIP.nc........OK
+Comparing Ct.mx050_SCRIP_land.nc........OK
+Comparing Cu.mx050_SCRIP.nc........OK
+Comparing Cv.mx050_SCRIP.nc........OK
+Comparing grid_cice_NEMS_mx050.nc........OK
+Comparing kmtu_cice_NEMS_mx050.nc........OK
+Comparing mesh.mx050.nc........OK
+Comparing rect.0p50_SCRIP.nc........OK
+Comparing rect.1p00_SCRIP.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
+Comparing rect.9p00_SCRIP.nc........OK
+Comparing tripole.mx050.Bu.to.Ct.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.Bu.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.Cu.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.Cv.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.rect.0p50.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.rect.0p50.conserve.nc........OK
+Comparing tripole.mx050.Ct.to.rect.1p00.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.rect.1p00.conserve.nc........OK
+Comparing tripole.mx050.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.rect.5p00.conserve.nc........OK
+Comparing tripole.mx050.Ct.to.rect.9p00.bilinear.nc........OK
+Comparing tripole.mx050.Ct.to.rect.9p00.conserve.nc........OK
+Comparing tripole.mx050.Cu.to.Ct.bilinear.nc........OK
+Comparing tripole.mx050.Cv.to.Ct.bilinear.nc........OK
+Comparing tripole.mx050.nc........OK
+
+Elapsed time: 00h:06m:14s. Have a nice day!
+
+Working dir = /work2/noaa/stmp/dworthen/CPLD_GRIDGEN/rt_956360/100
+Baseline dir = /work/noaa/nems/role-nems/ufs_utils.hercules/reg_tests/cpld_gridgen/baseline_data/100
+
+Checking test 100 results ....
+Comparing Bu.mx100_SCRIP.nc........OK
+Comparing C1152.mx100.tile1.nc........OK
+Comparing C1152.mx100.tile2.nc........OK
+Comparing C1152.mx100.tile3.nc........OK
+Comparing C1152.mx100.tile4.nc........OK
+Comparing C1152.mx100.tile5.nc........OK
+Comparing C1152.mx100.tile6.nc........OK
+Comparing C192.mx100.tile1.nc........OK
+Comparing C192.mx100.tile2.nc........OK
+Comparing C192.mx100.tile3.nc........OK
+Comparing C192.mx100.tile4.nc........OK
+Comparing C192.mx100.tile5.nc........OK
+Comparing C192.mx100.tile6.nc........OK
+Comparing C384.mx100.tile1.nc........OK
+Comparing C384.mx100.tile2.nc........OK
+Comparing C384.mx100.tile3.nc........OK
+Comparing C384.mx100.tile4.nc........OK
+Comparing C384.mx100.tile5.nc........OK
+Comparing C384.mx100.tile6.nc........OK
+Comparing C48.mx100.tile1.nc........OK
+Comparing C48.mx100.tile2.nc........OK
+Comparing C48.mx100.tile3.nc........OK
+Comparing C48.mx100.tile4.nc........OK
+Comparing C48.mx100.tile5.nc........OK
+Comparing C48.mx100.tile6.nc........OK
+Comparing C768.mx100.tile1.nc........OK
+Comparing C768.mx100.tile2.nc........OK
+Comparing C768.mx100.tile3.nc........OK
+Comparing C768.mx100.tile4.nc........OK
+Comparing C768.mx100.tile5.nc........OK
+Comparing C768.mx100.tile6.nc........OK
+Comparing C96.mx100.tile1.nc........OK
+Comparing C96.mx100.tile2.nc........OK
+Comparing C96.mx100.tile3.nc........OK
+Comparing C96.mx100.tile4.nc........OK
+Comparing C96.mx100.tile5.nc........OK
+Comparing C96.mx100.tile6.nc........OK
+Comparing Ct.mx100.to.C1152.nc........OK
+Comparing Ct.mx100.to.C192.nc........OK
+Comparing Ct.mx100.to.C384.nc........OK
+Comparing Ct.mx100.to.C48.nc........OK
+Comparing Ct.mx100.to.C768.nc........OK
+Comparing Ct.mx100.to.C96.nc........OK
+Comparing Ct.mx100_SCRIP.nc........OK
+Comparing Ct.mx100_SCRIP_land.nc........OK
+Comparing Cu.mx100_SCRIP.nc........OK
+Comparing Cv.mx100_SCRIP.nc........OK
+Comparing grid_cice_NEMS_mx100.nc........OK
+Comparing kmtu_cice_NEMS_mx100.nc........OK
+Comparing mesh.mx100.nc........OK
+Comparing rect.1p00_SCRIP.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
+Comparing rect.9p00_SCRIP.nc........OK
+Comparing tripole.mx100.Bu.to.Ct.bilinear.nc........OK
+Comparing tripole.mx100.Ct.to.Bu.bilinear.nc........OK
+Comparing tripole.mx100.Ct.to.Cu.bilinear.nc........OK
+Comparing tripole.mx100.Ct.to.Cv.bilinear.nc........OK
+Comparing tripole.mx100.Ct.to.rect.1p00.bilinear.nc........OK
+Comparing tripole.mx100.Ct.to.rect.1p00.conserve.nc........OK
+Comparing tripole.mx100.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx100.Ct.to.rect.5p00.conserve.nc........OK
+Comparing tripole.mx100.Ct.to.rect.9p00.bilinear.nc........OK
+Comparing tripole.mx100.Ct.to.rect.9p00.conserve.nc........OK
+Comparing tripole.mx100.Cu.to.Ct.bilinear.nc........OK
+Comparing tripole.mx100.Cv.to.Ct.bilinear.nc........OK
+Comparing tripole.mx100.nc........OK
+Comparing ufs.topo_edits_011818.nc........OK
+
+Elapsed time: 00h:03m:45s. Have a nice day!
+
+Working dir = /work2/noaa/stmp/dworthen/CPLD_GRIDGEN/rt_956360/500
+Baseline dir = /work/noaa/nems/role-nems/ufs_utils.hercules/reg_tests/cpld_gridgen/baseline_data/500
+
+Checking test 500 results ....
+Comparing Bu.mx500_SCRIP.nc........OK
+Comparing C1152.mx500.tile1.nc........OK
+Comparing C1152.mx500.tile2.nc........OK
+Comparing C1152.mx500.tile3.nc........OK
+Comparing C1152.mx500.tile4.nc........OK
+Comparing C1152.mx500.tile5.nc........OK
+Comparing C1152.mx500.tile6.nc........OK
+Comparing C192.mx500.tile1.nc........OK
+Comparing C192.mx500.tile2.nc........OK
+Comparing C192.mx500.tile3.nc........OK
+Comparing C192.mx500.tile4.nc........OK
+Comparing C192.mx500.tile5.nc........OK
+Comparing C192.mx500.tile6.nc........OK
+Comparing C24.mx500.tile1.nc........OK
+Comparing C24.mx500.tile2.nc........OK
+Comparing C24.mx500.tile3.nc........OK
+Comparing C24.mx500.tile4.nc........OK
+Comparing C24.mx500.tile5.nc........OK
+Comparing C24.mx500.tile6.nc........OK
+Comparing C384.mx500.tile1.nc........OK
+Comparing C384.mx500.tile2.nc........OK
+Comparing C384.mx500.tile3.nc........OK
+Comparing C384.mx500.tile4.nc........OK
+Comparing C384.mx500.tile5.nc........OK
+Comparing C384.mx500.tile6.nc........OK
+Comparing C48.mx500.tile1.nc........OK
+Comparing C48.mx500.tile2.nc........OK
+Comparing C48.mx500.tile3.nc........OK
+Comparing C48.mx500.tile4.nc........OK
+Comparing C48.mx500.tile5.nc........OK
+Comparing C48.mx500.tile6.nc........OK
+Comparing C768.mx500.tile1.nc........OK
+Comparing C768.mx500.tile2.nc........OK
+Comparing C768.mx500.tile3.nc........OK
+Comparing C768.mx500.tile4.nc........OK
+Comparing C768.mx500.tile5.nc........OK
+Comparing C768.mx500.tile6.nc........OK
+Comparing C96.mx500.tile1.nc........OK
+Comparing C96.mx500.tile2.nc........OK
+Comparing C96.mx500.tile3.nc........OK
+Comparing C96.mx500.tile4.nc........OK
+Comparing C96.mx500.tile5.nc........OK
+Comparing C96.mx500.tile6.nc........OK
+Comparing Ct.mx500.to.C1152.nc........OK
+Comparing Ct.mx500.to.C192.nc........OK
+Comparing Ct.mx500.to.C24.nc........OK
+Comparing Ct.mx500.to.C384.nc........OK
+Comparing Ct.mx500.to.C48.nc........OK
+Comparing Ct.mx500.to.C768.nc........OK
+Comparing Ct.mx500.to.C96.nc........OK
+Comparing Ct.mx500_SCRIP.nc........OK
+Comparing Ct.mx500_SCRIP_land.nc........OK
+Comparing Cu.mx500_SCRIP.nc........OK
+Comparing Cv.mx500_SCRIP.nc........OK
+Comparing grid_cice_NEMS_mx500.nc........OK
+Comparing kmtu_cice_NEMS_mx500.nc........OK
+Comparing mesh.mx500.nc........OK
+Comparing rect.5p00_SCRIP.nc........OK
+Comparing rect.9p00_SCRIP.nc........OK
+Comparing tripole.mx500.Bu.to.Ct.bilinear.nc........OK
+Comparing tripole.mx500.Ct.to.Bu.bilinear.nc........OK
+Comparing tripole.mx500.Ct.to.Cu.bilinear.nc........OK
+Comparing tripole.mx500.Ct.to.Cv.bilinear.nc........OK
+Comparing tripole.mx500.Ct.to.rect.5p00.bilinear.nc........OK
+Comparing tripole.mx500.Ct.to.rect.5p00.conserve.nc........OK
+Comparing tripole.mx500.Ct.to.rect.9p00.bilinear.nc........OK
+Comparing tripole.mx500.Ct.to.rect.9p00.conserve.nc........OK
+Comparing tripole.mx500.Cu.to.Ct.bilinear.nc........OK
+Comparing tripole.mx500.Cv.to.Ct.bilinear.nc........OK
+Comparing tripole.mx500.nc........OK
+
+Elapsed time: 00h:02m:33s. Have a nice day!
+
+Working dir = /work2/noaa/stmp/dworthen/CPLD_GRIDGEN/rt_956360/900
+Baseline dir = /work/noaa/nems/role-nems/ufs_utils.hercules/reg_tests/cpld_gridgen/baseline_data/900
+
+Checking test 900 results ....
+Comparing Bu.mx900_SCRIP.nc........OK
+Comparing C12.mx900.tile1.nc........OK
+Comparing C12.mx900.tile2.nc........OK
+Comparing C12.mx900.tile3.nc........OK
+Comparing C12.mx900.tile4.nc........OK
+Comparing C12.mx900.tile5.nc........OK
+Comparing C12.mx900.tile6.nc........OK
+Comparing C24.mx900.tile1.nc........OK
+Comparing C24.mx900.tile2.nc........OK
+Comparing C24.mx900.tile3.nc........OK
+Comparing C24.mx900.tile4.nc........OK
+Comparing C24.mx900.tile5.nc........OK
+Comparing C24.mx900.tile6.nc........OK
+Comparing Ct.mx900.to.C12.nc........OK
+Comparing Ct.mx900.to.C24.nc........OK
+Comparing Ct.mx900_SCRIP.nc........OK
+Comparing Ct.mx900_SCRIP_land.nc........OK
+Comparing Cu.mx900_SCRIP.nc........OK
+Comparing Cv.mx900_SCRIP.nc........OK
+Comparing grid_cice_NEMS_mx900.nc........OK
+Comparing kmtu_cice_NEMS_mx900.nc........OK
+Comparing mesh.mx900.nc........OK
+Comparing rect.9p00_SCRIP.nc........OK
+Comparing tripole.mx900.Bu.to.Ct.bilinear.nc........OK
+Comparing tripole.mx900.Ct.to.Bu.bilinear.nc........OK
+Comparing tripole.mx900.Ct.to.Cu.bilinear.nc........OK
+Comparing tripole.mx900.Ct.to.Cv.bilinear.nc........OK
+Comparing tripole.mx900.Ct.to.rect.9p00.bilinear.nc........OK
+Comparing tripole.mx900.Ct.to.rect.9p00.conserve.nc........OK
+Comparing tripole.mx900.Cu.to.Ct.bilinear.nc........OK
+Comparing tripole.mx900.Cv.to.Ct.bilinear.nc........OK
+Comparing tripole.mx900.nc........OK
+
+Elapsed time: 00h:00m:05s. Have a nice day!
+
+REGRESSION TEST WAS SUCCESSFUL

--- a/reg_tests/cpld_gridgen/rt.sh
+++ b/reg_tests/cpld_gridgen/rt.sh
@@ -214,7 +214,7 @@ while read -r line || [ "$line" ]; do
        -l walltime=00:${WLCLK}:00 -N $TEST_NAME -l select=1:ncpus=1:mem=12GB -v RESNAME=$TEST_NAME,ATMLIST="'$ATMLIST'" ./cpld_gridgen.sh)
 
   else
-    tests[$i]=$(sbatch --parsable --ntasks-per-node=1 --nodes=1 --mem=12GB -t 00:${WLCLK}:00 -A $ACCOUNT -q $QUEUE -J $TEST_NAME \
+    tests[$i]=$(sbatch --parsable --ntasks-per-node=12 --nodes=1 -t 00:${WLCLK}:00 -A $ACCOUNT -q $QUEUE -J $TEST_NAME \
             $PARTITION -o run_${TEST_NAME}.log -e run_${TEST_NAME}.log ./cpld_gridgen.sh "$TEST_NAME" "$ATMLIST")
   fi
 

--- a/reg_tests/cpld_gridgen/rt.sh
+++ b/reg_tests/cpld_gridgen/rt.sh
@@ -98,7 +98,7 @@ elif [[  $target = wcoss2 ]]; then
   WLCLK=40
   export MOM6_FIXDIR=/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/mom6/${MOM6_version}
   BASELINE_ROOT=/lfs/h2/emc/nems/noscrub/emc.nems/UFS_UTILS/reg_tests/cpld_gridgen/baseline_data
-  export APRUN="mpiexec -n 1 -ppn 1 --cpu-bind core"
+  export APRUN="mpiexec -n 12 -ppn 12 --cpu-bind core"
   export NCCMP=nccmp
 fi
 
@@ -211,7 +211,7 @@ while read -r line || [ "$line" ]; do
 
   if [[ $target = wcoss2 ]]; then
     tests[$i]=$(qsub -V -o $PATHRT/run_${TEST_NAME}.log -e $PATHRT/run_${TEST_NAME}.log -q $QUEUE  -A $ACCOUNT \
-       -l walltime=00:${WLCLK}:00 -N $TEST_NAME -l select=1:ncpus=1:mem=12GB -v RESNAME=$TEST_NAME,ATMLIST="'$ATMLIST'" ./cpld_gridgen.sh)
+       -l walltime=00:${WLCLK}:00 -N $TEST_NAME -l select=1:ncpus=12 -v RESNAME=$TEST_NAME,ATMLIST="'$ATMLIST'" ./cpld_gridgen.sh)
 
   else
     tests[$i]=$(sbatch --parsable --ntasks-per-node=12 --nodes=1 -t 00:${WLCLK}:00 -A $ACCOUNT -q $QUEUE -J $TEST_NAME \

--- a/sorc/cpld_gridgen.fd/gen_fixgrid.F90
+++ b/sorc/cpld_gridgen.fd/gen_fixgrid.F90
@@ -68,10 +68,8 @@ program gen_fixgrid
   character(len= 6) :: cnx
 
   !-------------------------------------------------------------------------
-  ! Initialize esmf environment.
-  ! Everthing except the generation of the weights to map the ocean mask to
-  ! the ATM tiles and generation of the tripole:tripole weights is done on
-  ! the root PE.
+  ! Initialize esmf environment. Everything except the generation of the 
+  ! ESMF weights is done on the root PE.
   !-------------------------------------------------------------------------
 
   call ESMF_Initialize()
@@ -84,7 +82,6 @@ program gen_fixgrid
   if (localPet == 0) maintask=.true.
   if (maintask) then
      print '(a,i4,a)','Running on = ',npet,' tasks'
-
      !---------------------------------------------------------------------
      !
      !---------------------------------------------------------------------
@@ -558,7 +555,6 @@ program gen_fixgrid
           netcdf4fileFlag=.true., tileFilePath=trim(fv3dir)//'/'//trim(atmres)//'/', rc=rc)
      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
           line=__LINE__, file=__FILE__)) call ESMF_Finalize(endflag=ESMF_END_ABORT)
-
   end do
 
   !---------------------------------------------------------------------

--- a/sorc/cpld_gridgen.fd/gen_fixgrid.F90
+++ b/sorc/cpld_gridgen.fd/gen_fixgrid.F90
@@ -16,6 +16,7 @@
 program gen_fixgrid
 
   use ESMF
+  use mpi_f08
 
   use grdvars
   use inputnml
@@ -36,6 +37,7 @@ program gen_fixgrid
   implicit none
 
   ! local variables
+  type(MPI_Comm) :: mpic  ! mpi_f08
   real(dbl_kind) :: dxT, dyT
 
   real(kind=dbl_kind), parameter :: pi = 3.14159265358979323846_dbl_kind
@@ -47,11 +49,14 @@ program gen_fixgrid
   character(len=CL) :: fsrc, fdst, fwgt
   character(len= 2) :: cstagger
 
+  integer :: int_mpic
   integer :: rc,ncid,id,xtype
-  integer :: i,j,k,n,i2,j2
+  integer :: i,j,k,n,i2,j2,nvalid
   integer :: ii
+  integer :: ierr
   integer :: localPet, nPet
   logical :: fexist = .false.
+  logical :: maintask
 
   type(ESMF_RegridMethod_Flag) :: method
   type(ESMF_VM) :: vm
@@ -64,420 +69,466 @@ program gen_fixgrid
 
   !-------------------------------------------------------------------------
   ! Initialize esmf environment.
+  ! Everthing except the generation of the weights to map the ocean mask to
+  ! the ATM tiles and generation of the tripole:tripole weights is done on
+  ! the root PE.
   !-------------------------------------------------------------------------
 
-  call ESMF_VMGetGlobal(vm, rc=rc)
-  call ESMF_Initialize(VM=vm, logkindflag=ESMF_LOGKIND_MULTI, rc=rc)
-  call ESMF_VMGet(vm, localPet=localPet, peCount=nPet, rc=rc)
+  call ESMF_Initialize()
+  call ESMF_VMGetGlobal(vm)
+  call ESMF_VMGet(vm, localPet=localPet, peCount=nPet, mpiCommunicator=int_mpic, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, file=__FILE__)) call ESMF_Finalize(endflag=ESMF_END_ABORT)
-  roottask = .false.
-  if (localPet == 0) roottask =.true.
-  if (nPet /= 1) then
-     print *,npet,' More than one task specified; Aborting '
-     call ESMF_Finalize(endflag=ESMF_END_ABORT)
-  end if
+  mpic%mpi_val = int_mpic
+  maintask = .false.
+  if (localPet == 0) maintask=.true.
+  if (maintask) then
+     print '(a,i4,a)','Running on = ',npet,' tasks'
 
-  !---------------------------------------------------------------------
-  !
-  !---------------------------------------------------------------------
-
-  call read_inputnml('grid.nml')
-
-  print '(a,2i6)',' output grid requested ',ni,nj
-  print '(a,2i6)',' supergrid size used ', nx,ny
-  print '(a)',' output grid tag '//trim(res)
-  print '(a)',' supergrid source directory '//trim(dirsrc)
-  print '(a)',' output grid directory '//trim(dirout)
-  print '(a)',' atm mosaic directory '//trim(fv3dir)
-  print '(a)',' MOM6 topography file '//trim(topofile)
-  print '(a)',' MOM6 edits file '//trim(editsfile)
-  print *,'editmask flag ',editmask
-  print *,'debug flag ',debug
-  print *,'do_postwgts flag ',do_postwgts
-  print *
-
-  call allocate_all
-
-  call ESMF_LogWrite("Starting gen_fixgrid", ESMF_LOGMSG_INFO)
-  !---------------------------------------------------------------------
-  ! set up the arrays to retrieve the vertices
-  !---------------------------------------------------------------------
-
-  iVertCu = iVertCt + 1; jVertCu = jVertCt + 0
-  iVertCv = iVertCt + 0; jVertCv = jVertCt + 1
-  iVertBu = iVertCt + 1; jVertBu = jVertCt + 1
-
-  print '(a8,4i6)','iVertCt ',(iVertCt(i),i=1,4)
-  print '(a8,4i6)','jVertCt ',(jVertCt(i),i=1,4)
-  print *
-  print '(a8,4i6)','iVertCu ',(iVertCu(i),i=1,4)
-  print '(a8,4i6)','jVertCu ',(jVertCu(i),i=1,4)
-  print *
-  print '(a8,4i6)','iVertCv ',(iVertCv(i),i=1,4)
-  print '(a8,4i6)','jVertCv ',(jVertCv(i),i=1,4)
-  print *
-  print '(a8,4i6)','iVertBu ',(iVertBu(i),i=1,4)
-  print '(a8,4i6)','jVertBu ',(jVertBu(i),i=1,4)
-  print *
-
-  latCt_vert = -9999.0 ; lonCt_vert = -9999.0
-  latCu_vert = -9999.0 ; lonCu_vert = -9999.0
-  latCv_vert = -9999.0 ; lonCv_vert = -9999.0
-  latBu_vert = -9999.0 ; lonBu_vert = -9999.0
-
-  !---------------------------------------------------------------------
-  ! read the MOM6 land mask
-  !---------------------------------------------------------------------
-
-  fsrc = trim(dirsrc)//'/'//trim(maskfile)
-
-  rc = nf90_open(fsrc, nf90_nowrite, ncid)
-  print '(a)', 'reading ocean mask from '//trim(fsrc)
-  if(rc .ne. 0)print '(a)', 'nf90_open = '//trim(nf90_strerror(rc))
-
-  wet4 = 0.0; wet8 = 0.0
-  rc = nf90_inq_varid(ncid,  trim(maskname), id)
-  rc = nf90_inquire_variable(ncid, id, xtype=xtype)
-  if(xtype .eq. 5)rc = nf90_get_var(ncid,      id,  wet4)
-  if(xtype .eq. 6)rc = nf90_get_var(ncid,      id,  wet8)
-  rc = nf90_close(ncid)
-
-  if(xtype.eq. 6)wet4 = real(wet8,4)
-
-  !---------------------------------------------------------------------
-  ! read the MOM6 depth file
-  !---------------------------------------------------------------------
-
-  fsrc = trim(dirsrc)//'/'//trim(topofile)
-
-  rc = nf90_open(fsrc, nf90_nowrite, ncid)
-  print '(a)', 'reading ocean topography from '//trim(fsrc)
-  if(rc .ne. 0)print '(a)', 'nf90_open = '//trim(nf90_strerror(rc))
-
-  dp4 = 0.0; dp8 = 0.0
-  rc = nf90_inq_varid(ncid,  trim(toponame), id)
-  rc = nf90_inquire_variable(ncid, id, xtype=xtype)
-  if(xtype .eq. 5)rc = nf90_get_var(ncid,      id,  dp4)
-  if(xtype .eq. 6)rc = nf90_get_var(ncid,      id,  dp8)
-  rc = nf90_close(ncid)
-
-  if(xtype.eq. 6)dp4 = real(dp8,4)
-
-  if(editmask)then
      !---------------------------------------------------------------------
-     ! apply topoedits run time mask changes if required for this config
-     ! this will create a modified topoedits file which accounts for any
-     ! land mask changes created at run time by MOM6
+     !
      !---------------------------------------------------------------------
 
-     if(trim(editsfile)  == 'none')then
-        print '(a)', 'Need a valid editsfile to make mask edits '
-        call abort()
-     end if
-     inquire(file=trim(dirsrc)//'/'//trim(editsfile),exist=fexist)
-     if (.not. fexist) then
-        print '(a)', 'Required topoedits file '//trim(editsfile) &
-             //'for land mask changes is missing '
-        call abort()
-     end if
+     call read_inputnml('grid.nml')
+
+     print '(a,2i6)',' output grid requested ',ni,nj
+     print '(a,2i6)',' supergrid size used ', nx,ny
+     print '(a)',' output grid tag '//trim(res)
+     print '(a)',' supergrid source directory '//trim(dirsrc)
+     print '(a)',' output grid directory '//trim(dirout)
+     print '(a)',' atm mosaic directory '//trim(fv3dir)
+     print '(a)',' MOM6 topography file '//trim(topofile)
+     print '(a)',' MOM6 edits file '//trim(editsfile)
+     print *,'editmask flag ',editmask
+     print *,'debug flag ',debug
+     print *,'do_postwgts flag ',do_postwgts
+     print *
+
+     call allocate_all
+
+     call ESMF_LogWrite("Starting gen_fixgrid", ESMF_LOGMSG_INFO)
+     !---------------------------------------------------------------------
+     ! set up the arrays to retrieve the vertices
+     !---------------------------------------------------------------------
+
+     iVertCu = iVertCt + 1; jVertCu = jVertCt + 0
+     iVertCv = iVertCt + 0; jVertCv = jVertCt + 1
+     iVertBu = iVertCt + 1; jVertBu = jVertCt + 1
+
+     print '(a8,4i6)','iVertCt ',(iVertCt(i),i=1,4)
+     print '(a8,4i6)','jVertCt ',(jVertCt(i),i=1,4)
+     print *
+     print '(a8,4i6)','iVertCu ',(iVertCu(i),i=1,4)
+     print '(a8,4i6)','jVertCu ',(jVertCu(i),i=1,4)
+     print *
+     print '(a8,4i6)','iVertCv ',(iVertCv(i),i=1,4)
+     print '(a8,4i6)','jVertCv ',(jVertCv(i),i=1,4)
+     print *
+     print '(a8,4i6)','iVertBu ',(iVertBu(i),i=1,4)
+     print '(a8,4i6)','jVertBu ',(jVertBu(i),i=1,4)
+     print *
+
+     latCt_vert = -9999.0 ; lonCt_vert = -9999.0
+     latCu_vert = -9999.0 ; lonCu_vert = -9999.0
+     latCv_vert = -9999.0 ; lonCv_vert = -9999.0
+     latBu_vert = -9999.0 ; lonBu_vert = -9999.0
+
+     !---------------------------------------------------------------------
+     ! read the MOM6 land mask
+     !---------------------------------------------------------------------
+
+     fsrc = trim(dirsrc)//'/'//trim(maskfile)
+
+     rc = nf90_open(fsrc, nf90_nowrite, ncid)
+     print '(a)', 'reading ocean mask from '//trim(fsrc)
+     if(rc .ne. 0)print '(a)', 'nf90_open = '//trim(nf90_strerror(rc))
+
+     wet4 = 0.0; wet8 = 0.0
+     rc = nf90_inq_varid(ncid,  trim(maskname), id)
+     rc = nf90_inquire_variable(ncid, id, xtype=xtype)
+     if(xtype .eq. 5)rc = nf90_get_var(ncid,      id,  wet4)
+     if(xtype .eq. 6)rc = nf90_get_var(ncid,      id,  wet8)
+     rc = nf90_close(ncid)
+
+     if(xtype.eq. 6)wet4 = real(wet8,4)
+
+     !---------------------------------------------------------------------
+     ! read the MOM6 depth file
+     !---------------------------------------------------------------------
+
+     fsrc = trim(dirsrc)//'/'//trim(topofile)
+
+     rc = nf90_open(fsrc, nf90_nowrite, ncid)
+     print '(a)', 'reading ocean topography from '//trim(fsrc)
+     if(rc .ne. 0)print '(a)', 'nf90_open = '//trim(nf90_strerror(rc))
+
+     dp4 = 0.0; dp8 = 0.0
+     rc = nf90_inq_varid(ncid,  trim(toponame), id)
+     rc = nf90_inquire_variable(ncid, id, xtype=xtype)
+     if(xtype .eq. 5)rc = nf90_get_var(ncid,      id,  dp4)
+     if(xtype .eq. 6)rc = nf90_get_var(ncid,      id,  dp8)
+     rc = nf90_close(ncid)
+
+     if(xtype.eq. 6)dp4 = real(dp8,4)
+
+     if(editmask)then
+        !---------------------------------------------------------------------
+        ! apply topoedits run time mask changes if required for this config
+        ! this will create a modified topoedits file which accounts for any
+        ! land mask changes created at run time by MOM6
+        !---------------------------------------------------------------------
+
+        if(trim(editsfile)  == 'none')then
+           print '(a)', 'Need a valid editsfile to make mask edits '
+           call abort()
+        end if
+        inquire(file=trim(dirsrc)//'/'//trim(editsfile),exist=fexist)
+        if (.not. fexist) then
+           print '(a)', 'Required topoedits file '//trim(editsfile) &
+                //'for land mask changes is missing '
+           call abort()
+        end if
+
+        fsrc = trim(dirsrc)//'/'//trim(editsfile)
+        fdst = trim(dirout)//'/'//'ufs.'//trim(editsfile)
+        call add_topoedits(fsrc,fdst)
+     endif
+
+     !---------------------------------------------------------------------
+     ! MOM6 reads the depth file, applies the topo edits and then adjusts
+     ! depth using masking_depth and min/max depth. This call mimics
+     ! MOM6 routines apply_topography_edits_from_file and limit_topography
+     ! If the the topoedits file has been modified to account for MOM6 run
+     ! time land mask changes (above), then the depth will be created using
+     ! this modified topoedits file
+     !---------------------------------------------------------------------
 
      fsrc = trim(dirsrc)//'/'//trim(editsfile)
-     fdst = trim(dirout)//'/'//'ufs.'//trim(editsfile)
-     call add_topoedits(fsrc,fdst)
-  endif
+     if(editmask)fsrc = trim(dirout)//'/'//'ufs.'//trim(editsfile)
 
-  !---------------------------------------------------------------------
-  ! MOM6 reads the depth file, applies the topo edits and then adjusts
-  ! depth using masking_depth and min/max depth. This call mimics
-  ! MOM6 routines apply_topography_edits_from_file and limit_topography
-  ! If the the topoedits file has been modified to account for MOM6 run
-  ! time land mask changes (above), then the depth will be created using
-  ! this modified topoedits file
-  !---------------------------------------------------------------------
-
-  fsrc = trim(dirsrc)//'/'//trim(editsfile)
-  if(editmask)fsrc = trim(dirout)//'/'//'ufs.'//trim(editsfile)
-
-  if (trim(editsfile) /= 'none') then
-     inquire(file=trim(fsrc),exist=fexist)
-     if (.not. fexist) then
-        print '(a)', 'Required topoedits file '//trim(fsrc)//' is missing '
-        call abort()
+     if (trim(editsfile) /= 'none') then
+        inquire(file=trim(fsrc),exist=fexist)
+        if (.not. fexist) then
+           print '(a)', 'Required topoedits file '//trim(fsrc)//' is missing '
+           call abort()
+        end if
      end if
-  end if
-  call apply_topoedits(fsrc)
+     call apply_topoedits(fsrc)
 
-  !---------------------------------------------------------------------
-  ! read MOM6 supergrid file
-  !---------------------------------------------------------------------
+     !---------------------------------------------------------------------
+     ! read MOM6 supergrid file
+     !---------------------------------------------------------------------
 
-  fsrc = trim(dirsrc)//'/'//'ocean_hgrid.nc'
+     fsrc = trim(dirsrc)//'/'//'ocean_hgrid.nc'
 
-  rc = nf90_open(fsrc, nf90_nowrite, ncid)
-  print '(a)', 'reading supergrid from '//trim(fsrc)
-  if(rc .ne. 0)print '(a)', 'nf90_open = '//trim(nf90_strerror(rc))
+     rc = nf90_open(fsrc, nf90_nowrite, ncid)
+     print '(a)', 'reading supergrid from '//trim(fsrc)
+     if(rc .ne. 0)print '(a)', 'nf90_open = '//trim(nf90_strerror(rc))
 
-  rc = nf90_inq_varid(ncid, 'x', id)  !lon
-  rc = nf90_get_var(ncid,    id,  x)
+     rc = nf90_inq_varid(ncid, 'x', id)  !lon
+     rc = nf90_get_var(ncid,    id,  x)
 
-  rc = nf90_inq_varid(ncid, 'y', id)  !lat
-  rc = nf90_get_var(ncid,    id,  y)
+     rc = nf90_inq_varid(ncid, 'y', id)  !lat
+     rc = nf90_get_var(ncid,    id,  y)
 
-  rc = nf90_inq_varid(ncid, 'dx', id)
-  rc = nf90_get_var(ncid,     id, dx)
+     rc = nf90_inq_varid(ncid, 'dx', id)
+     rc = nf90_get_var(ncid,     id, dx)
 
-  rc = nf90_inq_varid(ncid, 'dy', id)
-  rc = nf90_get_var(ncid,     id, dy)
+     rc = nf90_inq_varid(ncid, 'dy', id)
+     rc = nf90_get_var(ncid,     id, dy)
 
-  rc = nf90_close(ncid)
-  sg_maxlat = maxval(y)
-  write(logmsg,'(a,f12.2)')'max lat in super grid ',maxval(y)
-  print '(a)',trim(logmsg)
+     rc = nf90_close(ncid)
+     sg_maxlat = maxval(y)
+     write(logmsg,'(a,f12.2)')'max lat in super grid ',maxval(y)
+     print '(a)',trim(logmsg)
 
-  !---------------------------------------------------------------------
-  ! fill grid variables
-  !---------------------------------------------------------------------
+     !---------------------------------------------------------------------
+     ! fill grid variables
+     !---------------------------------------------------------------------
 
-  do j = 1,nj
-     do i = 1,ni
-        i2 = 2*i ; j2 = 2*j
-        !deg->rad
-        ulon(i,j) =     x(i2,j2)*deg2rad
-        ulat(i,j) =     y(i2,j2)*deg2rad
-        !m->cm
-        htn(i,j) = (dx(i2-1,j2) + dx(i2,j2))*100._dbl_kind
-        hte(i,j) = (dy(i2,j2-1) + dy(i2,j2))*100._dbl_kind
-        !deg
-        lonBu(i,j) =     x(i2,j2)
-        latBu(i,j) =     y(i2,j2)
-        !deg
-        lonCt(i,j) =     x(i2-1,j2-1)
-        lonCu(i,j) =     x(i2,  j2-1)
-        lonCv(i,j) =     x(i2-1,j2  )
-        !deg
-        latCt(i,j) =     y(i2-1,j2-1)
-        latCu(i,j) =     y(i2,  j2-1)
-        latCv(i,j) =     y(i2-1,j2  )
-        !m2
-        dxT = dx(i2-1,j2-1) + dx(i2,j2-1)
-        dyT = dy(i2-1,j2-1) + dy(i2-1,j2)
-        areaCt(i,j) = dxT*dyT
+     do j = 1,nj
+        do i = 1,ni
+           i2 = 2*i ; j2 = 2*j
+           !deg->rad
+           ulon(i,j) =     x(i2,j2)*deg2rad
+           ulat(i,j) =     y(i2,j2)*deg2rad
+           !m->cm
+           htn(i,j) = (dx(i2-1,j2) + dx(i2,j2))*100._dbl_kind
+           hte(i,j) = (dy(i2,j2-1) + dy(i2,j2))*100._dbl_kind
+           !deg
+           lonBu(i,j) =     x(i2,j2)
+           latBu(i,j) =     y(i2,j2)
+           !deg
+           lonCt(i,j) =     x(i2-1,j2-1)
+           lonCu(i,j) =     x(i2,  j2-1)
+           lonCv(i,j) =     x(i2-1,j2  )
+           !deg
+           latCt(i,j) =     y(i2-1,j2-1)
+           latCu(i,j) =     y(i2,  j2-1)
+           latCv(i,j) =     y(i2-1,j2  )
+           !m2
+           dxT = dx(i2-1,j2-1) + dx(i2,j2-1)
+           dyT = dy(i2-1,j2-1) + dy(i2-1,j2)
+           areaCt(i,j) = dxT*dyT
+        enddo
      enddo
-  enddo
 
-  !---------------------------------------------------------------------
-  ! locate the ith index of the two poles on j=nj
-  ! the corner points must lie on the pole
-  !---------------------------------------------------------------------
+     !---------------------------------------------------------------------
+     ! locate the ith index of the two poles on j=nj
+     ! the corner points must lie on the pole
+     !---------------------------------------------------------------------
 
-  ipole = -1
-  j = nj
-  do i = 1,ni/2
-     if(latBu(i,j) .eq. sg_maxlat)ipole(1) = i
-  enddo
-  do i = ni/2+1,ni
-     if(latBu(i,j) .eq. sg_maxlat)ipole(2) = i
-  enddo
-  write(logmsg,'(a,2i6,2f12.2)')'poles found at i = ',ipole, latBu(ipole(1),nj), &
-       latBu(ipole(2),nj)
-  print '(a)',trim(logmsg)
+     ipole = -1
+     j = nj
+     do i = 1,ni/2
+        if(latBu(i,j) .eq. sg_maxlat)ipole(1) = i
+     enddo
+     do i = ni/2+1,ni
+        if(latBu(i,j) .eq. sg_maxlat)ipole(2) = i
+     enddo
+     write(logmsg,'(a,2i6,2f12.2)')'poles found at i = ',ipole, latBu(ipole(1),nj), &
+          latBu(ipole(2),nj)
+     print '(a)',trim(logmsg)
 
-  !---------------------------------------------------------------------
-  ! find the angle on centers using the same procedure as MOM6
-  !---------------------------------------------------------------------
+     !---------------------------------------------------------------------
+     ! find the angle on centers using the same procedure as MOM6
+     !---------------------------------------------------------------------
 
-  call find_ang((/1,ni/),(/1,nj/),lonBu,latBu,lonCt,anglet)
-  write(logmsg,'(a,2f12.2)')'ANGLET min,max: ',minval(anglet),maxval(anglet)
-  print '(a)',trim(logmsg)
-  write(logmsg,'(a,2f12.2)')'ANGLET edges i=1,i=ni: ',anglet(1,nj),anglet(ni,nj)
-  print '(a)',trim(logmsg)
+     call find_ang((/1,ni/),(/1,nj/),lonBu,latBu,lonCt,anglet)
+     write(logmsg,'(a,2f12.2)')'ANGLET min,max: ',minval(anglet),maxval(anglet)
+     print '(a)',trim(logmsg)
+     write(logmsg,'(a,2f12.2)')'ANGLET edges i=1,i=ni: ',anglet(1,nj),anglet(ni,nj)
+     print '(a)',trim(logmsg)
 
-  xangCt(:) = 0.0
-  do i = 1,ni
-     i2 = ipole(2)+(ipole(1)-i)+1
-     xangCt(i) = -anglet(i2,nj)       ! angle changes sign across seam
-  end do
+     xangCt(:) = 0.0
+     do i = 1,ni
+        i2 = ipole(2)+(ipole(1)-i)+1
+        xangCt(i) = -anglet(i2,nj)       ! angle changes sign across seam
+     end do
 
-  !---------------------------------------------------------------------
-  ! find the angle on corners using the same procedure as CICE6
-  !---------------------------------------------------------------------
+     !---------------------------------------------------------------------
+     ! find the angle on corners using the same procedure as CICE6
+     !---------------------------------------------------------------------
 
-  call find_angq((/1,ni/),(/1,nj/),xangCt,anglet,angle)
-  angle(ni,:) = -angle(1,:)
-  ! reverse angle for CICE
-  angle = -angle
-  write(logmsg,'(a,2f12.2)')'ANGLE min,max: ',minval(angle),maxval(angle)
-  print '(a)',trim(logmsg)
-  write(logmsg,'(a,2f12.2)')'ANGLE edges i=1,i=ni: ',angle(1,nj),angle(ni,nj)
-  print '(a)',trim(logmsg)
+     call find_angq((/1,ni/),(/1,nj/),xangCt,anglet,angle)
+     angle(ni,:) = -angle(1,:)
+     ! reverse angle for CICE
+     angle = -angle
+     write(logmsg,'(a,2f12.2)')'ANGLE min,max: ',minval(angle),maxval(angle)
+     print '(a)',trim(logmsg)
+     write(logmsg,'(a,2f12.2)')'ANGLE edges i=1,i=ni: ',angle(1,nj),angle(ni,nj)
+     print '(a)',trim(logmsg)
 
-  !---------------------------------------------------------------------
-  ! check the Bu angle
-  !---------------------------------------------------------------------
+     !---------------------------------------------------------------------
+     ! check the Bu angle
+     !---------------------------------------------------------------------
 
-  call find_angchk((/1,ni/),(/1,nj/),angle,angchk)
-  angchk(1,:) = -angchk(ni,:)
-  ! reverse angle for MOM6
-  angchk = -angchk
-  write(logmsg,'(a,2f12.2)')'ANGCHK min,max: ',minval(angchk),maxval(angchk)
-  print '(a)',trim(logmsg)
-  write(logmsg,'(a,2f12.2)')'ANGCHK edges i=1,i=ni: ',angchk(1,nj),angchk(ni,nj)
-  print '(a)',trim(logmsg)
+     call find_angchk((/1,ni/),(/1,nj/),angle,angchk)
+     angchk(1,:) = -angchk(ni,:)
+     ! reverse angle for MOM6
+     angchk = -angchk
+     write(logmsg,'(a,2f12.2)')'ANGCHK min,max: ',minval(angchk),maxval(angchk)
+     print '(a)',trim(logmsg)
+     write(logmsg,'(a,2f12.2)')'ANGCHK edges i=1,i=ni: ',angchk(1,nj),angchk(ni,nj)
+     print '(a)',trim(logmsg)
 
-  !---------------------------------------------------------------------
-  ! For the 1/4deg grid, hte at j=720 and j = 1440 is identically=0.0 for
-  ! j > 840 (64.0N). These are land points, but since CICE uses hte to
-  ! generate remaining variables, setting them to zero will cause problems
-  ! For 1deg grid, hte at ni/2 and ni are very small O~10-12, so test for
-  ! hte < 1.0
-  !---------------------------------------------------------------------
+     !---------------------------------------------------------------------
+     ! For the 1/4deg grid, hte at j=720 and j = 1440 is identically=0.0 for
+     ! j > 840 (64.0N). These are land points, but since CICE uses hte to
+     ! generate remaining variables, setting them to zero will cause problems
+     ! For 1deg grid, hte at ni/2 and ni are very small O~10-12, so test for
+     ! hte < 1.0
+     !---------------------------------------------------------------------
 
-  write(logmsg,'(a,2e12.5)')'min vals of hte at folds ', minval(hte(ni/2,:)),minval(hte(ni,:))
-  print '(a)',trim(logmsg)
-  do j = 1,nj
-     ii = ni/2
-     if(hte(ii,j) .le. 1.0)hte(ii,j) = 0.5*(hte(ii-1,j) + hte(ii+1,j))
-     ii = ni
-     if(hte(ii,j) .le. 1.0)hte(ii,j) = 0.5*(hte(ii-1,j) + hte(   1,j))
-  enddo
-  write(logmsg,'(a,2e12.5)')'min vals of hte at folds ', minval(hte(ni/2,:)),minval(hte(ni,:))
-  print '(a)',trim(logmsg)
+     write(logmsg,'(a,2e12.5)')'min vals of hte at folds ', minval(hte(ni/2,:)),minval(hte(ni,:))
+     print '(a)',trim(logmsg)
+     do j = 1,nj
+        ii = ni/2
+        if(hte(ii,j) .le. 1.0)hte(ii,j) = 0.5*(hte(ii-1,j) + hte(ii+1,j))
+        ii = ni
+        if(hte(ii,j) .le. 1.0)hte(ii,j) = 0.5*(hte(ii-1,j) + hte(   1,j))
+     enddo
+     write(logmsg,'(a,2e12.5)')'min vals of hte at folds ', minval(hte(ni/2,:)),minval(hte(ni,:))
+     print '(a)',trim(logmsg)
 
-  !---------------------------------------------------------------------
-  ! find required extended values for setting all vertices
-  !---------------------------------------------------------------------
+     !---------------------------------------------------------------------
+     ! find required extended values for setting all vertices
+     !---------------------------------------------------------------------
 
-  if(debug)call checkseam
+     if(debug)call checkseam
 
-  do i = 1,ni
-     i2 = ipole(2)+(ipole(1)-i)+1
-     xlonCt(i) = lonCt(i2,nj)
-     xlatCt(i) = latCt(i2,nj)
-  enddo
+     do i = 1,ni
+        i2 = ipole(2)+(ipole(1)-i)+1
+        xlonCt(i) = lonCt(i2,nj)
+        xlatCt(i) = latCt(i2,nj)
+     enddo
 
-  do i = 1,ni
-     i2 = ipole(2)+(ipole(1)-i)
-     if(i2 .lt. 1)i2 = ni
-     xlonCu(i) = lonCu(i2,nj)
-     xlatCu(i) = latCu(i2,nj)
-  enddo
+     do i = 1,ni
+        i2 = ipole(2)+(ipole(1)-i)
+        if(i2 .lt. 1)i2 = ni
+        xlonCu(i) = lonCu(i2,nj)
+        xlatCu(i) = latCu(i2,nj)
+     enddo
 
-  if(debug)call checkxlatlon
+     if(debug)call checkxlatlon
 
-  !approx lat at grid bottom
-  do i = 1,ni
-     dlatBu(i) = latBu(i,1) + 2.0*(latCu(i,1) - latBu(i,1))
-     dlatCv(i) = latCt(i,1) + 2.0*(latCt(i,1) - latCv(i,1))
-  enddo
+     !approx lat at grid bottom
+     do i = 1,ni
+        dlatBu(i) = latBu(i,1) + 2.0*(latCu(i,1) - latBu(i,1))
+        dlatCv(i) = latCt(i,1) + 2.0*(latCt(i,1) - latCv(i,1))
+     enddo
 
-  !---------------------------------------------------------------------
-  ! fill grid vertices variables
-  !---------------------------------------------------------------------
+     !---------------------------------------------------------------------
+     ! fill grid vertices variables
+     !---------------------------------------------------------------------
 
-  !Ct and Cu grids align in j
-  call fill_vertices(2,nj  , iVertCt,jVertCt, latBu,lonBu, latCt_vert,lonCt_vert)
-  call           fill_bottom(iVertCt,jVertCt, latBu,lonBu, latCt_vert,lonCt_vert,dlatBu)
+     !Ct and Cu grids align in j
+     call fill_vertices(2,nj  , iVertCt,jVertCt, latBu,lonBu, latCt_vert,lonCt_vert)
+     call           fill_bottom(iVertCt,jVertCt, latBu,lonBu, latCt_vert,lonCt_vert,dlatBu)
 
-  call fill_vertices(2,nj  , iVertCu,jVertCu, latCv,lonCv, latCu_vert,lonCu_vert)
-  call           fill_bottom(iVertCu,jVertCu, latCv,lonCv, latCu_vert,lonCu_vert,dlatCv)
+     call fill_vertices(2,nj  , iVertCu,jVertCu, latCv,lonCv, latCu_vert,lonCu_vert)
+     call           fill_bottom(iVertCu,jVertCu, latCv,lonCv, latCu_vert,lonCu_vert,dlatCv)
 
-  !Cv and Bu grids align in j
-  call fill_vertices(1,nj-1, iVertCv,jVertCv, latCu,lonCu, latCv_vert,lonCv_vert)
-  call              fill_top(iVertCv,jVertCv, latCu,lonCu, latCv_vert,lonCv_vert, xlatCu, xlonCu)
+     !Cv and Bu grids align in j
+     call fill_vertices(1,nj-1, iVertCv,jVertCv, latCu,lonCu, latCv_vert,lonCv_vert)
+     call              fill_top(iVertCv,jVertCv, latCu,lonCu, latCv_vert,lonCv_vert, xlatCu, xlonCu)
 
-  call fill_vertices(1,nj-1, iVertBu,jVertBu, latCt,lonCt, latBu_vert,lonBu_vert)
-  call              fill_top(iVertBu,jVertBu, latCt,lonCt, latBu_vert,lonBu_vert, xlatCt, xlonCt)
+     call fill_vertices(1,nj-1, iVertBu,jVertBu, latCt,lonCt, latBu_vert,lonBu_vert)
+     call              fill_top(iVertBu,jVertBu, latCt,lonCt, latBu_vert,lonBu_vert, xlatCt, xlonCt)
 
-  if(debug)call checkpoint
+     if(debug)call checkpoint
 
-  if(minval(latCt_vert) .lt. -1.e3)stop
-  if(minval(lonCt_vert) .lt. -1.e3)stop
-  if(minval(latCu_vert) .lt. -1.e3)stop
-  if(minval(lonCu_vert) .lt. -1.e3)stop
-  if(minval(latCv_vert) .lt. -1.e3)stop
-  if(minval(lonCv_vert) .lt. -1.e3)stop
-  if(minval(latBu_vert) .lt. -1.e3)stop
-  if(minval(lonBu_vert) .lt. -1.e3)stop
-  deallocate(xlonCt, xlatCt, xlonCu, xlatCu, dlatBu, dlatCv)
+     if(minval(latCt_vert) .lt. -1.e3)stop
+     if(minval(lonCt_vert) .lt. -1.e3)stop
+     if(minval(latCu_vert) .lt. -1.e3)stop
+     if(minval(lonCu_vert) .lt. -1.e3)stop
+     if(minval(latCv_vert) .lt. -1.e3)stop
+     if(minval(lonCv_vert) .lt. -1.e3)stop
+     if(minval(latBu_vert) .lt. -1.e3)stop
+     if(minval(lonBu_vert) .lt. -1.e3)stop
+     deallocate(xlonCt, xlatCt, xlonCu, xlatCu, dlatBu, dlatCv)
 
-  !---------------------------------------------------------------------
-  ! write out grid file files
-  !---------------------------------------------------------------------
+     !---------------------------------------------------------------------
+     ! write out grid file files
+     !---------------------------------------------------------------------
 
-  ! create a history attribute
-  call date_and_time(date=cdate)
-  history = 'created on '//trim(cdate)//' from '//trim(fsrc)
+     ! create a history attribute
+     call date_and_time(date=cdate)
+     history = 'created on '//trim(cdate)//' from '//trim(fsrc)
 
-  ! write fix grid
-  fdst = trim(dirout)//'/'//'tripole.mx'//trim(res)//'.nc'
-  call write_tripolegrid(trim(fdst))
+     ! write fix grid
+     fdst = trim(dirout)//'/'//'tripole.mx'//trim(res)//'.nc'
+     call write_tripolegrid(trim(fdst))
 
-  ! write cice grid
-  fdst = trim(dirout)//'/'//'grid_cice_NEMS_mx'//trim(res)//'.nc'
-  call write_cicegrid(trim(fdst))
-  deallocate(ulon, ulat, htn, hte)
+     ! write cice grid
+     fdst = trim(dirout)//'/'//'grid_cice_NEMS_mx'//trim(res)//'.nc'
+     call write_cicegrid(trim(fdst))
+     deallocate(ulon, ulat, htn, hte)
 
-  ! write SCRIP files for generation of positional weights
-  do k = 1,nv
-     cstagger = trim(staggerlocs(k))
-     fdst = trim(dirout)//'/'//trim(cstagger)//'.mx'//trim(res)//'_SCRIP.nc'
+     ! write SCRIP files for generation of positional weights
+     do k = 1,nv
+        cstagger = trim(staggerlocs(k))
+        fdst = trim(dirout)//'/'//trim(cstagger)//'.mx'//trim(res)//'_SCRIP.nc'
+        logmsg = 'creating SCRIP file '//trim(fdst)
+        print '(a)',trim(logmsg)
+        call write_scripgrid(trim(fdst),trim(cstagger))
+     end do
+     deallocate(latCv_vert, lonCv_vert)
+     deallocate(latCu_vert, lonCu_vert)
+     deallocate(latBu_vert, lonBu_vert)
+
+     ! write SCRIP file with land mask, used for mapped ocean mask
+     ! and  mesh creation
+     cstagger = trim(staggerlocs(1))
+     fdst= trim(dirout)//'/'//trim(cstagger)//'.mx'//trim(res)//'_SCRIP_land.nc'
      logmsg = 'creating SCRIP file '//trim(fdst)
      print '(a)',trim(logmsg)
-     call write_scripgrid(trim(fdst),trim(cstagger))
-  end do
-  deallocate(latCv_vert, lonCv_vert)
-  deallocate(latCu_vert, lonCu_vert)
-  deallocate(latBu_vert, lonBu_vert)
+     call write_scripgrid(trim(fdst),trim(cstagger),imask=int(wet4))
+     deallocate(latCt_vert, lonCt_vert)
 
-  ! write SCRIP file with land mask, used for mapped ocean mask
-  ! and  mesh creation
-  cstagger = trim(staggerlocs(1))
-  fdst= trim(dirout)//'/'//trim(cstagger)//'.mx'//trim(res)//'_SCRIP_land.nc'
-  logmsg = 'creating SCRIP file '//trim(fdst)
-  print '(a)',trim(logmsg)
-  call write_scripgrid(trim(fdst),trim(cstagger),imask=int(wet4))
-  deallocate(latCt_vert, lonCt_vert)
+     !---------------------------------------------------------------------
+     ! write lat,lon,depth and mask arrays required by ww3 in creating
+     ! mod_def file
+     !---------------------------------------------------------------------
 
+     write(cnx,i4fmt)nx
+     write(form1,'(a)')'('//trim(cnx)//'f14.8)'
+     write(form2,'(a)')'('//trim(cnx)//'i2)'
+
+     allocate(ww3mask(1:ni,1:nj)); ww3mask = int(wet4)
+     allocate(ww3dpth(1:ni,1:nj)); ww3dpth = dp4
+
+     where(latCt .ge. maximum_lat)ww3mask = 3
+     !close last row
+     ww3mask(:,nj) = 3
+
+     open(unit=21,file=trim(dirout)//'/'//'ww3.mx'//trim(res)//'_x.inp',form='formatted')
+     open(unit=22,file=trim(dirout)//'/'//'ww3.mx'//trim(res)//'_y.inp',form='formatted')
+     open(unit=23,file=trim(dirout)//'/'//'ww3.mx'//trim(res)//'_bottom.inp',form='formatted')
+     open(unit=24,file=trim(dirout)//'/'//'ww3.mx'//trim(res)//'_mapsta.inp',form='formatted')
+     ! cice0 .ne. cicen requires obstruction map, should be initialized as zeros (w3grid,ln3032)
+     open(unit=25,file=trim(dirout)//'/'//'ww3.mx'//trim(res)//'_obstr.inp',form='formatted')
+
+     do j = 1,nj
+        write( 21,trim(form1))lonCt(:,j)
+        write( 22,trim(form1))latCt(:,j)
+     end do
+     do j = 1,nj
+        write( 23,trim(form1))ww3dpth(:,j)
+        write( 24,trim(form2))ww3mask(:,j)
+        !'obsx' and 'obsy' arrays ???
+        write( 25,trim(form2))ww3mask(:,j)*0
+        write( 25,trim(form2))ww3mask(:,j)*0
+     end do
+
+     close(21); close(22); close(23); close(24); close(25)
+     deallocate(ww3mask); deallocate(ww3dpth)
+     deallocate(wet4, wet8)
+
+     nvalid = size(catm)
+  end if ! if (maintask)
   !---------------------------------------------------------------------
-  ! write lat,lon,depth and mask arrays required by ww3 in creating
-  ! mod_def file
+  ! set up for parallel work
   !---------------------------------------------------------------------
-
-  write(cnx,i4fmt)nx
-  write(form1,'(a)')'('//trim(cnx)//'f14.8)'
-  write(form2,'(a)')'('//trim(cnx)//'i2)'
-
-  allocate(ww3mask(1:ni,1:nj)); ww3mask = int(wet4)
-  allocate(ww3dpth(1:ni,1:nj)); ww3dpth = dp4
-
-  where(latCt .ge. maximum_lat)ww3mask = 3
-  !close last row
-  ww3mask(:,nj) = 3
-
-  open(unit=21,file=trim(dirout)//'/'//'ww3.mx'//trim(res)//'_x.inp',form='formatted')
-  open(unit=22,file=trim(dirout)//'/'//'ww3.mx'//trim(res)//'_y.inp',form='formatted')
-  open(unit=23,file=trim(dirout)//'/'//'ww3.mx'//trim(res)//'_bottom.inp',form='formatted')
-  open(unit=24,file=trim(dirout)//'/'//'ww3.mx'//trim(res)//'_mapsta.inp',form='formatted')
-  ! cice0 .ne. cicen requires obstruction map, should be initialized as zeros (w3grid,ln3032)
-  open(unit=25,file=trim(dirout)//'/'//'ww3.mx'//trim(res)//'_obstr.inp',form='formatted')
-
-  do j = 1,nj
-     write( 21,trim(form1))lonCt(:,j)
-     write( 22,trim(form1))latCt(:,j)
-  end do
-  do j = 1,nj
-     write( 23,trim(form1))ww3dpth(:,j)
-     write( 24,trim(form2))ww3mask(:,j)
-     !'obsx' and 'obsy' arrays ???
-     write( 25,trim(form2))ww3mask(:,j)*0
-     write( 25,trim(form2))ww3mask(:,j)*0
-  end do
-
-  close(21); close(22); close(23); close(24); close(25)
-  deallocate(ww3mask); deallocate(ww3dpth)
-  deallocate(wet4, wet8)
-
+  call mpi_bcast(nvalid, 1, MPI_INTEGER, 0, mpic, ierr)
+  if (ierr /= MPI_SUCCESS) then
+     print *,' error in mpi broadcast for size(catm) '
+     call mpi_abort(mpic, rc)
+     call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  end if
+  if (.not. maintask) then
+     allocate(catm(nvalid))
+  end if
+  call mpi_bcast(catm, size(catm), MPI_INTEGER, 0, mpic, ierr)
+  if (ierr /= MPI_SUCCESS) then
+     print '(a)',' error in mpi broadcast for catm '
+     call mpi_abort(mpic, rc)
+     call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  end if
+  call mpi_bcast(dirout, len(dirout), MPI_CHARACTER, 0, mpic, ierr)
+  if (ierr /= MPI_SUCCESS) then
+     print '(a)',' error in mpi broadcast for dirout '
+     call mpi_abort(mpic, rc)
+     call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  end if
+  call mpi_bcast(res,    len(res),    MPI_CHARACTER, 0, mpic, ierr)
+  if (ierr /= MPI_SUCCESS) then
+     print '(a)',' error in mpi broadcast for res '
+     call mpi_abort(mpic, rc)
+     call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  end if
+  call mpi_bcast(fv3dir, len(fv3dir), MPI_CHARACTER, 0, mpic, ierr)
+  if (ierr /= MPI_SUCCESS) then
+     print '(a)',' error in mpi broadcast for fv3dir '
+     call mpi_abort(mpic, rc)
+     call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  end if
+  call mpi_bcast(do_postwgts, 1, MPI_LOGICAL, 0, mpic, ierr)
+  if (ierr /= MPI_SUCCESS) then
+     print '(a)',' error in mpi broadcast for do_postwgts '
+     call mpi_abort(mpic, rc)
+     call ESMF_Finalize(endflag=ESMF_END_ABORT)
+  end if
   !---------------------------------------------------------------------
   ! use ESMF regridding to produce mapped ocean mask; first generate
   ! conservative regrid weights from ocean to tiles; then generate the
@@ -499,7 +550,7 @@ program gen_fixgrid
      fdst = trim(fv3dir)//'/'//trim(atmres)//'/'//trim(atmres)//'_mosaic.nc'
      fwgt = trim(dirout)//'/'//'Ct.mx'//trim(res)//'.to.'//trim(atmres)//'.nc'
      logmsg = 'creating weight file '//trim(fwgt)
-     print '(a)',trim(logmsg)
+     if (maintask) print '(a)',trim(logmsg)
 
      call ESMF_RegridWeightGen(srcFile=trim(fsrc),dstFile=trim(fdst),         &
           weightFile=trim(fwgt), regridmethod=method,                         &
@@ -508,9 +559,6 @@ program gen_fixgrid
      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
           line=__LINE__, file=__FILE__)) call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
-     logmsg = 'creating mapped ocean mask for '//trim(atmres)
-     print '(a)',trim(logmsg)
-     call make_frac_land(trim(fsrc), trim(fwgt))
   end do
 
   !---------------------------------------------------------------------
@@ -525,7 +573,7 @@ program gen_fixgrid
      fsrc = trim(dirout)//'/'//trim(cstagger)//'.mx'//trim(res)//'_SCRIP.nc'
      fwgt = trim(dirout)//'/'//'tripole.mx'//trim(res)//'.'//trim(cstagger)//'.to.Ct.bilinear.nc'
      logmsg = 'creating weight file '//trim(fwgt)
-     print '(a)',trim(logmsg)
+     if (maintask) print '(a)',trim(logmsg)
 
      call ESMF_RegridWeightGen(srcFile=trim(fsrc),dstFile=trim(fdst), &
           weightFile=trim(fwgt), regridmethod=method,                 &
@@ -548,7 +596,7 @@ program gen_fixgrid
      fdst = trim(dirout)//'/'//trim(cstagger)//'.mx'//trim(res)//'_SCRIP.nc'
      fwgt = trim(dirout)//'/'//'tripole.mx'//trim(res)//'.Ct.to.'//trim(cstagger)//'.bilinear.nc'
      logmsg = 'creating weight file '//trim(fwgt)
-     print '(a)',trim(logmsg)
+     if (maintask) print '(a)',trim(logmsg)
 
      call ESMF_RegridWeightGen(srcFile=trim(fsrc),dstFile=trim(fdst), &
           weightFile=trim(fwgt), regridmethod=method,                 &
@@ -558,21 +606,37 @@ program gen_fixgrid
           line=__LINE__, file=__FILE__)) call ESMF_Finalize(endflag=ESMF_END_ABORT)
   end do
 
-  !---------------------------------------------------------------------
-  !
-  !---------------------------------------------------------------------
+  if(do_postwgts)call make_postwgts(maintask)
+  if (maintask) then
+     !---------------------------------------------------------------------
+     ! make mapped ocean mask file and clean up
+     !---------------------------------------------------------------------
 
-  if(do_postwgts)call make_postwgts
+     do n = 1,size(catm)
+        npx = catm(n)
+        if (npx < 100) then
+           write(atmres,'(a,i2)')'C',npx
+        elseif (npx < 1000) then
+           write(atmres,'(a,i3)')'C',npx
+        else
+           write(atmres,'(a,i4)')'C',npx
+        end if
+        fsrc = trim(dirout)//'/'//'Ct.mx'//trim(res)//'_SCRIP_land.nc'
+        fwgt = trim(dirout)//'/'//'Ct.mx'//trim(res)//'.to.'//trim(atmres)//'.nc'
+        logmsg = 'creating mapped ocean mask for '//trim(atmres)
+        print '(a)',trim(logmsg)
+        call make_frac_land(trim(fsrc), trim(fwgt))
+     end do
 
-  !---------------------------------------------------------------------
-  ! clean up
-  !---------------------------------------------------------------------
+     !---------------------------------------------------------------------
+     ! clean up
+     !---------------------------------------------------------------------
 
-  deallocate(x, y, dx, dy)
-  deallocate(areaCt, anglet, angle, angchk)
-  deallocate(latCt, lonCt)
-  deallocate(latCv, lonCv)
-  deallocate(latCu, lonCu)
-  deallocate(latBu, lonBu)
-
+     deallocate(x, y, dx, dy)
+     deallocate(areaCt, anglet, angle, angchk)
+     deallocate(latCt, lonCt)
+     deallocate(latCv, lonCv)
+     deallocate(latCu, lonCu)
+     deallocate(latBu, lonBu)
+  endif ! if (maintask)
 end program gen_fixgrid

--- a/sorc/cpld_gridgen.fd/postwgts.F90
+++ b/sorc/cpld_gridgen.fd/postwgts.F90
@@ -18,9 +18,12 @@ module postwgts
 contains
   !> Create the ESMF weights file to remap from the Ct location to a rectilinear grid
   !!
+  !! @param[in]  maintask    !> logical flag for maintask
+  !!
   !! @author Denise.Worthen@noaa.gov
 
-  subroutine make_postwgts
+  subroutine make_postwgts(maintask)
+    logical, intent(in) :: maintask
 
     ! local variables
     character(len=CL) :: fsrc, fdst, fwgt
@@ -80,7 +83,7 @@ contains
           fwgt = trim(dirout)//'/'//'tripole.mx'//trim(res)//'.Ct.to.rect.'//trim(destgrds(nd)) &
                //'.'//trim(methodname(k))//'.nc'
           logmsg = 'creating weight file '//trim(fwgt)
-          print '(a)',trim(logmsg)
+          if (maintask) print '(a)',trim(logmsg)
 
           call ESMF_RegridWeightGen(srcFile=trim(fsrc),dstFile=trim(fdst), &
                weightFile=trim(fwgt), regridmethod=method,                 &


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Updates the cpld_gridgen utility to generate the ESMF weights in parallel.

## TESTS CONDUCTED: 
If there are changes to the build or source code, the tests below must be conducted. Contact a repository manager if you need assistance.

- [x] Compile branch on all Tier 1 machines using Intel
  - [x] Orion
  - [x] Jet
  - [x] Ursa
  - [x] Hercules
  - [x] WCOSS2
- [x] Compile branch on Ursa using GNU. at 851a4284
- [x] Compile branch in 'Debug' mode on WCOSS2. at 624acb01
- [x] Compile with Doxygen on any machine with no errors. Ursa at 851a4284
- [x] Run unit tests locally on any Tier 1 machine. Ursa at 851a4284
- [x] Run relevant consistency tests locally on all Tier 1 machines.
  - [x] Orion
  - [x] Jet
  - [x] Ursa
  - [x] Hercules
  - [x] WCOSS2 

Describe any additional tests performed.

On Hercules, Orion, Ursa, Jet, and WCOSS2 all tests are B4B.

On Hercules, the development branch of the 025 resolution is ~27 minutes and with this branch it is ~16 minutes of elapsed time. 

Tests on Orion seem to be very slow when comparing files against the baselines. 

Tests were run on Jet; all were B4B but the summary.log file was not created. The job reports ``(DependencyNeverSatisfied)``

## ISSUE: 

- fixes #760 
