### PR TITLE
Remove the double slashes in the regrid log file

### DIFF
--- a/cmake/mpiexec.hercules
+++ b/cmake/mpiexec.hercules
@@ -6,7 +6,7 @@
 #   $2+ - Executable and its arguments
 #
 
-ACCOUNT=fv3-cpu
+ACCOUNT=nems
 QOS=debug
 
 NP=$1

--- a/sorc/regrid_sfc.fd/grids_IO.F90
+++ b/sorc/regrid_sfc.fd/grids_IO.F90
@@ -202,9 +202,9 @@
 
          if ( n_files > 1) then
              write(tchar,'(i1)') tt
-             fname = dir_read//"/"//fname_read//".tile"//tchar//".nc"
+             fname = dir_read//fname_read//".tile"//tchar//".nc"
          else
-             fname = dir_read//"/"//fname_read
+             fname = dir_read//fname_read
          endif
 
          print *, 'Reading ', trim(fname)


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR removed the duplicate slashes in the log files generated by the `sfcanl_regrid` job. 

## GENERATIVE AI USAGE
Transparency in the use of generative AI is required by NOAA policy.
* [x] GenAI is NOT used in this work
* [ ] GenAI is used in this work: (INSERT GENERATIVE AI TOOL HERE)
  * [ ] The code has been reviewed, edited, and validated by NWS staff.

## TESTING

### WHICH CONSISTENCY TESTS TO RUN:
- [ ] chgres_cube
- [ ] cpld_gridgen
- [ ] global_cycle
- [ ] grid_gen
- [ ] ice_blend
- [ ] ocnice_prep
- [x] regrid_sfc
- [ ] snow2mdl
- [ ] weight_gen

### TESTS CONDUCTED: 
<!--If there are changes to the build or source code, the tests below must be conducted. Contact a repository manager if you need assistance.-->

- [x] Compile branch using Intel:
  - [x] Orion
  - [x] Ursa
  - [x] Gaea C6
  - [x] Hercules
  - [x] WCOSS2
- [x] Compile branch using GNU:
  - [x] Ursa
- [ ] Compile branch in 'Debug' mode:
  - [ ] WCOSS2
- [x] Run unit tests on any Tier 1 machine.
- [x] Run relevant consistency tests:
  - [x] Orion
  - [x] Ursa
  - [x] Gaea C6
  - [x] Hercules
  - [x] WCOSS2

Describe any additional tests performed.

## DEPENDENCIES:
<!-- Add any links to pending PRs that are required prior to merging this PR. For example:
* ufs-community/UFS_UTILS/pull/<pr_number> -->

## DOCUMENTATION:
<!--All new and updated source code must be documented with Doxygen.-->
- [x] Doxygen does not need updates.
- [ ] Doxygen is updated.

<!--If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files in the docs/source directory as supporting material.-->

## LINKED ISSUES: 
<!--If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. For example, "Fixes issue mentioned in /#123" or "Related to bug in https://github.com/NOAA-EMC/other_repository/pull/63"-->

## CONTRIBUTORS (optional): 
<!--If others have contributed to this work aside from the PR author, list them here-->
