### PR TITLE
Update EE2 Environment Variables: Replace NET-Specific (VARgfs) with Global (VARglobal)

### DIFF
--- a/reg_tests/global_cycle/C192.gsitile_lndincsoilnoahmp.sh
+++ b/reg_tests/global_cycle/C192.gsitile_lndincsoilnoahmp.sh
@@ -14,11 +14,11 @@ NCCMP=${NCCMP:-$(which nccmp)}
 
 export MAX_TASKS_CY=6
 
-export HOMEgfs=$NWPROD
+export HOMEglobal=$NWPROD
 
-export FIXgfs=$HOMEreg/fix
+export FIXglobal=$HOMEreg/fix
 
-export CYCLEXEC=$HOMEgfs/exec/global_cycle
+export CYCLEXEC=$HOMEglobal/exec/global_cycle
 
 export CDATE=2019073000
 export FHOUR=00
@@ -46,7 +46,7 @@ export CYCLVARS=FSNOL=-2.,FSNOS=99999.,
 export PGMOUT='out'
 export PGMERR='err'
 
-$HOMEgfs/ush/global_cycle_driver.sh
+$HOMEglobal/ush/global_cycle_driver.sh
 
 iret=$?
 
@@ -82,7 +82,7 @@ if [ $test_failed -ne 0 ]; then
   echo "<<< C192 GSI-TILE based LANDINC SOIL-NOAHMP CYCLE TEST FAILED. >>>"
   echo "**********************************************"
   if [ "$UPDATE_BASELINE" = "TRUE" ]; then
-    $HOMEgfs/reg_tests/update_baseline.sh $HOMEreg "c192.gsitile_lndincsoilnoahmp" $commit_num
+    $HOMEglobal/reg_tests/update_baseline.sh $HOMEreg "c192.gsitile_lndincsoilnoahmp" $commit_num
   fi
 else
   echo

--- a/reg_tests/global_cycle/C192.jedi_lndincsoilnoahmp.sh
+++ b/reg_tests/global_cycle/C192.jedi_lndincsoilnoahmp.sh
@@ -16,11 +16,11 @@ NCCMP=${NCCMP:-$(which nccmp)}
 
 export MAX_TASKS_CY=6
 
-export HOMEgfs=$NWPROD
+export HOMEglobal=$NWPROD
 
-export FIXgfs=$HOMEreg/fix
+export FIXglobal=$HOMEreg/fix
 
-export CYCLEXEC=$HOMEgfs/exec/global_cycle
+export CYCLEXEC=$HOMEglobal/exec/global_cycle
 
 export CDATE=2019073000
 export FHOUR=00
@@ -49,7 +49,7 @@ export CYCLVARS=FSNOL=-2.,FSNOS=99999.,
 export PGMOUT='out'
 export PGMERR='err'
 
-$HOMEgfs/ush/global_cycle_driver.sh
+$HOMEglobal/ush/global_cycle_driver.sh
 
 iret=$?
 
@@ -85,7 +85,7 @@ if [ $test_failed -ne 0 ]; then
   echo "<<< C192 JEDI based LANDINC SOIL-NOAHMP CYCLE TEST FAILED. >>>"
   echo "**********************************************"
   if [ "$UPDATE_BASELINE" = "TRUE" ]; then
-    $HOMEgfs/reg_tests/update_baseline.sh $HOMEreg "c192.jedi_lndincsoilnoahmp" $commit_num
+    $HOMEglobal/reg_tests/update_baseline.sh $HOMEreg "c192.jedi_lndincsoilnoahmp" $commit_num
   fi
 else
   echo

--- a/reg_tests/global_cycle/C48.noahmp.coupled.sh
+++ b/reg_tests/global_cycle/C48.noahmp.coupled.sh
@@ -14,9 +14,9 @@ NCCMP=${NCCMP:-$(which nccmp)}
 
 export MAX_TASKS_CY=6
 
-export HOMEgfs=$NWPROD
+export HOMEglobal=$NWPROD
 
-export CYCLEXEC=$HOMEgfs/exec/global_cycle
+export CYCLEXEC=$HOMEglobal/exec/global_cycle
 
 export CDATE=2021032406
 export FHOUR=00
@@ -35,7 +35,7 @@ export JCAP=1534
 export LONB=3072
 export LATB=1536
 
-export FNAISC=$HOMEgfs/fix/am/IMS-NIC.blended.ice.monthly.clim.grb
+export FNAISC=$HOMEglobal/fix/am/IMS-NIC.blended.ice.monthly.clim.grb
 
 export DONST="YES"
 export use_ufo=.true.
@@ -48,7 +48,7 @@ export CYCLVARS=FSNOL=99999.,FSNOS=99999.,
 export PGMOUT='out'
 export PGMERR='err'
 
-$HOMEgfs/ush/global_cycle_driver.sh
+$HOMEglobal/ush/global_cycle_driver.sh
 
 iret=$?
 
@@ -84,7 +84,7 @@ if [ $test_failed -ne 0 ]; then
   echo "<<< C48 NOAHMP COUPLED GRID TEST FAILED. >>>"
   echo "******************************************"
   if [ "$UPDATE_BASELINE" = "TRUE" ]; then
-    $HOMEgfs/reg_tests/update_baseline.sh $HOMEreg "c48.noahmp.coupled" $commit_num
+    $HOMEglobal/reg_tests/update_baseline.sh $HOMEreg "c48.noahmp.coupled" $commit_num
   fi
 else
   echo

--- a/reg_tests/global_cycle/C768.fv3gfs.sh
+++ b/reg_tests/global_cycle/C768.fv3gfs.sh
@@ -11,11 +11,11 @@ NCCMP=${NCCMP:-$(which nccmp)}
 
 export MAX_TASKS_CY=6
 
-export HOMEgfs=$NWPROD
+export HOMEglobal=$NWPROD
 
-export CYCLEXEC=$HOMEgfs/exec/global_cycle
+export CYCLEXEC=$HOMEglobal/exec/global_cycle
 
-export FIXgfs=$HOMEreg/fix
+export FIXglobal=$HOMEreg/fix
 
 export CDATE=2019073000
 export FHOUR=00
@@ -34,25 +34,25 @@ export JCAP=1534
 export LONB=3072
 export LATB=1536
 
-export FNALBC2=$HOMEgfs/fix/am/global_albedo4.1x1.grb
-export FNALBC=$HOMEgfs/fix/am/global_snowfree_albedo.bosu.t1534.3072.1536.rg.grb
-export FNALBC=$HOMEgfs/fix/am/global_snowfree_albedo.bosu.t1534.3072.1536.rg.grb
-export FNTG3C=$HOMEgfs/fix/am/global_tg3clim.2.6x1.5.grb
-export FNVETC=$HOMEgfs/fix/am/global_vegtype.igbp.t1534.3072.1536.rg.grb
-export FNSOTC=$HOMEgfs/fix/am/global_soiltype.statsgo.t1534.3072.1536.rg.grb
-export FNVEGC=$HOMEgfs/fix/am/global_vegfrac.0.144.decpercent.grb
-export FNVMNC=$HOMEgfs/fix/am/global_shdmin.0.144x0.144.grb
-export FNVMXC=$HOMEgfs/fix/am/global_shdmax.0.144x0.144.grb
-export FNSLPC=$HOMEgfs/fix/am/global_slope.1x1.grb
-export FNABSC=$HOMEgfs/fix/am/global_mxsnoalb.uariz.t1534.3072.1536.rg.grb
-export FNAISC=$HOMEgfs/fix/am/CFSR.SEAICE.1982.2012.monthly.clim.grb
-export FNMSKH=$HOMEgfs/fix/am/global_slmask.t1534.3072.1536.grb
-export FNGLAC=$HOMEgfs/fix/am/global_glacier.2x2.grb
-export FNMXIC=$HOMEgfs/fix/am/global_maxice.2x2.grb
-export FNTSFC=$HOMEgfs/fix/am/RTGSST.1982.2012.monthly.clim.grb
-export FNSALC=$HOMEgfs/fix/am/global_salclm.t1534.3072.1536.nc
-export FNSNOC=$HOMEgfs/fix/am/global_snoclim.1.875.grb
-export FNSMCC=$HOMEgfs/fix/am/global_soilmgldas.statsgo.t1534.3072.1536.grb
+export FNALBC2=$HOMEglobal/fix/am/global_albedo4.1x1.grb
+export FNALBC=$HOMEglobal/fix/am/global_snowfree_albedo.bosu.t1534.3072.1536.rg.grb
+export FNALBC=$HOMEglobal/fix/am/global_snowfree_albedo.bosu.t1534.3072.1536.rg.grb
+export FNTG3C=$HOMEglobal/fix/am/global_tg3clim.2.6x1.5.grb
+export FNVETC=$HOMEglobal/fix/am/global_vegtype.igbp.t1534.3072.1536.rg.grb
+export FNSOTC=$HOMEglobal/fix/am/global_soiltype.statsgo.t1534.3072.1536.rg.grb
+export FNVEGC=$HOMEglobal/fix/am/global_vegfrac.0.144.decpercent.grb
+export FNVMNC=$HOMEglobal/fix/am/global_shdmin.0.144x0.144.grb
+export FNVMXC=$HOMEglobal/fix/am/global_shdmax.0.144x0.144.grb
+export FNSLPC=$HOMEglobal/fix/am/global_slope.1x1.grb
+export FNABSC=$HOMEglobal/fix/am/global_mxsnoalb.uariz.t1534.3072.1536.rg.grb
+export FNAISC=$HOMEglobal/fix/am/CFSR.SEAICE.1982.2012.monthly.clim.grb
+export FNMSKH=$HOMEglobal/fix/am/global_slmask.t1534.3072.1536.grb
+export FNGLAC=$HOMEglobal/fix/am/global_glacier.2x2.grb
+export FNMXIC=$HOMEglobal/fix/am/global_maxice.2x2.grb
+export FNTSFC=$HOMEglobal/fix/am/RTGSST.1982.2012.monthly.clim.grb
+export FNSALC=$HOMEglobal/fix/am/global_salclm.t1534.3072.1536.nc
+export FNSNOC=$HOMEglobal/fix/am/global_snoclim.1.875.grb
+export FNSMCC=$HOMEglobal/fix/am/global_soilmgldas.statsgo.t1534.3072.1536.grb
 
 export DONST="YES"
 export use_ufo=.true.
@@ -63,7 +63,7 @@ export CYCLVARS=FSNOL=-2.,FSNOS=99999.,
 export PGMOUT='out'
 export PGMERR='err'
 
-$HOMEgfs/ush/global_cycle_driver.sh
+$HOMEglobal/ush/global_cycle_driver.sh
 
 iret=$?
 
@@ -99,7 +99,7 @@ if [ $test_failed -ne 0 ]; then
   echo "<<< C768 GLOBAL CYCLE TEST FAILED. >>>"
   echo "*********************************"
   if [ "$UPDATE_BASELINE" = "TRUE" ]; then
-    $HOMEgfs/reg_tests/update_baseline.sh $HOMEreg "c768.fv3gfs" $commit_num
+    $HOMEglobal/reg_tests/update_baseline.sh $HOMEreg "c768.fv3gfs" $commit_num
   fi
 else
   echo

--- a/reg_tests/global_cycle/C768.lndincsnow.sh
+++ b/reg_tests/global_cycle/C768.lndincsnow.sh
@@ -12,11 +12,11 @@ NCCMP=${NCCMP:-$(which nccmp)}
 
 export MAX_TASKS_CY=6
 
-export HOMEgfs=$NWPROD
+export HOMEglobal=$NWPROD
 
-export FIXgfs=$HOMEreg/fix
+export FIXglobal=$HOMEreg/fix
 
-export CYCLEXEC=$HOMEgfs/exec/global_cycle
+export CYCLEXEC=$HOMEglobal/exec/global_cycle
 
 export CDATE=2019073000
 export FHOUR=00
@@ -47,7 +47,7 @@ export CYCLVARS=FSNOL=99999.,FSNOS=99999.,
 export PGMOUT='out'
 export PGMERR='err'
 
-$HOMEgfs/ush/global_cycle_driver.sh
+$HOMEglobal/ush/global_cycle_driver.sh
 
 iret=$?
 
@@ -83,7 +83,7 @@ if [ $test_failed -ne 0 ]; then
   echo "<<< C768 LANDINC SNOW CYCLE TEST FAILED. >>>"
   echo "****************************************"
   if [ "$UPDATE_BASELINE" = "TRUE" ]; then
-    $HOMEgfs/reg_tests/update_baseline.sh $HOMEreg "c768.lndincsnow" $commit_num
+    $HOMEglobal/reg_tests/update_baseline.sh $HOMEreg "c768.lndincsnow" $commit_num
   fi
 else
   echo

--- a/reg_tests/ice_blend/driver.hercules.sh
+++ b/reg_tests/ice_blend/driver.hercules.sh
@@ -53,7 +53,7 @@ if [ "$UPDATE_BASELINE" = "TRUE" ]; then
 fi
 
 export HOMEreg=/work/noaa/nems/role-nems/ufs_utils.hercules/reg_tests/ice_blend
-export HOMEgfs=$PWD/../..
+export HOMEglobal=$PWD/../..
 
 ./ice_blend.sh
 

--- a/reg_tests/ice_blend/driver.jet.sh
+++ b/reg_tests/ice_blend/driver.jet.sh
@@ -55,7 +55,7 @@ export WGRIB=/apps/wgrib/1.8.1.0b/bin/wgrib
 
 export HOMEreg=/lfs5/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/reg_tests/ice_blend
 
-export HOMEgfs=$PWD/../..
+export HOMEglobal=$PWD/../..
 
 ./ice_blend.sh
 

--- a/reg_tests/ice_blend/driver.orion.sh
+++ b/reg_tests/ice_blend/driver.orion.sh
@@ -53,7 +53,7 @@ if [ "$UPDATE_BASELINE" = "TRUE" ]; then
 fi
 
 export HOMEreg=/work/noaa/nems/role-nems/ufs_utils/reg_tests/ice_blend
-export HOMEgfs=$PWD/../..
+export HOMEglobal=$PWD/../..
 
 ./ice_blend.sh
 

--- a/reg_tests/ice_blend/driver.ursa.sh
+++ b/reg_tests/ice_blend/driver.ursa.sh
@@ -57,7 +57,7 @@ if [ "$UPDATE_BASELINE" = "TRUE" ]; then
 fi
 
 export HOMEreg=/scratch3/NCEPDEV/nems/role.ufsutils/ufs_utils/reg_tests/ice_blend
-export HOMEgfs=$PWD/../..
+export HOMEglobal=$PWD/../..
 
 ./ice_blend.sh
 

--- a/reg_tests/ice_blend/driver.wcoss2.sh
+++ b/reg_tests/ice_blend/driver.wcoss2.sh
@@ -52,7 +52,7 @@ if [ "$UPDATE_BASELINE" = "TRUE" ]; then
 fi
 
 export HOMEreg=/lfs/h2/emc/nems/noscrub/emc.nems/UFS_UTILS/reg_tests/ice_blend
-export HOMEgfs=$PBS_O_WORKDIR/../..
+export HOMEglobal=$PBS_O_WORKDIR/../..
 
 ./ice_blend.sh
 

--- a/reg_tests/ice_blend/ice_blend.sh
+++ b/reg_tests/ice_blend/ice_blend.sh
@@ -21,7 +21,7 @@ grid173="0 0 0 0 0 0 0 0 4320 2160 0 0 89958000 42000 48 -89958000 359958000 830
 $COPYGB2 -x -i3 -g "$grid173" ims.icec.grib2 ims.icec.5min.grib2
 
 FIVE_MIN_ICE_FILE=${HOMEreg}/input_data/seaice.5min.grib2.gdas.2018120618
-FIVE_MIN_ICE_MASK_FILE=${HOMEgfs}/fix/am/emcsfc_gland5min.grib2
+FIVE_MIN_ICE_MASK_FILE=${HOMEglobal}/fix/am/emcsfc_gland5min.grib2
 BLENDED_ICE_FILE="seaice.5min.blend"
 
 # These are input files.
@@ -33,13 +33,13 @@ export FORT15="$FIVE_MIN_ICE_FILE"
 export FORT51=${BLENDED_ICE_FILE}
 
 # Run the emcsfc_ice_blend executable.
-${HOMEgfs}/exec/emcsfc_ice_blend >> OUTPUT 2> errfile
+${HOMEglobal}/exec/emcsfc_ice_blend >> OUTPUT 2> errfile
 iret=$?
 
 if [ $iret -ne 0 ]; then
   set +x
   echo "<<< ICE_BLEND TEST FAILED. <<<"
-  echo "<<< ICE_BLEND TEST FAILED. <<<"  > ${HOMEgfs}/reg_tests/ice_blend/summary.log
+  echo "<<< ICE_BLEND TEST FAILED. <<<"  > ${HOMEglobal}/reg_tests/ice_blend/summary.log
   exit $iret
 else
 # Follow the OPS procedure by converting the output to grib1 and replace the
@@ -63,16 +63,16 @@ if [ $test_failed -ne 0 ]; then
   echo "*********************************"
   echo "<<< ICE BLEND TEST FAILED. >>>"
   echo "*********************************"
-  echo "<<< ICE BLEND TEST FAILED. >>>" > ${HOMEgfs}/reg_tests/ice_blend/summary.log
+  echo "<<< ICE BLEND TEST FAILED. >>>" > ${HOMEglobal}/reg_tests/ice_blend/summary.log
   if [ "$UPDATE_BASELINE" = "TRUE" ]; then
-    ${HOMEgfs}/reg_tests/update_baseline.sh $HOMEreg "t1534" $commit_num
+    ${HOMEglobal}/reg_tests/update_baseline.sh $HOMEreg "t1534" $commit_num
   fi
 else
   echo
   echo "*********************************"
   echo "<<< ICE BLEND TEST PASSED. >>>"
   echo "*********************************"
-  echo "<<< ICE BLEND TEST PASSED. >>>" > ${HOMEgfs}/reg_tests/ice_blend/summary.log
+  echo "<<< ICE BLEND TEST PASSED. >>>" > ${HOMEglobal}/reg_tests/ice_blend/summary.log
 fi
 
 exit 0

--- a/reg_tests/snow2mdl/driver.hercules.sh
+++ b/reg_tests/snow2mdl/driver.hercules.sh
@@ -49,7 +49,7 @@ rm -fr $DATA_ROOT
 export OMP_NUM_THREADS=1
 
 export HOMEreg=/work/noaa/nems/role-nems/ufs_utils.hercules/reg_tests/snow2mdl
-export HOMEgfs=$PWD/../..
+export HOMEglobal=$PWD/../..
 
 # The first test uses the hemispheric air force/afwa data, which was used in OPS.
 

--- a/reg_tests/snow2mdl/driver.jet.sh
+++ b/reg_tests/snow2mdl/driver.jet.sh
@@ -46,7 +46,7 @@ if [ "$UPDATE_BASELINE" = "TRUE" ]; then
 fi
 
 export HOMEreg=/lfs5/HFIP/hfv3gfs/emc.nemspara/role.ufsutils/ufs_utils/reg_tests/snow2mdl
-export HOMEgfs=$PWD/../..
+export HOMEglobal=$PWD/../..
 
 rm -fr $DATA_ROOT
 

--- a/reg_tests/snow2mdl/driver.orion.sh
+++ b/reg_tests/snow2mdl/driver.orion.sh
@@ -49,7 +49,7 @@ export OMP_NUM_THREADS=1
 rm -fr $DATA_ROOT
 
 export HOMEreg=/work/noaa/nems/role-nems/ufs_utils/reg_tests/snow2mdl
-export HOMEgfs=$PWD/../..
+export HOMEglobal=$PWD/../..
 
 # The first test uses the hemispheric afwa/air force data, which was used in OPS.
 

--- a/reg_tests/snow2mdl/driver.ursa.sh
+++ b/reg_tests/snow2mdl/driver.ursa.sh
@@ -47,7 +47,7 @@ if [ "$UPDATE_BASELINE" = "TRUE" ]; then
 fi
 
 export HOMEreg=/scratch3/NCEPDEV/nems/role.ufsutils/ufs_utils/reg_tests/snow2mdl
-export HOMEgfs=$PWD/../..
+export HOMEglobal=$PWD/../..
 
 # The first test uses hemispheric afwa/airforce data, as was done in OPS.
 

--- a/reg_tests/snow2mdl/driver.wcoss2.sh
+++ b/reg_tests/snow2mdl/driver.wcoss2.sh
@@ -43,7 +43,7 @@ if [ "$UPDATE_BASELINE" = "TRUE" ]; then
 fi
 
 export HOMEreg=/lfs/h2/emc/nems/noscrub/emc.nems/UFS_UTILS/reg_tests/snow2mdl
-export HOMEgfs=$PWD/../..
+export HOMEglobal=$PWD/../..
 
 LOG_FILE=consistency.log
 SUM_FILE=summary.log

--- a/reg_tests/snow2mdl/snow2mdl.global.sh
+++ b/reg_tests/snow2mdl/snow2mdl.global.sh
@@ -14,10 +14,10 @@ echo "BEGIN SNOW2MDL GLOBAL TEST."
 
 set -x
 
-HOMEush="${HOMEgfs}/ush"
-HOMEparm="${HOMEgfs}/parm"
-HOMEexec="${HOMEgfs}/exec"
-HOMEfix="${HOMEgfs}/fix/am"
+HOMEush="${HOMEglobal}/ush"
+HOMEparm="${HOMEglobal}/parm"
+HOMEexec="${HOMEglobal}/exec"
+HOMEfix="${HOMEglobal}/fix/am"
 
 source "${HOMEush}/atparse.bash"  # include function atparse for parsing @[XYZ] templated files
 
@@ -73,7 +73,7 @@ if [ $test_failed -ne 0 ]; then
   echo "*********************************"
   if [ "$UPDATE_BASELINE" = "TRUE" ]; then
     cd $DATA
-    $HOMEgfs/reg_tests/update_baseline.sh $HOMEreg "t1534.global" $commit_num
+    $HOMEglobal/reg_tests/update_baseline.sh $HOMEreg "t1534.global" $commit_num
   fi
 else
   echo

--- a/reg_tests/snow2mdl/snow2mdl.hemi.sh
+++ b/reg_tests/snow2mdl/snow2mdl.hemi.sh
@@ -25,13 +25,13 @@ cat << EOF > ./fort.41
   afwa_lsmask_sh_file=""
  /
  &qc
-  climo_qc_file="$HOMEgfs/fix/am/emcsfc_snow_cover_climo.grib2"
+  climo_qc_file="$HOMEglobal/fix/am/emcsfc_snow_cover_climo.grib2"
  /
  &model_specs
-  model_lat_file="$HOMEgfs/fix/am/global_latitudes.t1534.3072.1536.grb"
-  model_lon_file="$HOMEgfs/fix/am/global_longitudes.t1534.3072.1536.grb"
-  model_lsmask_file="$HOMEgfs/fix/am/global_slmask.t1534.3072.1536.grb"
-  gfs_lpl_file="$HOMEgfs/fix/am/global_lonsperlat.t1534.3072.1536.txt"
+  model_lat_file="$HOMEglobal/fix/am/global_latitudes.t1534.3072.1536.grb"
+  model_lon_file="$HOMEglobal/fix/am/global_longitudes.t1534.3072.1536.grb"
+  model_lsmask_file="$HOMEglobal/fix/am/global_slmask.t1534.3072.1536.grb"
+  gfs_lpl_file="$HOMEglobal/fix/am/global_lonsperlat.t1534.3072.1536.txt"
   /
  &output_data
   model_snow_file="./snogrb_model"
@@ -50,7 +50,7 @@ cat << EOF > ./fort.41
  /
 EOF
 
-eval $HOMEgfs/exec/emcsfc_snow2mdl >> OUTPUT 2> errfile
+eval $HOMEglobal/exec/emcsfc_snow2mdl >> OUTPUT 2> errfile
 iret=$?
 if [ $iret -ne 0 ]; then
   set +x
@@ -74,7 +74,7 @@ if [ $test_failed -ne 0 ]; then
   echo "*********************************"
   if [ "$UPDATE_BASELINE" = "TRUE" ]; then
     cd $DATA
-    $HOMEgfs/reg_tests/update_baseline.sh $HOMEreg "t1534.hemi" $commit_num
+    $HOMEglobal/reg_tests/update_baseline.sh $HOMEreg "t1534.hemi" $commit_num
   fi
 else
   echo

--- a/ush/global_cycle.sh
+++ b/ush/global_cycle.sh
@@ -26,13 +26,13 @@
 #     LONB_CASE     j-dimension of the global climatology files. NOT the
 #                   j-dimension of the model grid. Computed from CASE by default.
 #     OCNRES        Ocean grid resolution. '100' is one degree.
-#     HOMEgfs       Directory for gfs.  Default is 
+#     HOMEglobal       Directory for gfs.  Default is 
 #                   PACKAGEROOT/gfs.v15.0.0.
 #     PACKAGEROOT   Location of gfs package.
-#     FIXgfs        Directory for fixed data. Default is $HOMEgfs/fix.
-#     FIXorog       Directory for fixed orography data. Default is $FIXgfs/orog
-#     EXECgfs       Directory of the program executable.  Defaults to
-#                   $HOMEgfs/exec
+#     FIXglobal        Directory for fixed data. Default is $HOMEglobal/fix.
+#     FIXorog       Directory for fixed orography data. Default is $FIXglobal/orog
+#     EXECglobal       Directory of the program executable.  Defaults to
+#                   $HOMEglobal/exec
 #     DATA          Working directory
 #                   (if nonexistent will be made, used and deleted)
 #                   Defaults to current working directory
@@ -48,27 +48,27 @@
 #     SUFINP        Suffix to add to input analysis files.
 #                   Defaults to none.
 #     CYCLEXEC      Program executable.
-#                   Defaults to ${EXECgfs}/global_cycle$XC
+#                   Defaults to ${EXECglobal}/global_cycle$XC
 #     FNGLAC        Input glacier climatology GRIB file.
-#                   Defaults to ${FIXgfs}/am/global_glacier.2x2.grb
+#                   Defaults to ${FIXglobal}/am/global_glacier.2x2.grb
 #     FNMXIC        Input maximum sea ice climatology GRIB file.
-#                   Defaults to ${FIXgfs}/am/global_maxice.2x2.grb
+#                   Defaults to ${FIXglobal}/am/global_maxice.2x2.grb
 #     FNTSFC        Input SST climatology GRIB file.
-#                   Defaults to ${FIXgfs}/am/RTGSST.1982.2012.monthly.clim.grb
+#                   Defaults to ${FIXglobal}/am/RTGSST.1982.2012.monthly.clim.grb
 #     FNSALC        Input Salinity climatology netcdf file.
-#                   Defaults to ${FIXgfs}/am/global_salclm.t1534.3072.1536.nc
+#                   Defaults to ${FIXglobal}/am/global_salclm.t1534.3072.1536.nc
 #     FNSNOC        Input snow climatology GRIB file.
-#                   Defaults to ${FIXgfs}/am/global_snoclim.1.875.grb
+#                   Defaults to ${FIXglobal}/am/global_snoclim.1.875.grb
 #     FNZORC        Input roughness climatology.
 #                   Defaults to igbp vegetation type-based lookup table
 #                   FNVETC must be set to igbp file:
-#                   ${FIXgfs}/am/global_vegtype.igbp.t$JCAP_CASE.$LONB_CASE.$LATB_CASE.rg.grb
+#                   ${FIXglobal}/am/global_vegtype.igbp.t$JCAP_CASE.$LONB_CASE.$LATB_CASE.rg.grb
 #     FNALBC        Input 4-component albedo climatology GRIB file.
 #                   defaults to ${FIXorog}/${CASE}/sfc/${CASE}.mx${OCNRES}.snowfree_albedo.tileX.nc
 #     FNALBC2       Input 'facsf' and 'facwf' albedo climatology GRIB file.
 #                   Defaults to ${FIXorog}/${CASE}/sfc/${CASE}.mx${OCNRES}.facsf.tileX.nc
 #     FNAISC        Input sea ice climatology GRIB file.
-#                   Defaults to ${FIXgfs}/am/IMS-NIC.blended.ice.monthly.clim.grb
+#                   Defaults to ${FIXglobal}/am/IMS-NIC.blended.ice.monthly.clim.grb
 #     FNTG3C        Input deep soil temperature climatology GRIB file.
 #                   Defaults to ${FIXorog}/${CASE}/sfc/${CASE}.mx${OCNRES}.substrate_temperature.tileX.nc
 #     FNVEGC        Input vegetation fraction climatology GRIB file.
@@ -78,7 +78,7 @@
 #     FNSOTC        Input soil type climatology GRIB file.
 #                   Defaults to ${FIXorog}/${CASE}/sfc/${CASE}.mx${OCNRES}.soil_type.tileX.nc
 #     FNSMCC        Input soil moisture climatology GRIB file.
-#                   Defaults to ${FIXgfs}/am/global_soilmgldas.statsgo.t$JCAP_CASE.$LONB_CASE.$LATB_CASE.grb
+#                   Defaults to ${FIXglobal}/am/global_soilmgldas.statsgo.t$JCAP_CASE.$LONB_CASE.$LATB_CASE.grb
 #     FNVMNC        Input min veg frac climatology GRIB file.
 #                   Defaults to ${FIXorog}/${CASE}/sfc/${CASE}.mx${OCNRES}.vegetation_greenness.tileX.nc
 #     FNVMXC        Input max veg frac climatology GRIB file.
@@ -89,7 +89,7 @@
 #                   Defaults to ${FIXorog}/${CASE}/sfc/${CASE}.mx${OCNRES}.maximum_snow_albedo.tileX.nc
 #     FNMSKH        Input high resolution land mask GRIB file.  Use to set mask for
 #                   some of the input climatology fields.  This is NOT the model mask.
-#                   Defaults to ${FIXgfs}/am/global_slmask.t1534.3072.1536.grb
+#                   Defaults to ${FIXglobal}/am/global_slmask.t1534.3072.1536.grb
 #     NST_FILE      GSI file on the gaussian grid containing NST increments.
 #                   Defaults to NULL (no file).
 #     FNTSFA        Input SST analysis GRIB file.
@@ -226,10 +226,10 @@ OCNRES=${OCNRES:-100}
 #  Directories.
 gfs_ver=${gfs_ver:-v15.0.0}
 PACKAGEROOT=${PACKAGEROOT:-/lfs/h1/ops/prod/packages}
-HOMEgfs=${HOMEgfs:-${PACKAGEROOT}/gfs_ver.${gfs_ver}}
-EXECgfs=${EXECgfs:-$HOMEgfs/exec}
-FIXgfs=${FIXgfs:-$HOMEgfs/fix}
-FIXorog=${FIXorog:-$FIXgfs/orog}
+HOMEglobal=${HOMEglobal:-${PACKAGEROOT}/gfs_ver.${gfs_ver}}
+EXECglobal=${EXECglobal:-$HOMEglobal/exec}
+FIXglobal=${FIXglobal:-$HOMEglobal/fix}
+FIXorog=${FIXorog:-$FIXglobal/orog}
 DATA=${DATA:-$(pwd)}
 COMIN=${COMIN:-$(pwd)}
 COMOUT=${COMOUT:-$(pwd)}
@@ -238,7 +238,7 @@ COMOUT=${COMOUT:-$(pwd)}
 XC=${XC:-" "}
 PREINP=${PREINP:-" "}
 SUFINP=${SUFINP:-" "}
-CYCLEXEC=${CYCLEXEC:-$EXECgfs/global_cycle$XC}
+CYCLEXEC=${CYCLEXEC:-$EXECglobal/global_cycle$XC}
 
 CDATE=${CDATE:?}
 FHOUR=${FHOUR:-00}
@@ -275,14 +275,14 @@ MAX_TASKS_CY=${MAX_TASKS_CY:-99999}
 FRAC_GRID=${FRAC_GRID:-.false.}
 COUPLED=${COUPLED:-.false.}
 
-FNGLAC=${FNGLAC:-${FIXgfs}/am/global_glacier.2x2.grb}
-FNMXIC=${FNMXIC:-${FIXgfs}/am/global_maxice.2x2.grb}
-FNTSFC=${FNTSFC:-${FIXgfs}/am/RTGSST.1982.2012.monthly.clim.grb}
-FNSALC=${FNSALC:-${FIXgfs}/am/global_salclm.t1534.3072.1536.nc}
-FNSNOC=${FNSNOC:-${FIXgfs}/am/global_snoclim.1.875.grb}
+FNGLAC=${FNGLAC:-${FIXglobal}/am/global_glacier.2x2.grb}
+FNMXIC=${FNMXIC:-${FIXglobal}/am/global_maxice.2x2.grb}
+FNTSFC=${FNTSFC:-${FIXglobal}/am/RTGSST.1982.2012.monthly.clim.grb}
+FNSALC=${FNSALC:-${FIXglobal}/am/global_salclm.t1534.3072.1536.nc}
+FNSNOC=${FNSNOC:-${FIXglobal}/am/global_snoclim.1.875.grb}
 FNZORC=${FNZORC:-igbp}
-FNAISC=${FNAISC:-${FIXgfs}/am/IMS-NIC.blended.ice.monthly.clim.grb}
-FNSMCC=${FNSMCC:-${FIXgfs}/am/global_soilmgldas.statsgo.t$JCAP_CASE.$LONB_CASE.$LATB_CASE.grb}
+FNAISC=${FNAISC:-${FIXglobal}/am/IMS-NIC.blended.ice.monthly.clim.grb}
+FNSMCC=${FNSMCC:-${FIXglobal}/am/global_soilmgldas.statsgo.t$JCAP_CASE.$LONB_CASE.$LATB_CASE.grb}
 FNALBC2=${FNALBC2:-${FIXorog}/${CASE}/sfc/${CASE}.mx${OCNRES}.facsf.tileX.nc}
 FNTG3C=${FNTG3C:-${FIXorog}/${CASE}/sfc/${CASE}.mx${OCNRES}.substrate_temperature.tileX.nc}
 FNVEGC=${FNVEGC:-${FIXorog}/${CASE}/sfc/${CASE}.mx${OCNRES}.vegetation_greenness.tileX.nc}
@@ -293,7 +293,7 @@ FNABSC=${FNABSC:-${FIXorog}/${CASE}/sfc/${CASE}.mx${OCNRES}.maximum_snow_albedo.
 FNVMNC=${FNVMNC:-${FIXorog}/${CASE}/sfc/${CASE}.mx${OCNRES}.vegetation_greenness.tileX.nc}
 FNVMXC=${FNVMXC:-${FIXorog}/${CASE}/sfc/${CASE}.mx${OCNRES}.vegetation_greenness.tileX.nc}
 FNSLPC=${FNSLPC:-${FIXorog}/${CASE}/sfc/${CASE}.mx${OCNRES}.slope_type.tileX.nc}
-FNMSKH=${FNMSKH:-${FIXgfs}/am/global_slmask.t1534.3072.1536.grb}
+FNMSKH=${FNMSKH:-${FIXglobal}/am/global_slmask.t1534.3072.1536.grb}
 NST_FILE=${NST_FILE:-"NULL"}
 FNTSFA=${FNTSFA:-${COMIN}/${PREINP}sstgrb${SUFINP}}
 FNACNA=${FNACNA:-${COMIN}/${PREINP}engicegrb${SUFINP}}
@@ -324,7 +324,7 @@ ln -fs $FNTSFC sstclm
 ln -fs $FNSALC salclm
 
 # If the appropriate resolution fix file is not present, use the highest resolution available (T1534)
-[[ ! -f $FNSMCC ]] && FNSMCC="$FIXgfs/am/global_soilmgldas.statsgo.t1534.3072.1536.grb"
+[[ ! -f $FNSMCC ]] && FNSMCC="$FIXglobal/am/global_soilmgldas.statsgo.t1534.3072.1536.grb"
 
 ################################################################################
 #  Make surface analysis

--- a/ush/global_cycle_driver.sh
+++ b/ush/global_cycle_driver.sh
@@ -21,17 +21,17 @@ pwd=$(pwd)
 export DMPDIR=${DMPDIR:-$pwd}
 export PACKAGEROOT=${PACKAGEROOT:-/lfs/h1/ops/prod/packages}
 export gfs_ver=${gfs_ver:-v15.0.0}
-export HOMEgfs=${HOMEgfs:-${PACKAGEROOT}/gfs.${gfs_ver}}
-export FIXgfs=${FIXgfs:-$HOMEgfs/fix}   
-export FIXorog=${FIXorog:-$FIXgfs/orog}
+export HOMEglobal=${HOMEglobal:-${PACKAGEROOT}/gfs.${gfs_ver}}
+export FIXglobal=${FIXglobal:-$HOMEglobal/fix}   
+export FIXorog=${FIXorog:-$FIXglobal/orog}
 
 ntiles=${ntiles:-6}
 DONST=${DONST:-"NO"}
 COMIN=${COMIN:-$pwd}
 COMOUT=${COMOUT:-$pwd}
 
-CYCLESH=${CYCLESH:-$HOMEgfs/ush/global_cycle.sh}
-export CYCLEXEC=${CYCLEXEC:-$HOMEgfs/exec/global_cycle}
+CYCLESH=${CYCLESH:-$HOMEglobal/ush/global_cycle.sh}
+export CYCLEXEC=${CYCLEXEC:-$HOMEglobal/exec/global_cycle}
 export OMP_NUM_THREADS_CY=${OMP_NUM_THREADS_CY:-24}
 export APRUNCY=${APRUNCY:-"time"}
 export VERBOSE=${VERBOSE:-"YES"}


### PR DESCRIPTION
## DESCRIPTION OF CHANGES:
- This PR updates multiple scripts in UFS_UTILS to adopt the EE2 global workflow naming convention. Modifications were made to test scripts for global_cycle, ice_blend, and snow2mdl, as well as to driver scripts in the ush directory. These changes ensure that the UFS_UTILS submodule is fully compatible with the global-workflow naming standards proposed in issue [#4410](https://github.com/NOAA-EMC/global-workflow/issues/4410). All NET-specific environment variables have been replaced with global equivalents, improving clarity, consistency, and maintainability across the workflow.  

## TESTS CONDUCTED: 
- All available CI tests were run successfully in the global-workflow repository using the updated UFS_UTILS submodule.

- [x] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Ursa, Hercules and WCOSS2).
- [x] Compile branch on Ursa using GNU.
- [x] Compile branch in 'Debug' mode on WCOSS2.
- [x] Compile with Doxygen on any machine with no errors.
- [x] Run unit tests locally on any Tier 1 machine.
- [x] Run relevant consistency tests locally on all Tier 1 machines.


## DEPENDENCIES:
Add any links to pending PRs that are required prior to merging this PR. - NONE

## ISSUE: 
Ref: [#4410](https://github.com/NOAA-EMC/global-workflow/issues/4410)

## CONTRIBUTORS (optional): 
- @DavidHuber-NOAA 
