### PR TITLE
Update tf_thaw_set in global_cycle

### DIFF
--- a/sorc/global_cycle.fd/cycle.F90
+++ b/sorc/global_cycle.fd/cycle.F90
@@ -1582,6 +1582,7 @@ ENDIF
  tf(:,:)   = reshape(tf_ij,(/nx,ny/) )
 
  tf_thaw = bmiss
+ is_ice = .false.
 
  do krad = 1, max_search
 


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 
Compiling with debug mode and running tests for the GCAFS NCO stability tests, highlighted a failure for an undefined is_ice variable in the `tf_thaw_set` subroutine of `sorc/global_cycle.fd/cycle.F90`. This PR adds a default value of `is_ice=.false`. to the `tf_thaw_set` subroutine. This line is already included in the `ADJUST_NSST` [subroutine](https://github.com/ufs-community/UFS_UTILS/blob/develop/sorc/global_cycle.fd/cycle.F90#L1219) which uses a similar algorithm. 


## TESTING

### WHICH CONSISTENCY TESTS TO RUN:
- [ ] global_cycle


### TESTS CONDUCTED: 
<!--If there are changes to the build or source code, the tests below must be conducted. Contact a repository manager if you need assistance.-->

- [x] Compile branch using Intel:
  - [x] Orion
  - [x] Ursa
  - [x] Hercules
  - [x] WCOSS2
- [x] Compile branch using GNU:
  - [x] Ursa
- [x] Compile branch in 'Debug' mode:
  - [x] WCOSS2
- [x] Compile with Doxygen with no errors.
- [x] Run unit tests on any Tier 1 machine.
- [x] Run relevant consistency tests:
  - [x] Orion
  - [x] Ursa
  - [x] Hercules
  - [x] WCOSS2




## DOCUMENTATION:
<!--All new and updated source code must be documented with Doxygen.-->
- [ ] Doxygen does not need updates.

<!--If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files in the docs/source directory as supporting material.-->

## LINKED ISSUES: 
Resolves #1151 
