### PR TITLE
Make gdas_init outputs follow EE2 compliant names

### DIFF
--- a/util/gdas_init/copy_coldstart_files.sh
+++ b/util/gdas_init/copy_coldstart_files.sh
@@ -20,17 +20,25 @@ copy_data()
     cp out.sfc.${tile}.nc ${SAVEDIR_MODEL_DATA}/sfc_data.${tile}.nc
   done
 
-  # TODO: This will need to be updated for GFS v17 retros and/or operational tarballs.
   if [ ${MEM} == 'gdas' ]; then
     SAVEDIR_ANALYSIS=$SUBDIR/analysis/atmos
     mkdir -p $SAVEDIR_ANALYSIS
     for abias_file in ${INPUT_DATA_DIR}/*abias*; do
       base_abias_name=$(basename ${abias_file})
-      cp ${INPUT_DATA_DIR}/${base_abias_name} $SAVEDIR_ANALYSIS/${base_abias_name}.txt
+      # Test for v17 style abias file names
+      if [[ "${base_abias_name}" == *".txt" ]]; then
+        cp ${INPUT_DATA_DIR}/${base_abias_name} $SAVEDIR_ANALYSIS/${base_abias_name}
+      else
+        cp ${INPUT_DATA_DIR}/${base_abias_name} $SAVEDIR_ANALYSIS/${base_abias_name}.txt
+      fi
     done
     for radstat_file in ${INPUT_DATA_DIR}/*radstat; do
       base_radstat_name=$(basename ${radstat_file})
-      cp ${INPUT_DATA_DIR}/${base_radstat_name} $SAVEDIR_ANALYSIS/${base_radstat_name}.tar
+      if [[ "${base_radstat_name}" == *".tar" ]]; then
+        cp ${INPUT_DATA_DIR}/${base_radstat_name} $SAVEDIR_ANALYSIS/${base_radstat_name}
+      else
+        cp ${INPUT_DATA_DIR}/${base_radstat_name} $SAVEDIR_ANALYSIS/${base_radstat_name}.tar
+      fi
       group=$(stat -c %G ${INPUT_DATA_DIR}/${base_radstat_name})
       if [[ "${group}" == "rstprod" ]]; then
         chgrp rstprod $SAVEDIR_ANALYSIS/${base_radstat_name}.tar

--- a/util/gdas_init/copy_coldstart_files.sh
+++ b/util/gdas_init/copy_coldstart_files.sh
@@ -36,13 +36,15 @@ copy_data()
       base_radstat_name=$(basename ${radstat_file})
       if [[ "${base_radstat_name}" == *".tar" ]]; then
         cp ${INPUT_DATA_DIR}/${base_radstat_name} $SAVEDIR_ANALYSIS/${base_radstat_name}
+        final_name=${base_radstat_name}
       else
         cp ${INPUT_DATA_DIR}/${base_radstat_name} $SAVEDIR_ANALYSIS/${base_radstat_name}.tar
+        final_name=${base_radstat_name}.tar
       fi
       group=$(stat -c %G ${INPUT_DATA_DIR}/${base_radstat_name})
       if [[ "${group}" == "rstprod" ]]; then
-        chgrp rstprod $SAVEDIR_ANALYSIS/${base_radstat_name}.tar
-        chmod 640 $SAVEDIR_ANALYSIS/${base_radstat_name}.tar
+        chgrp rstprod $SAVEDIR_ANALYSIS/${final_name}
+        chmod 640 $SAVEDIR_ANALYSIS/${final_name}
       fi
     done
   fi

--- a/util/gdas_init/copy_coldstart_files.sh
+++ b/util/gdas_init/copy_coldstart_files.sh
@@ -20,11 +20,23 @@ copy_data()
     cp out.sfc.${tile}.nc ${SAVEDIR_MODEL_DATA}/sfc_data.${tile}.nc
   done
 
+  # TODO: This will need to be updated for GFS v17 retros and/or operational tarballs.
   if [ ${MEM} == 'gdas' ]; then
     SAVEDIR_ANALYSIS=$SUBDIR/analysis/atmos
     mkdir -p $SAVEDIR_ANALYSIS
-    cp ${INPUT_DATA_DIR}/*abias* $SAVEDIR_ANALYSIS/
-    cp ${INPUT_DATA_DIR}/*radstat $SAVEDIR_ANALYSIS/
+    for abias_file in ${INPUT_DATA_DIR}/*abias*; do
+      base_abias_name=$(basename ${abias_file})
+      cp ${INPUT_DATA_DIR}/${base_abias_name} $SAVEDIR_ANALYSIS/${base_abias_name}.txt
+    done
+    for radstat_file in ${INPUT_DATA_DIR}/*radstat; do
+      base_radstat_name=$(basename ${radstat_file})
+      cp ${INPUT_DATA_DIR}/${base_radstat_name} $SAVEDIR_ANALYSIS/${base_radstat_name}.tar
+      group=$(stat -c %G ${INPUT_DATA_DIR}/${base_radstat_name})
+      if [[ "${group}" == "rstprod" ]]; then
+        chgrp rstprod $SAVEDIR_ANALYSIS/${base_radstat_name}.tar
+        chmod 640 $SAVEDIR_ANALYSIS/${base_radstat_name}.tar
+      fi
+    done
   fi
 }
 

--- a/util/gdas_init/get_pre-v14.data.sh
+++ b/util/gdas_init/get_pre-v14.data.sh
@@ -27,6 +27,9 @@ if [ "$bundle" = "gdas" ]; then
   htar -xvf $directory/$file ./gdas1.t${hh}z.radstat
   rc=$?
   [ $rc != 0 ] && exit $rc
+  chgrp rstprod gdas1.t${hh}z.radstat
+  rc=$?
+  [ $rc != 0 ] && exit $rc
   htar -xvf $directory/$file ./gdas1.t${hh}z.abias_air
   rc=$?
   [ $rc != 0 ] && exit $rc

--- a/util/gdas_init/get_v14.data.sh
+++ b/util/gdas_init/get_v14.data.sh
@@ -26,6 +26,9 @@ if [ "$bundle" = "gdas" ] || [ "$bundle" = "gfs" ] ; then
     htar -xvf $directory/$file ./gdas.t${hh}z.radstat
     rc=$?
     [ $rc != 0 ] && exit $rc
+    chgrp rstprod gdas.t${hh}z.radstat
+    rc=$?
+    [ $rc != 0 ] && exit $rc
     htar -xvf $directory/$file ./gdas.t${hh}z.abias_air
     rc=$?
     [ $rc != 0 ] && exit $rc

--- a/util/gdas_init/get_v15.data.sh
+++ b/util/gdas_init/get_v15.data.sh
@@ -69,6 +69,9 @@ if [ "$bundle" == "gdas" ] || [ "$bundle" == "gfs" ] ; then
   htar -xvf $directory/$file ./gdas.${yy}${mm}${dd}/${hh}/gdas.t${hh}z.radstat
   rc=$?
   [ $rc != 0 ] && exit $rc
+  chgrp rstprod ./gdas.${yy}${mm}${dd}/${hh}/gdas.t${hh}z.radstat
+  rc=$?
+  [ $rc != 0 ] && exit $rc
   htar -xvf $directory/$file ./gdas.${yy}${mm}${dd}/${hh}/gdas.t${hh}z.abias
   rc=$?
   [ $rc != 0 ] && exit $rc

--- a/util/gdas_init/get_v16.data.sh
+++ b/util/gdas_init/get_v16.data.sh
@@ -99,6 +99,9 @@ if [ "$bundle" = "gdas" ] || [ "$bundle" = "gfs" ]; then
     htar -xvf $directory/$file ./gdas.${yy}${mm}${dd}/${hh}/atmos/gdas.t${hh}z.radstat
     rc=$?
     [ $rc != 0 ] && exit $rc
+    chgrp rstprod ./gdas.${yy}${mm}${dd}/${hh}/atmos/gdas.t${hh}z.radstat
+    rc=$?
+    [ $rc != 0 ] && exit $rc
 
   fi
 

--- a/util/gdas_init/get_v16retro.data.sh
+++ b/util/gdas_init/get_v16retro.data.sh
@@ -138,6 +138,8 @@ else
   htar -xvf $directory/$file -L ./list.hires3
   rc=$?
   [ $rc != 0 ] && exit $rc
+  find . -type f -name "*radstat*" -exec chgrp rstprod {} \
+  [ $rc != 0 ] && exit $rc
 
 fi # is this gdas or gfs CDUMP?
 

--- a/util/gdas_init/get_v16retro.data.sh
+++ b/util/gdas_init/get_v16retro.data.sh
@@ -138,7 +138,8 @@ else
   htar -xvf $directory/$file -L ./list.hires3
   rc=$?
   [ $rc != 0 ] && exit $rc
-  find . -type f -name "*radstat*" -exec chgrp rstprod {} \
+  find . -type f -name "*radstat*" -exec chgrp rstprod {} \;
+  rc=$?
   [ $rc != 0 ] && exit $rc
 
 fi # is this gdas or gfs CDUMP?


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This updates the gdas_init utility so that the filenames copied from the operational tarballs are renamed to the expected EE2 formats.  This goes hand-in-hand with https://github.com/NOAA-EMC/global-workflow/pull/4205.

I am also adding a check to keep the `radstat` data protected as it almost always is `rstprod`.

## TESTS CONDUCTED: 
- [x] Run a test of gdas_init on Ursa and verify names are as expected.
    - [x] Verified that the radstat files were all rstprod

## DEPENDENCIES:
None

## DOCUMENTATION:
N/A

## ISSUE: 
https://github.com/NOAA-EMC/global-workflow/issues/4173