### PR TITLE
Containerize GCC & Intel CI workflows

### DIFF
--- a/.github/workflows/ubuntu_gcc.yaml
+++ b/.github/workflows/ubuntu_gcc.yaml
@@ -41,5 +41,5 @@ jobs:
           export FC=mpif90
           cmake -S ufs_utils -B build -DCMAKE_INSTALL_PREFIX=install
           cmake --build build --parallel 4 --verbose
-          cmake --install build
           ctest --test-dir build --parallel 4 --output-on-failure
+          cmake --install build

--- a/.github/workflows/ubuntu_gcc.yaml
+++ b/.github/workflows/ubuntu_gcc.yaml
@@ -1,66 +1,13 @@
 name: GCC Linux Build and Test
 on: [push, pull_request, workflow_dispatch]
 
-
-# Use custom shell with -l so .bash_profile is sourced
-# without having to do it in manually every step
-defaults:
-  run:
-    shell: bash -leo pipefail {0}
-
-env:
-  cache_key: gcc
-  CC: gcc-13
-  FC: gfortran-13
-  CXX: g++-13
-
-# The jobs are split into:
-# 1. a dependency build step (setup), and
-# 2. a UFS-utils build and test step (ufs_utils)
-# The setup is run once and the environment is cached,
-# so each subsequent build and test of UFS-utils can reuse the cached
-# dependencies to save time (and compute).
-
 jobs:
-  setup:
+  ufs_utils-gcc:
     runs-on: ubuntu-24.04
-
-    steps:
-      - name: checkout  # this is to get the ci/spack.yaml file
-        uses: actions/checkout@v3
-        with:
-            path: ufs_utils
-
-      # Cache spack, compiler and dependencies
-      - name: cache-env
-        id: cache-env
-        uses: actions/cache@v3
-        with:
-          path: |
-            spack
-            ~/.spack
-          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ufs_utils/ci/spack.yaml') }}
-
-      # Install dependencies using Spack
-      - name: install-dependencies-with-spack
-        if: steps.cache-env.outputs.cache-hit != 'true'
-        run: |
-          git clone -c feature.manyFiles=true https://github.com/spack/spack.git
-          source spack/share/spack/setup-env.sh
-          sed "s/\[oneapi, gcc@13:13, apple-clang@14\]/\[gcc@13:13\]/g" ufs_utils/ci/spack.yaml > spack_ci.yaml
-          spack env create ufs_utils-env spack_ci.yaml
-          spack env activate ufs_utils-env
-          spack config add "packages:all:prefer:['%gcc']"
-          sudo apt install cmake
-          spack external find
-          spack add mpich@3.4.2
-          spack concretize
-          spack install -v --fail-fast --dirty
-          spack clean --all
-
-  ufs_utils:
-    needs: setup
-    runs-on: ubuntu-24.04
+    # Dependencies are preinstalled in a container image.
+    # For available images, see https://github.com/orgs/NOAA-EMC/packages?tab=packages&q=ufs-utils.
+    # See https://github.com/NOAA-EMC/ci-common-build-cache/#using-container-images for further container usage instructions.
+    container: ghcr.io/noaa-emc/ci-common-build-cache/ufs-utils-ubuntu-24.04-gcc-13-mpich-x@sha256:081212acfb78e790a3ee6471cd3dab41737f60214678e9a2c428fe8b6fdedaa7
 
     steps:
       - name: checkout
@@ -69,31 +16,30 @@ jobs:
             path: ufs_utils
             submodules: recursive
 
-      - name: cache-env
-        id: cache-env
-        uses: actions/cache@v3
-        with:
-          path: |
-            spack
-            ~/.spack
-          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ufs_utils/ci/spack.yaml') }}
-
       - name: build
+        shell: bash
         run: |
-          source spack/share/spack/setup-env.sh
-          spack env activate ufs_utils-env
+          . /entrypoint.sh
+          spack uninstall --force --yes-to-all gcc-runtime # prevents CMake config warnings
+          ############################
+          ## Modify Spack installation, if needed
+          ##
+          ## For `swap-package` custom Spack command documentation,
+          ## see https://github.com/NOAA-EMC/spack-helpers#modify-package-spec-swap-package.
+          ## To request a package addition or update , create an issue or PR at
+          ## https://github.com/NOAA-EMC/ci-common-build-cache/.
+          ##
+          ## Configure a different version/build options for a package:
+          #spack swap-package foo@1.2.3
+          ## Configure an additional package not already in Spack:
+          #spack add bar@4.5.6
+          ## Concretize environment and run the installation:
+          #spack concretize --fresh
+          #spack install --only-concrete
+          ############################
           export CC=mpicc
           export FC=mpif90
-          cd ufs_utils
-          mkdir -p build && cd build
-          cmake -DCMAKE_INSTALL_PREFIX=../install ..
-          make -j2 VERBOSE=1
-          make install
-
-      - name: ctest
-        run: |
-          source spack/share/spack/setup-env.sh
-          spack env activate ufs_utils-env
-          cd ufs_utils
-          cd build
-          ctest --verbose --rerun-failed --output-on-failure
+          cmake -S ufs_utils -B build -DCMAKE_INSTALL_PREFIX=install
+          cmake --build build --parallel 4 --verbose
+          cmake --install build
+          ctest --test-dir build --parallel 4 --output-on-failure

--- a/.github/workflows/ubuntu_gcc.yaml
+++ b/.github/workflows/ubuntu_gcc.yaml
@@ -20,7 +20,6 @@ jobs:
         shell: bash
         run: |
           . /entrypoint.sh
-          spack uninstall --force --yes-to-all gcc-runtime # prevents CMake config warnings
           ############################
           ## Modify Spack installation, if needed
           ##
@@ -37,6 +36,7 @@ jobs:
           #spack concretize --fresh
           #spack install --only-concrete
           ############################
+          spack uninstall --force --yes-to-all gcc-runtime # prevents CMake config warnings
           export CC=mpicc
           export FC=mpif90
           cmake -S ufs_utils -B build -DCMAKE_INSTALL_PREFIX=install

--- a/.github/workflows/ubuntu_intel.yaml
+++ b/.github/workflows/ubuntu_intel.yaml
@@ -1,127 +1,54 @@
-name: Intel Linux Build and Test
+name: Intel oneAPI Linux Build and Test
 on: [push, pull_request, workflow_dispatch]
 
-# Use custom shell with -l so .bash_profile is sourced which loads intel/oneapi/setvars.sh
-# without having to do it in manually every step
-defaults:
-  run:
-    shell: bash -leo pipefail {0}
-
-# Set I_MPI_CC/F90 so IntelLLVM is used.
-env:
-  cache_key: intel
-  CC: mpiicx
-  FC: mpiifx
-  CXX: mpiicpx
-  I_MPI_CC: icx
-  I_MPI_F90: ifx
-  I_MPI_CXX: icpx
-
-# The jobs are split into:
-# 1. a dependency build step (setup), and
-# 2. a UFS-utils build and test step (ufs_utils)
-# The setup is run once and the environment is cached,
-# so each subsequent build and test of UFS-utils can reuse the cached
-# dependencies to save time (and compute).
-
 jobs:
-  setup:
+  ufs_utils-oneapi:
     runs-on: ubuntu-24.04
+    # Dependencies are preinstalled in a container image.
+    # For available images, see https://github.com/orgs/NOAA-EMC/packages?tab=packages&q=ufs-utils.
+    # See https://github.com/NOAA-EMC/ci-common-build-cache/#using-container-images for further container usage instructions.
+    container: ghcr.io/noaa-emc/ci-common-build-cache/ufs-utils-ubuntu-24.04-oneapi-2025.3-intel-oneapi-mpi-2021.17@sha256:93fb43fdd2e74e1a4081b52bbf5a1afd244d4e48219fa2c7f06fdcddb609697e
 
     steps:
-      - name: checkout  # this is to get the ci/spack.yaml file
-        uses: actions/checkout@v3
-        with:
-            path: ufs_utils
-
-      # Cache spack, compiler and dependencies
-      - name: cache-env
-        id: cache-env
-        uses: actions/cache@v3
-        with:
-          path: |
-            spack
-            ~/.spack
-            /opt/intel
-          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ufs_utils/ci/spack.yaml') }}
-
-      - name: install-intel-compilers
-        run: |
-          wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-          sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-          echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-          sudo apt-get update
-          sudo apt-get install intel-oneapi-mpi-devel intel-oneapi-openmp-2024.1 intel-oneapi-compiler-fortran-2024.1 intel-oneapi-compiler-dpcpp-cpp-2024.1
-          echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
-
-      # Install dependencies using Spack
-      - name: install-dependencies-with-spack
-        if: steps.cache-env.outputs.cache-hit != 'true'
-        run: |
-          sudo mv /usr/local /usr/local_mv
-          git clone -c feature.manyFiles=true https://github.com/spack/spack.git
-          source spack/share/spack/setup-env.sh
-          sed "s/\[oneapi, gcc@10:10, apple-clang@14\]/\[oneapi\]/g" ufs_utils/ci/spack.yaml > spack_ci.yaml
-          spack env create ufs_utils-env spack_ci.yaml
-          spack env activate ufs_utils-env
-          spack compiler find
-          sudo apt install cmake
-          spack external find --not-buildable gmake
-          spack external find
-          spack config add "packages:all:prefer:['%oneapi']"
-          spack config add "packages:fortran:require:'intel-oneapi-compilers'"
-          spack config add "packages:mpi:require:intel-oneapi-mpi"
-          spack config add "packages:mpi:buildable:false"
-          spack config add "packages:mpi:require:intel-oneapi-mpi"
-          intel_mpi_version=$(basename $(realpath /opt/intel/oneapi/mpi/latest))
-          sed -i "s|^  packages:|  packages:\n    intel-oneapi-mpi:\n      buildable: false\n      externals:\n      - spec: intel-oneapi-mpi@${intel_mpi_version}\n        prefix: /opt/intel/oneapi|" $SPACK_ENV/spack.yaml
-          spack config add "packages:python:require:'@3.11'"
-          cat $SPACK_ENV/spack.yaml
-          spack concretize
-          spack install --dirty --show-log-on-error --fail-fast
-          spack clean --all
-
-  ufs_utils:
-    needs: setup
-    runs-on: ubuntu-24.04
-
-    steps:
-      - name: install-intel
-        run: |
-          echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
-
       - name: checkout
         uses: actions/checkout@v3
         with:
             path: ufs_utils
             submodules: recursive
 
-      - name: cache-env
-        id: cache-env
-        uses: actions/cache@v3
-        with:
-          path: |
-            spack
-            ~/.spack
-            /opt/intel
-          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ufs_utils/ci/spack.yaml') }}
+      - name: "Install Intel compilers & MPI"
+        uses: NOAA-EMC/ci-install-intel-toolkit@develop
+        with: # Match versions to container configuration
+          install-classic: false
+          oneapi-version: 2025.3
+          install-mpi: true
+          mpi-version: 2021.17
+          mpi-wrapper-setup: oneapi
+          compiler-setup: oneapi
+          configure-gcc: false
 
       - name: build
+        shell: bash
         run: |
-          source spack/share/spack/setup-env.sh
-          spack env activate ufs_utils-env
-          export CC=mpiicx
-          export FC=mpiifx
-          cd ufs_utils
-          mkdir -p build && cd build
-          cmake -DCMAKE_INSTALL_PREFIX=../install ..
-          make -j2 VERBOSE=1
-          make install
-
-      - name: ctest
-        run: |
-          source spack/share/spack/setup-env.sh
-          spack env activate ufs_utils-env
-          cd ufs_utils
-          cd build
-          ctest --verbose --rerun-failed --output-on-failure
+          . /entrypoint.sh
+          spack uninstall --force --yes-to-all gcc-runtime intel-oneapi-runtime # prevents CMake config warnings
+          ############################
+          ## Modify Spack installation, if needed
+          ##
+          ## For `swap-package` custom Spack command documentation,
+          ## see https://github.com/NOAA-EMC/spack-helpers#modify-package-spec-swap-package.
+          ## To request a package addition or update , create an issue or PR at
+          ## https://github.com/NOAA-EMC/ci-common-build-cache/.
+          ##
+          ## Configure a different version/build options for a package:
+          #spack swap-package foo@1.2.3
+          ## Configure an additional package not already in Spack:
+          #spack add bar@4.5.6
+          ## Concretize environment and run the installation:
+          #spack concretize --fresh
+          #spack install --only-concrete
+          ############################
+          cmake -S ufs_utils -B build -DCMAKE_INSTALL_PREFIX=install
+          cmake --build build --parallel 4 --verbose
+          cmake --install build
+          ctest --test-dir build --parallel 4 --output-on-failure

--- a/.github/workflows/ubuntu_intel.yaml
+++ b/.github/workflows/ubuntu_intel.yaml
@@ -50,5 +50,5 @@ jobs:
           ############################
           cmake -S ufs_utils -B build -DCMAKE_INSTALL_PREFIX=install
           cmake --build build --parallel 4 --verbose
-          cmake --install build
           ctest --test-dir build --parallel 4 --output-on-failure
+          cmake --install build

--- a/.github/workflows/ubuntu_intel.yaml
+++ b/.github/workflows/ubuntu_intel.yaml
@@ -31,7 +31,6 @@ jobs:
         shell: bash
         run: |
           . /entrypoint.sh
-          spack uninstall --force --yes-to-all gcc-runtime intel-oneapi-runtime # prevents CMake config warnings
           ############################
           ## Modify Spack installation, if needed
           ##
@@ -48,6 +47,7 @@ jobs:
           #spack concretize --fresh
           #spack install --only-concrete
           ############################
+          spack uninstall --force --yes-to-all gcc-runtime intel-oneapi-runtime # prevents CMake config warnings
           cmake -S ufs_utils -B build -DCMAKE_INSTALL_PREFIX=install
           cmake --build build --parallel 4 --verbose
           ctest --test-dir build --parallel 4 --output-on-failure


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR containerizing the GCC and Intel CI workflows based on the containers generated by https://github.com/NOAA-EMC/ci-common-build-cache.

Note: I haven't looked yet at precaching test files, either in the UFS_UTILS container images or through the Actions cache.

## TESTING
<!--
### WHICH CONSISTENCY TESTS TO RUN:
- [ ] chgres_cube
- [ ] cpld_gridgen
- [ ] global_cycle
- [ ] grid_gen
- [ ] ice_blend
- [ ] ocnice_prep
- [ ] regrid_sfc
- [ ] snow2mdl
- [ ] weight_gen

### TESTS CONDUCTED: 

- [ ] Compile branch using Intel:
  - [ ] Orion
  - [ ] Ursa
  - [ ] Hercules
  - [ ] WCOSS2
- [ ] Compile branch using GNU:
  - [ ] Ursa
- [ ] Compile branch in 'Debug' mode:
  - [ ] WCOSS2
- [ ] Compile with Doxygen with no errors.
- [ ] Run unit tests on any Tier 1 machine.
- [ ] Run relevant consistency tests:
  - [ ] Orion
  - [ ] Ursa
  - [ ] Hercules
  - [ ] WCOSS2

Optional test.

- [ ] Run full set of chgres_cube consistency tests on Ursa.
-->
PR CI runs successfully with updated workflows (including CTest & installation).

## DEPENDENCIES:
none

## DOCUMENTATION:
Workflows are internally documented with comments, including links to https://github.com/NOAA-EMC/ci-common-build-cache documentation.

## LINKED ISSUES: 
* closes (replaces) #1156 