### PR TITLE
Update ccpp-physics to enable non 6-hourly global cycle updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "ccpp"]
 	path = ccpp-physics
-  # Temporarily point to a fork until PRs are merged
-	url = https://github.com/DavidHuber-NOAA/ccpp-physics.git
+	url = https://github.com/ufs-community/ccpp-physics.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "ccpp"]
 	path = ccpp-physics
-	url = https://github.com/ufs-community/ccpp-physics.git
+  # Temporarily point to a fork until PRs are merged
+	url = https://github.com/DavidHuber-NOAA/ccpp-physics.git

--- a/sorc/global_cycle.fd/cycle.F90
+++ b/sorc/global_cycle.fd/cycle.F90
@@ -316,6 +316,7 @@
                    FRAC_GRID,COUPLED,ZSEA1,ZSEA2,ISOT,IVEGSRC,MYRANK)
 !
  USE READ_WRITE_DATA
+ use sfccyc_module, only: sfccycle
  use machine
  USE MPI
  USE LAND_INCREMENTS, ONLY: GAUSSIAN_TO_FV3_INTERP,     &


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This updates CCPP-physics to enable non-6-hourly global_cycle updates. This is needed for GFS v17 where updates are made on the IAU components and will also be needed if we ever go to 4DVar or hourly cycling.

## TESTS CONDUCTED: 

- [x] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Ursa, Hercules and WCOSS2).
- [x] Compile branch on Ursa using GNU.
- [x] Compile branch in 'Debug' mode on WCOSS2.
- [x] Run unit tests locally on any Tier 1 machine.
- [x] Run relevant consistency tests locally on all Tier 1 machines.
    - Ran all consistency tests on Ursa 

Optional test.

- [x] Run full set of chgres_cube consistency tests on Ursa.

Describe any additional tests performed.

- Ran this through `C96_atm3DVar_extended` test case on WCOSS2.

## DEPENDENCIES:
- [ ] https://github.com/ufs-community/ccpp-physics/pull/336

## ISSUE: 
https://github.com/NOAA-EMC/global-workflow/issues/4364

## CONTRIBUTORS (optional): 
@ClaraDraper-NOAA @jiaruidong2017 @RussTreadon-NOAA
