### PR TITLE
Expand machine detection for Derecho

### DIFF
--- a/sorc/machine-setup.sh
+++ b/sorc/machine-setup.sh
@@ -59,7 +59,7 @@ elif [[ "$(hostname)" =~ "hercules" || "$(hostname)" =~ "Hercules" ]]; then
 elif [[ -d /work/00315 && -d /scratch/00315 ]] ; then
     target=stampede
     module purge
-elif [[ "$(hostname)" =~ "Derecho" || "$(hostname)" =~ "derecho" ]]; then
+elif [[ -d /glade/derecho ]]; then
     target="derecho"
     module purge
 else


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Changes the detection method for Derecho to be based on path. This allows ufs-utils to detect Derecho even when on a compute node.

Resolves #1140

## TESTS CONDUCTED: 
If there are changes to the build or source code, the tests below must be conducted. Contact a repository manager if you need assistance.

- [ ] Compile branch on all Tier 1 machines using Intel (Orion, Jet, Ursa, Hercules and WCOSS2).
- [ ] Compile branch on Ursa using GNU.
- [ ] Compile branch in 'Debug' mode on WCOSS2.
- [ ] Compile with Doxygen on any machine with no errors.
- [ ] Run unit tests locally on any Tier 1 machine.
- [ ] Run relevant consistency tests locally on all Tier 1 machines.

Optional test.

- [ ] Run full set of chgres_cube consistency tests on Ursa.

Describe any additional tests performed.

- [x] Compile branch on Derecho using Intel on login node
- [x] Compile branch on Derecho using Intel on compute node

## DEPENDENCIES:
None

## DOCUMENTATION:
N/A

## ISSUE: 
Resolves #1140 

## CONTRIBUTORS (optional): 
None
